### PR TITLE
Fixed a compatibility issue with WP 5.5 and newer versions of GFUR.

### DIFF
--- a/gravity-forms/gw-custom-activation-template.php
+++ b/gravity-forms/gw-custom-activation-template.php
@@ -3,16 +3,17 @@
 * Gravity Forms Custom Activation Template
 * http://gravitywiz.com/customizing-gravity-forms-user-registration-activation-page
 */
-add_action('wp', 'custom_maybe_activate_user', 9);
+add_action( 'wp', 'custom_maybe_activate_user', 9 );
 function custom_maybe_activate_user() {
 
-    $template_path = STYLESHEETPATH . '/gfur-activate-template/activate.php';
-    $is_activate_page = isset( $_GET['page'] ) && $_GET['page'] == 'gf_activation';
-    
-    if( ! file_exists( $template_path ) || ! $is_activate_page  )
-        return;
-    
-    require_once( $template_path );
-    
-    exit();
+	$template_path    = STYLESHEETPATH . '/gfur-activate-template/activate.php';
+	$is_activate_page = isset( $_GET['page'] ) && $_GET['page'] === 'gf_activation';
+
+	if ( ! file_exists( $template_path ) || ! $is_activate_page ) {
+		return;
+	}
+
+	require_once( $template_path );
+
+	exit();
 }

--- a/gravity-forms/gw-custom-activation-template.php
+++ b/gravity-forms/gw-custom-activation-template.php
@@ -1,0 +1,18 @@
+<?php
+/**
+* Gravity Forms Custom Activation Template
+* http://gravitywiz.com/customizing-gravity-forms-user-registration-activation-page
+*/
+add_action('wp', 'custom_maybe_activate_user', 9);
+function custom_maybe_activate_user() {
+
+    $template_path = STYLESHEETPATH . '/gfur-activate-template/activate.php';
+    $is_activate_page = isset( $_GET['page'] ) && $_GET['page'] == 'gf_activation';
+    
+    if( ! file_exists( $template_path ) || ! $is_activate_page  )
+        return;
+    
+    require_once( $template_path );
+    
+    exit();
+}

--- a/gravity-forms/gw-custom-activation-template.php
+++ b/gravity-forms/gw-custom-activation-template.php
@@ -8,6 +8,7 @@ function custom_maybe_activate_user() {
 
 	$template_path    = STYLESHEETPATH . '/gfur-activate-template/activate.php';
 	$is_activate_page = isset( $_GET['page'] ) && $_GET['page'] === 'gf_activation';
+	$is_activate_page = $is_activate_page || isset( $_GET['gfur_activation'] ); // WP 5.5 Compatibility
 
 	if ( ! file_exists( $template_path ) || ! $is_activate_page ) {
 		return;


### PR DESCRIPTION
This PR adds the [custom activation template](https://gravitywiz.com/customizing-gravity-forms-user-registration-activation-page/) snippet to the repo and fixes an issue with newer versions of GFUR where the `page` parameter has been changed to `gfur_activation`.

Ticket: [#19745](https://secure.helpscout.net/conversation/1275451153/19745?folderId=3808239)