### PR TITLE
Support to set the coupon limit using a field value

### DIFF
--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -56,10 +56,10 @@ class GW_Create_Coupon {
 			$coupon_name = ($coupon_name == ''? $coupon_code : $coupon_name);
 		}
 
-		$limit_value = rgar($entry, $this->_args['meta']['coupon_limit']);
-		if ($limit_value != null){
-			 $this->_args['meta']['coupon_limit'] = $limit_value;
-		}
+		$limit_value = $this->_args['meta']['coupon_limit'];
+        if( is_callable( $limit_value ) ) {
+            $limit_value = call_user_func( $limit_value );
+        }
 
 		$amount      = $this->_args['amount'];
 		$type        = $this->_args['type'];

--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -56,6 +56,11 @@ class GW_Create_Coupon {
 			$coupon_name = ($coupon_name == ''? $coupon_code : $coupon_name);
 		}
 
+		$limit_value = rgar($entry, $this->_args['meta']['coupon_limit']);
+		if ($limit_value != null){
+			 $this->_args['meta']['coupon_limit'] = $limit_value;
+		}
+
 		$amount      = $this->_args['amount'];
 		$type        = $this->_args['type'];
 


### PR DESCRIPTION
PR to add support to set the coupon limit using a field value. If the value entered for the coupon_limit parameter is not a valid field ID, the parameter value will be used as the coupon limit.