### PR TITLE
Added support to set WooCommerce Coupons start date

### DIFF
--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -185,7 +185,7 @@ class GW_Create_Coupon {
             $start_date = date('Y-m-d H:i:s');
         }
 
-        // WooCommerce coupon uses the Post Title as the coupon code hence $coupon_code is assiged to Post Title and $coupon_name is assigned to the Post Content
+        // WooCommerce coupon uses the Post Title as the coupon code hence $coupon_code is assigned to Post Title and $coupon_name is assigned to the Post Content
 		$coupon = array(
 			'post_title'   => $coupon_code,
 			'post_content' => $coupon_name,

--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -180,13 +180,19 @@ class GW_Create_Coupon {
 	 */
 	public function create_coupon_wc( $coupon_name, $coupon_code, $amount, $type, $entry, $form ) {
 
-		// WooCommerce coupon uses the Post Title as the coupon code hence $coupon_code is assiged to Post Title and $coupon_name is assigned to the Post Content
+        $start_date = $this->_args['meta']['start_date'];
+        if ( $start_date ==''|| strtotime($start_date) == false )  {
+            $start_date = date('Y-m-d H:i:s');
+        }
+
+        // WooCommerce coupon uses the Post Title as the coupon code hence $coupon_code is assiged to Post Title and $coupon_name is assigned to the Post Content
 		$coupon = array(
 			'post_title'   => $coupon_code,
 			'post_content' => $coupon_name,
 			'post_status'  => 'publish',
 			'post_author'  => 1,
-			'post_type'	   => 'shop_coupon'
+			'post_type'	   => 'shop_coupon',
+            'post_date'    => $start_date
 		);
 
 		$new_coupon_id = wp_insert_post( $coupon );


### PR DESCRIPTION
This is a PR adding support to set a start date for Woocommerce Coupons. WooCommerce Coupons don't have a field or attribute to set the start date, so the start date value passed is assigned to the post_date variable. This means that, if the date is in the future it will schedule the coupon post but if it's in the past or it's the current date it will publish the coupon.

The start_date parameter is expected to be an element within the meta array and in this format; '2020-12-11'. If no start_date value is passed, the current date is used.