### PR TITLE
Converts gw-form-list-active-by-default.php to a plugin

### DIFF
--- a/gravity-forms/gw-form-list-active-by-default.php
+++ b/gravity-forms/gw-form-list-active-by-default.php
@@ -1,7 +1,21 @@
 <?php
 /**
  * Gravity Wiz // Gravity Forms // Default Form List to Active Forms
- * http://gravitywiz.com/
+ *
+ * Sets Form List view to Active Forms by Default.
+ *
+ * @version 0.1
+ * @author  David Smith <david@gravitywiz.com>
+ * @license GPL-2.0+
+ * @link    https://gravitywiz.com
+ *
+ * Plugin Name: Gravity Forms Default Form List to Active
+ * Plugin URI: http://gravitywiz.com
+ * Description: Sets Form List view to Active Forms by Default.
+ * Author: Gravity Wiz
+ * Version: 0.1
+ * Author URI: http://gravitywiz.com
+ *
  */
 add_action( 'init', function() {
 


### PR DESCRIPTION
This PR converts the Form List Active by Default snippet to a plugin since it doesn't require any configuration.