### PR TITLE
Added new snippet: gw-update-posts.php

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Update Posts
+ *
+ * Update existing post title and content with values from Gravity Forms.
+ *
+ * @version 0.1
+ * @author  Scott Buchmann <scott@gravitywiz.com>
+ * @license GPL-2.0+
+ * @link    http://gravitywiz.com
+ */
+class GW_Update_Posts {
+
+	public function __construct( $args = array() ) {
+
+		// set our default arguments, parse against the provided arguments, and store for
+		// use throughout the class
+		$this->_args = wp_parse_args(
+			$args,
+			array(
+				'form_id' => false,
+				'post_id' => false,
+				'title'   => false,
+				'content' => false,
+			)
+		);
+
+		// do version check in the init to make sure if GF is going to be loaded, it is
+		// already loaded
+		add_action( 'init', array( $this, 'init' ) );
+
+	}
+
+	public function init() {
+
+		// make sure we're running the required minimum version of Gravity Forms
+		if ( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=') ) {
+			return;
+		}
+
+		if ( ! empty( $this->_args['form_id'] ) ) {
+			add_action( "gform_after_submission_{$this->_args['form_id']}", array( $this, 'set_post_content' ), 10, 2);
+
+		}
+	}
+
+	public function set_post_content( $entry, $form ) {
+
+		//get post
+		$post = get_post( rgar( $entry, $this->_args['post_id'] ) );
+
+		//change post content
+		$post->post_title = rgar( $entry, $this->_args['title'] );
+		$post->post_content = rgar( $entry, $this->_args['content'] );
+
+		//update post
+		wp_update_post( $post );
+	}
+
+}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -49,6 +49,10 @@ class GW_Update_Posts {
 		//get post
 		$post = get_post( rgar( $entry, $this->_args['post_id'] ) );
 
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			return;
+		}
+
 		//change post content
 		$post->post_title = rgar( $entry, $this->_args['title'] );
 		$post->post_content = rgar( $entry, $this->_args['content'] );

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -13,8 +13,7 @@ class GW_Update_Posts {
 
 	public function __construct( $args = array() ) {
 
-		// set our default arguments, parse against the provided arguments, and store for
-		// use throughout the class
+		// Set our default arguments, parse against the provided arguments, and store for use throughout the class.
 		$this->_args = wp_parse_args(
 			$args,
 			array(
@@ -25,15 +24,14 @@ class GW_Update_Posts {
 			)
 		);
 
-		// do version check in the init to make sure if GF is going to be loaded, it is
-		// already loaded
+		// Do version check in the init to make sure if GF is going to be loaded, it is already loaded.
 		add_action( 'init', array( $this, 'init' ) );
 
 	}
 
 	public function init() {
 
-		// make sure we're running the required minimum version of Gravity Forms
+		// Make sure we're running the required minimum version of Gravity Forms.
 		if ( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=') ) {
 			return;
 		}
@@ -46,18 +44,16 @@ class GW_Update_Posts {
 
 	public function set_post_content( $entry, $form ) {
 
-		//get post
+		// Get the post and, if the current user has capabilities, update post with new content.
 		$post = get_post( rgar( $entry, $this->_args['post_id'] ) );
 
 		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 			return;
 		}
 
-		//change post content
 		$post->post_title = rgar( $entry, $this->_args['title'] );
 		$post->post_content = rgar( $entry, $this->_args['content'] );
 
-		//update post
 		wp_update_post( $post );
 	}
 


### PR DESCRIPTION
This PR adds a new snippet that will update WP post titles and content with values from GF entry. Usage example:

```
new GW_Update_Posts( array(
	'form_id' => 123,
	'post_id' => 1,
	'title'   => 2,
	'content' => 3
) );
```