### PR TITLE
Fixed an issue where populating to a non-date field without specifying a format would fail.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -152,10 +152,11 @@ class GW_Populate_Date {
 			$timestamp = current_time( 'timestamp' );
 		}
 
+		$target_is_date_field = GFFormsModel::get_input_type( $field ) === 'date';
 		// Always respect the passed format; it may conflict with the Date format but this is used at the user's discretion.
-		if ( $this->_args['format'] ) {
+		if ( $this->_args['format'] || ! $target_is_date_field ) {
 			$format = $this->get_format();
-		} elseif ( GFFormsModel::get_input_type( $field ) == 'date' ) {
+		} else {
 
 			list( $format, $divider ) = $field['dateFormat'] ? array_pad( explode( '_', $field['dateFormat'] ), 2, 'slash' ) : array( 'mdy', 'slash' );
 			$dividers                 = array(


### PR DESCRIPTION
This PR fixes an issue where this snippet would fail to populate the `$format` variable if the target field is not a date field and a format was not specified in the snippet's configuration.

The `get_format()` method already had a fallback but a call to it was skipped if a format was not passed as one of the arguments during setup.

#21705.