### PR TITLE
Replaced GPNF save and continue snippet with a comment indicating its migration.

### DIFF
--- a/gp-nested-forms/gpnf-clear-session-after-save-and-continue.php
+++ b/gp-nested-forms/gpnf-clear-session-after-save-and-continue.php
@@ -1,11 +1,4 @@
 <?php
 /**
- * Gravity Perks // Nested Forms // Clear Session after Save & Continue
- * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ * This snippet's functionality has been integrated into GP Nested Forms as of 1.0-beta-9.2
  */
-add_action( 'gform_post_process', function( $form ) {
-	if ( rgpost( 'gform_save' ) && class_exists( 'GPNF_Session' ) ) {
-		$session = new GPNF_Session( $form['id'] );
-		$session->delete_cookie();
-	}
-} );

--- a/gp-nested-forms/gpnf-clear-session-after-save-and-continue.php
+++ b/gp-nested-forms/gpnf-clear-session-after-save-and-continue.php
@@ -1,4 +1,0 @@
-<?php
-/**
- * This snippet's functionality has been integrated into GP Nested Forms as of 1.0-beta-9.2
- */


### PR DESCRIPTION
This PR replaces the content of the GPNF clear session snippet as its functionality has been migrated to GPNF's core.

Future PRs may remove the snippet's file if needed.