### PR TITLE
Fix Custom Database Snippet Filtering

### DIFF
--- a/gp-populate-anything/gppa-custom-database.php
+++ b/gp-populate-anything/gppa-custom-database.php
@@ -27,6 +27,16 @@ class GPPA_Object_Type_Database_Testing extends GPPA_Object_Type_Database {
 	public function get_db() {
 		return new wpdb( self::DB_USER, self::DB_PASSWORD, self::DB_NAME, self::DB_HOST );
 	}
+
+	public function __construct( $id ) {
+		parent::__construct( $id );
+
+		add_action( sprintf( 'gppa_pre_object_type_query_%s', $id ), array( $this, 'add_filter_hooks' ) );
+	}
+
+	public function add_filter_hooks() {
+		add_filter( sprintf( 'gppa_object_type_%s_filter', $this->id ), array( $this, 'process_filter_default' ), 10, 4 );
+	}
 }
 
 add_action('init', function() {

--- a/gp-populate-anything/gppa-custom-database.php
+++ b/gp-populate-anything/gppa-custom-database.php
@@ -3,12 +3,12 @@
  * Gravity Perks // Populate Anything // Custom Database
  * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
  *
- * By default, Populate Anything will only show the database that the current WordPress 
+ * By default, Populate Anything will only show the database that the current WordPress
  * installation is on.
  *
- * The following snippet allows registering additional an additional database with custom credentials. 
- * 
- * You can add multiple databases by adjusting the class names and adding additional 
+ * The following snippet allows registering additional an additional database with custom credentials.
+ *
+ * You can add multiple databases by adjusting the class names and adding additional
  * gp_populate_anything()->register_object_type() calls.
  */
 class GPPA_Object_Type_Database_Testing extends GPPA_Object_Type_Database {
@@ -25,7 +25,7 @@ class GPPA_Object_Type_Database_Testing extends GPPA_Object_Type_Database {
 	}
 
 	public function get_db() {
-		return new wpdb(self::DB_USER, self::DB_PASSWORD, self::DB_NAME, self::DB_HOST);
+		return new wpdb( self::DB_USER, self::DB_PASSWORD, self::DB_NAME, self::DB_HOST );
 	}
 }
 


### PR DESCRIPTION
This PR overrides the `\GPPA_Object_Type_Database->constructor()` and 
`\GPPA_Object_Type_Database->add_filter_hooks()` to ensure that filtering hooks are set and fired correctly.

The default filter names are `gppa_pre_object_type_query_database` and `gppa_object_type_database_filter`, this breaks down when using this snippet as the custom class ID (`database-testing`) causes GPPA to attempt to apply `gppa_object_type_database-testing_filter` which in turn results in `\GPPA_Object_Type_Database->build_where_clause()` to never run.

Reference: #22473