### PR TITLE
Fixed a potential issue where GWSA may cause the Events Calendar to show a blank page.

### DIFF
--- a/gravity-forms/gw-submit-to-access.php
+++ b/gravity-forms/gw-submit-to-access.php
@@ -137,7 +137,6 @@ class GW_Submit_Access {
 		$url = $this->get_requires_submission_redirect( $post->ID );
 		if ( $url ) {
 			wp_redirect( $url );
-			exit;
 		}
 
 	}


### PR DESCRIPTION
This PR fixes a compatibility issue with the Events Calendar and GWSA.

If a user uses [this specific hook](https://theeventscalendar.com/support/forums/topic/events-custom-fields-missing-since-4-8-1-update/) to enable WP Custom Fields and then sets a `gwsa_requires_submission_redirect` custom field on any event, the `wp_redirect()` does not execute on the master events list page (`{domain}/events/`) as expect, but the `exit()` call directly afterwards causes the page to stop loading.

This ends up breaking the listing page if any single event is set to require submission before access (and also has a URL redirect).

#22826