### PR TITLE
Fixed a compatibility issue with GF 2.5.

### DIFF
--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -4,7 +4,7 @@
  *
  * Include custom Javascript with your form.
  *
- * @version  1.5
+ * @version  1.6
  * @author   David Smith <david@gravitywiz.com>
  * @license  GPL-2.0+
  * @link     http://gravitywiz.com/
@@ -13,7 +13,7 @@
  * Plugin URI:   http://gravitywiz.com/
  * Description:  Include custom Javascript with your form.
  * Author:       Gravity Wiz
- * Version:      1.5
+ * Version:      1.6
  * Author URI:   http://gravitywiz.com
  *
  * Usage:

--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -94,9 +94,9 @@ class GF_Custom_JS {
 		// GF 2.5 may fire `gform_form_settings` before `save_custom_js_setting`
 		$custom_js = rgar( $form, 'customJS' );
 		$post_js   = esc_html( rgpost( 'customJS' ) );
-		if ( $post_js && $post_js !== $custom_js ) {
-			$custom_js = $post_js;
-		}
+		// Always favor posted JS if it's available
+		$custom_js = ( $post_js ) ? $post_js : $custom_js;
+
 		$settings[ __( 'Custom Javascript' ) ] = array(
 			'custom_js' => sprintf(
 				'<tr id="custom_js_setting" class="child_setting_row">

--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -92,10 +92,10 @@ class GF_Custom_JS {
 	public function add_custom_js_setting( $settings, $form ) {
 
 		// GF 2.5 may fire `gform_form_settings` before `save_custom_js_setting`
-		$customJS = rgar( $form, 'customJS' );
-		$postJS   = esc_html( rgpost( 'custom_js' ) );
-		if ( $postJS && $postJS !== $customJS ) {
-			$customJS = $postJS;
+		$custom_js = rgar( $form, 'customJS' );
+		$post_js   = esc_html( rgpost( 'customJS' ) );
+		if ( $post_js && $post_js !== $custom_js ) {
+			$custom_js = $post_js;
 		}
 		$settings[ __( 'Custom Javascript' ) ] = array(
 			'custom_js' => sprintf(
@@ -115,7 +115,7 @@ class GF_Custom_JS {
 					.CodeMirror-wrap { border: 1px solid #e1e1e1; }
 				</style>',
 				__( 'Include any custom Javascript that you would like to output wherever this form is rendered.' ),
-				$customJS
+				$custom_js
 			),
 		);
 

--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -91,12 +91,18 @@ class GF_Custom_JS {
 
 	public function add_custom_js_setting( $settings, $form ) {
 
+		// GF 2.5 may fire `gform_form_settings` before `save_custom_js_setting`
+		$customJS = rgar( $form, 'customJS' );
+		$postJS   = esc_html( rgpost( 'custom_js' ) );
+		if ( $postJS && $postJS !== $customJS ) {
+			$customJS = $postJS;
+		}
 		$settings[ __( 'Custom Javascript' ) ] = array(
 			'custom_js' => sprintf(
 				'<tr id="custom_js_setting" class="child_setting_row">
 					<td colspan="2">
 						<p style="margin-top:-1rem;">%s</p>
-						<textarea id="custom_js" name="custom_js" spellcheck="false" 
+						<textarea id="custom_js" name="custom_js" spellcheck="false"
 							style="width:100%%;height:14rem;">%s</textarea>
 					</td>
 				</td>
@@ -109,7 +115,7 @@ class GF_Custom_JS {
 					.CodeMirror-wrap { border: 1px solid #e1e1e1; }
 				</style>',
 				__( 'Include any custom Javascript that you would like to output wherever this form is rendered.' ),
-				rgar( $form, 'customJS' )
+				$customJS
 			),
 		);
 


### PR DESCRIPTION
This PR fixes an issue with GF 2.5 and the Custom JS snippet.

GF 2.5 seems to fire the `gform_form_settings` hook before `save_custom_js_setting`, causing this snippet to display an outdated version of the JS code and requiring a page refresh before showing the latest version.

The commit here tweaks `add_custom_js_setting()` to favor the posted value if it's available and differs from the saved version.

#23065