### PR TITLE
Fixed an issue where Cache Buster would not display a form's title.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -4,7 +4,7 @@
  *
  * Bypass your website cache when loading a Gravity Forms form.
  *
- * @version 0.3
+ * @version 0.4
  * @author  David Smith <david@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com/
@@ -13,7 +13,7 @@
  * Plugin URI: http://gravitywiz.com/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author: Gravity Wiz
- * Version: 0.3
+ * Version: 0.4
  * Author URI: http://gravitywiz.com
  *
  */

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -179,7 +179,7 @@ class GW_Cache_Buster {
 			$form_id = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 		}
 
-		$atts = json_decode( rgpost( 'atts' ) );
+		$atts = json_decode( rgpost( 'atts' ), true );
 
 		gravity_form( $form_id, rgar( $atts, 'title' ), rgar( $atts, 'description' ), false, rgar( $atts, 'field_values' ), true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 


### PR DESCRIPTION
This PR fixes an issue with the way Cache Buster passes a form's attribute to the Gravity Form constructor.

The implementation of `rgar()` accepts objects only if they are (or implement) [`ArrayAccess`](https://www.php.net/manual/en/class.arrayaccess.php). This caused `rgar` to fail and in turn passed `null` into GF.

The solution here was to modify the `json_decode` call to return an associative array instead of an object.

#23101