### PR TITLE
Fixed parsing of `title` and `description` boolean values in shortcodes.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -181,7 +181,7 @@ class GW_Cache_Buster {
 
 		$atts = json_decode( rgpost( 'atts' ), true );
 
-		gravity_form( $form_id, rgar( $atts, 'title' ), rgar( $atts, 'description' ), false, rgar( $atts, 'field_values' ), true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
+		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, rgar( $atts, 'field_values' ), true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();
 	}


### PR DESCRIPTION
This PR fixes the parsing of the `title` and `description` attributes in shortcodes.

Passing `false` as a string to Gravity Forms' `GFFormDisplay::get_form()` ends up being evaluated as `true` since there's no type checking involved.

The commit in this PR explicitly uses `filter_var` with `FILTER_VALIDATE_BOOLEAN` to correct for that. It also adds `true` as the default setting to match GF's signature.

#23249