### PR TITLE
Fixed a potential crash in GW Form List Active by Default if GF is not active.

### DIFF
--- a/gravity-forms/gw-form-list-active-by-default.php
+++ b/gravity-forms/gw-form-list-active-by-default.php
@@ -18,7 +18,9 @@
  *
  */
 add_action( 'init', function() {
-
+	if ( ! class_exists( 'GFForms' ) ) {
+		return;
+	}
 	if ( GFForms::get_page() === 'form_list' ) {
 
 		$params = array();


### PR DESCRIPTION
This PR fixes a potential crash if GF is not installed or has been deactivated.

#23384