### PR TITLE
Added partial entries support to GPEP Edit Entry snippet.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -4,19 +4,36 @@
  *
  * Edit entry ID specified in field with current form submission.
  *
- * @version   1.0
+ * @version   1.1
  * @author    David Smith <david@gravitywiz.com>
  * @license   GPL-2.0+
  * @link      https://gravitywiz.com/edit-gravity-forms-entries-on-the-front-end/
  */
-// Update "123" with your form ID.
-add_filter( 'gform_entry_id_pre_save_lead_123', 'my_update_entry_on_form_submission', 10, 2 );
-function my_update_entry_on_form_submission( $entry_id, $form ) {
+class GPEPEditEntry {
+	private $form_id;
+	private $delete_partial;
 
-	if ( is_callable( 'gp_easy_passthrough' ) ) {
-		$session = gp_easy_passthrough()->session_manager();
-		$update_entry_id = $session[ gp_easy_passthrough()->get_slug() . '_' . $form['id'] ];
+	public function __construct( $options ) {
+		$this->form_id        = rgar( $options, 'form_id' );
+		$this->delete_partial = rgar( $options, 'delete_partial' );
+		add_filter( sprintf( 'gform_entry_id_pre_save_lead_%s', $this->form_id ), array( $this, 'update_entry_id' ), 10, 2 );
 	}
 
-	return isset( $update_entry_id ) && $update_entry_id ? $update_entry_id : $entry_id;
+	public function update_entry_id( $entry_id, $form ) {
+		if ( is_callable( 'gp_easy_passthrough' ) ) {
+			$session         = gp_easy_passthrough()->session_manager();
+			$update_entry_id = $session[ gp_easy_passthrough()->get_slug() . '_' . $form['id'] ];
+			if ( $update_entry_id && $this->delete_partial ) {
+				GFAPI::delete_entry( $entry_id );
+			}
+		}
+
+		return isset( $update_entry_id ) && $update_entry_id ? $update_entry_id : $entry_id;
+	}
 }
+
+// Configurations
+new GPEPEditEntry( array(
+	'form_id'        => 179,   // Set this to the form ID
+	'delete_partial' => true, // Set this to true to delete partial entries if enabled
+) );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -35,5 +35,5 @@ class GPEPEditEntry {
 // Configurations
 new GPEPEditEntry( array(
 	'form_id'        => 179,   // Set this to the form ID
-	'delete_partial' => true, // Set this to true to delete partial entries if enabled
+	'delete_partial' => false, // Set this to true to delete partial entries if enabled
 ) );


### PR DESCRIPTION
This PR adds support for partial entries. It also uses the `class` approach for encapsulation and easier configuration.

Currently when partial entries are enabled and used alongside GPEP and this snippet, a temporary empty entry is left behind each time a form is submitted.

With the new option added, we simply delete the stale partial entry if the user chose to enable it.

#23339, #23599