### PR TITLE
Fixed an issue with field set with `No Duplicates` causing update to fail.

### DIFF
--- a/gravity-forms/gw-gravity-forms-populate-form.php
+++ b/gravity-forms/gw-gravity-forms-populate-form.php
@@ -5,7 +5,7 @@
  * Pass an entry ID and populate the form automatically. No form configuration required. Optionally update the entry on
  * submission.
  *
- * @version  1.6
+ * @version  1.6.1
  * @author   David Smith <david@gravitywiz.com>
  * @license  GPL-2.0+
  * @link     http://gravitywiz.com/
@@ -15,7 +15,7 @@
  * Plugin URI:   http://gravitywiz.com/
  * Description:  Pass an entry ID and populate the form automatically. No form configuration required. Optionally update the entry on submission.
  * Author:       Gravity Wiz
- * Version:      1.6
+ * Version:      1.6.1
  * Author URI:   http://gravitywiz.com
  */
 class GW_Populate_Form {


### PR DESCRIPTION
This PR fixes an issue with the Populate Form with Entry snippet.

If a field is marked as having `No Duplicates` in its settings, the snippet will not work as `gform_entry_id_pre_save_lead` is fired after validation has been completed.

To fix that, this PR adds a new `validate_field` method to filter `gform_field_validation`. It checks if a field that has failed validation did so due to a duplicate entry error while also ensuring that the snippet is being used to update the entry. If all these conditions are met, it overrides the validation error.

#23712

