### PR TITLE
Added GPNF Delay Child Notifications to the library

### DIFF
--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -30,6 +30,7 @@ class GW_GPNF_Delay_Child_Notifications {
 
 		add_filter( 'gpnf_should_send_notification', array( $this, 'gpnf_should_send_notification' ), 10, 7 );
 		add_action( 'gform_post_payment_completed', array( $this, 'gform_post_payment_completed' ) );
+		// Removing this filter causes the original issue of double notification to occur, see HS#23899 PR #85
 		remove_filter( 'gform_entry_post_save', array( gpnf_notification_processing(), 'maybe_send_child_notifications' ), 11 );
 
 	}
@@ -38,8 +39,6 @@ class GW_GPNF_Delay_Child_Notifications {
 		if ( $context === 'parent' && $this->is_applicable_form( $parent_form['id'] ) ) {
 			$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
 			$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
-			// Prevent double notifications for non-delayed payment gateways.
-			remove_filter( 'gform_post_payment_completed', array( $this, 'gpnf_should_send_notification' ) );
 		}
 
 		return $should_send_notification;

--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -37,7 +37,7 @@ class GW_GPNF_Delay_Child_Notifications {
 		if ( in_array( rgar( $form, 'id' ), $this->form_ids, true ) ) {
 				return $entry;
 		}
-				return gpnf_notification_processing()->maybe_send_child_notifications( $entry, $form );
+		return gpnf_notification_processing()->maybe_send_child_notifications( $entry, $form );
 	}
 }
 

--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Delay Child Notifications for Parent Payment
+ * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ */
+class GW_GPNF_Delay_Child_Notifications {
+	public $form_ids;
+
+	public function __construct( $args ) {
+		$this->form_ids = $args['form_ids'];
+
+		add_filter( 'gpnf_should_send_notification', function( $should_send_notification, $notification, $context, $parent_form, $nested_form_field, $entry, $child_form ) {
+
+			if ( $context === 'parent' ) {
+				$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
+				$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
+			}
+
+			return $should_send_notification;
+		}, 10, 7 );
+
+		add_action( 'gform_post_payment_completed', function( $entry ) {
+			if ( is_callable( 'gpnf_notification_processing' ) ) {
+				gpnf_notification_processing()->maybe_send_child_notifications( $entry, GFAPI::get_form( $entry['form_id'] ) );
+			}
+		} );
+
+		remove_filter( 'gform_entry_post_save', array( gpnf_notification_processing(), 'maybe_send_child_notifications' ), 11 );
+		add_filter( 'gform_entry_post_save', array( $this, 'gform_entry_post_save' ), 11, 2 );
+	}
+
+	public function gform_entry_post_save( $entry, $form ) {
+		/**
+		 * Do not send notification for form ID 100 on the normal entry save hook. This form is expected to send
+		 * notifications using the gform_post_payment_completed action.
+		 */
+		if ( in_array( rgar( $form, 'id' ), $this->form_ids, true ) ) {
+				return $entry;
+		}
+				return gpnf_notification_processing()->maybe_send_child_notifications( $entry, $form );
+	}
+}
+
+// Configuration
+new GW_GPNF_Delay_Child_Notifications( array(
+	'form_ids' => array( 3 ), // Add all parent form IDs to this array
+) );

--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -18,7 +18,7 @@ class GW_GPNF_Delay_Child_Notifications {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
-			'form_ids' => false,
+			'form_id' => false,
 		) );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -30,32 +30,39 @@ class GW_GPNF_Delay_Child_Notifications {
 
 		add_filter( 'gpnf_should_send_notification', array( $this, 'gpnf_should_send_notification' ), 10, 7 );
 		add_action( 'gform_post_payment_completed', array( $this, 'gform_post_payment_completed' ) );
+		remove_filter( 'gform_entry_post_save', array( gpnf_notification_processing(), 'maybe_send_child_notifications' ), 11 );
 
 	}
 
 	public function gpnf_should_send_notification( $should_send_notification, $notification, $context, $parent_form, $nested_form_field, $entry, $child_form ) {
-
-		if ( $context === 'parent' ) {
+		if ( $context === 'parent' && $this->is_applicable_form( $parent_form['id'] ) ) {
 			$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
 			$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
 			// Prevent double notifications for non-delayed payment gateways.
 			remove_filter( 'gform_post_payment_completed', array( $this, 'gpnf_should_send_notification' ) );
 		}
+
 		return $should_send_notification;
 
 	}
 
 	public function gform_post_payment_completed( $entry ) {
-
-		if ( is_callable( 'gpnf_notification_processing' ) ) {
+		if ( is_callable( 'gpnf_notification_processing' ) && $this->is_applicable_form( $entry['form_id'] ) ) {
 			gpnf_notification_processing()->maybe_send_child_notifications( $entry, GFAPI::get_form( $entry['form_id'] ) );
 		}
 
+	}
+
+	public function is_applicable_form( $form ) {
+
+		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
+
+		return empty( $this->_args['form_id'] ) || (int) $form_id === (int) $this->_args['form_id'];
 	}
 
 }
 
 // Configuration
 new GW_GPNF_Delay_Child_Notifications( array(
-	'form_ids' => array( 3 ), // Add all parent form IDs to this array
+	'form_id' => 3, // Set this to the parent form ID
 ) );

--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -30,7 +30,6 @@ class GW_GPNF_Delay_Child_Notifications {
 
 		add_filter( 'gpnf_should_send_notification', array( $this, 'gpnf_should_send_notification' ), 10, 7 );
 		add_action( 'gform_post_payment_completed', array( $this, 'gform_post_payment_completed' ) );
-		remove_filter( 'gform_entry_post_save', array( gpnf_notification_processing(), 'maybe_send_child_notifications' ), 11 );
 
 	}
 
@@ -39,9 +38,9 @@ class GW_GPNF_Delay_Child_Notifications {
 		if ( $context === 'parent' ) {
 			$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
 			$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
+			// Prevent double notifications for non-delayed payment gateways.
+			remove_filter( 'gform_post_payment_completed', array( $this, 'gpnf_should_send_notification' ) );
 		}
-		// Prevent double notifications for non-delayed payment gateways.
-		remove_filter( 'gform_post_payment_completed', array( $this, 'gpnf_should_send_notification' ) );
 		return $should_send_notification;
 
 	}

--- a/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gp-nested-forms-delay-child-notifications-for-parent-payment.php
@@ -1,44 +1,59 @@
 <?php
 /**
- * Gravity Perks // Nested Forms // Delay Child Notifications for Parent Payment
- * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ * Gravity Wiz // Nested Forms // Delay Child Notifications for Parent Payment
+ * https://github.com/gravitywiz/snippet-library/blob/master/gw-snippet-template.php
+ *
+ * Delay GP Nested Forms child form notification until payment processing is completed.
+ *
+ * Plugin Name:  Delay Child Notifications for Parent Payment
+ * Plugin URI:   http://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ * Description:  Delay GP Nested Forms child form notification until payment processing is completed.
+ * Author:       Gravity Wiz
+ * Version:      1.1
+ * Author URI:   http://gravitywiz.com
  */
 class GW_GPNF_Delay_Child_Notifications {
-	public $form_ids;
 
-	public function __construct( $args ) {
-		$this->form_ids = $args['form_ids'];
+	public function __construct( $args = array() ) {
 
-		add_filter( 'gpnf_should_send_notification', function( $should_send_notification, $notification, $context, $parent_form, $nested_form_field, $entry, $child_form ) {
+		// set our default arguments, parse against the provided arguments, and store for use throughout the class
+		$this->_args = wp_parse_args( $args, array(
+			'form_ids' => false,
+		) );
 
-			if ( $context === 'parent' ) {
-				$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
-				$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
-			}
+		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
+		add_action( 'init', array( $this, 'init' ) );
 
-			return $should_send_notification;
-		}, 10, 7 );
+	}
 
-		add_action( 'gform_post_payment_completed', function( $entry ) {
-			if ( is_callable( 'gpnf_notification_processing' ) ) {
-				gpnf_notification_processing()->maybe_send_child_notifications( $entry, GFAPI::get_form( $entry['form_id'] ) );
-			}
-		} );
+	public function init() {
 
+		add_filter( 'gpnf_should_send_notification', array( $this, 'gpnf_should_send_notification' ), 10, 7 );
+		add_action( 'gform_post_payment_completed', array( $this, 'gform_post_payment_completed' ) );
 		remove_filter( 'gform_entry_post_save', array( gpnf_notification_processing(), 'maybe_send_child_notifications' ), 11 );
-		add_filter( 'gform_entry_post_save', array( $this, 'gform_entry_post_save' ), 11, 2 );
+
 	}
 
-	public function gform_entry_post_save( $entry, $form ) {
-		/**
-		 * Do not send notification for form ID 100 on the normal entry save hook. This form is expected to send
-		 * notifications using the gform_post_payment_completed action.
-		 */
-		if ( in_array( rgar( $form, 'id' ), $this->form_ids, true ) ) {
-				return $entry;
+	public function gpnf_should_send_notification( $should_send_notification, $notification, $context, $parent_form, $nested_form_field, $entry, $child_form ) {
+
+		if ( $context === 'parent' ) {
+			$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
+			$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
 		}
-		return gpnf_notification_processing()->maybe_send_child_notifications( $entry, $form );
+		// Prevent double notifications for non-delayed payment gateways.
+		remove_filter( 'gform_post_payment_completed', array( $this, 'gpnf_should_send_notification' ) );
+		return $should_send_notification;
+
 	}
+
+	public function gform_post_payment_completed( $entry ) {
+
+		if ( is_callable( 'gpnf_notification_processing' ) ) {
+			gpnf_notification_processing()->maybe_send_child_notifications( $entry, GFAPI::get_form( $entry['form_id'] ) );
+		}
+
+	}
+
 }
 
 // Configuration


### PR DESCRIPTION
This PR imports the GPNF Delay Child Notifications for Parent Payment snippet.

It also fixes an issue where notifications were sent twice by filtering on `gform_entry_post_save` and specific parent form IDs.

#23899 / DWC.