### PR TITLE
Fixed an issue where field values were not passed properly to GF.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -184,9 +184,13 @@ class GW_Cache_Buster {
 			$form_id = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 		}
 
-		$atts = json_decode( rgpost( 'atts' ), true );
-
-		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, rgar( $atts, 'field_values' ), true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
+		$atts         = json_decode( rgpost( 'atts' ), true );
+		$field_values = rgar( $atts, 'field_values' );
+		// GF expects an associative array for field values. Parse them before passing it on.
+		if ( $field_values ) {
+			parse_str( $field_values, $field_values );
+		}
+		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();
 	}

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -4,7 +4,7 @@
  *
  * Bypass your website cache when loading a Gravity Forms form.
  *
- * @version 0.6
+ * @version 0.7
  * @author  David Smith <david@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com/
@@ -13,7 +13,7 @@
  * Plugin URI: http://gravitywiz.com/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author: Gravity Wiz
- * Version: 0.6
+ * Version: 0.7
  * Author URI: http://gravitywiz.com
  *
  */

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -184,12 +184,9 @@ class GW_Cache_Buster {
 			$form_id = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 		}
 
-		$atts         = json_decode( rgpost( 'atts' ), true );
-		$field_values = rgar( $atts, 'field_values' );
+		$atts = json_decode( rgpost( 'atts' ), true );
 		// GF expects an associative array for field values. Parse them before passing it on.
-		if ( $field_values ) {
-			parse_str( $field_values, $field_values );
-		}
+		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
 		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();


### PR DESCRIPTION
This PR fixes an issue where `field_values` were not being passed properly in the short code.

An example cause would look like: `[gravityform id="233" title="false" cachebuster="1" description="false" field_values="webinar_code=123-456-789"]`.

GF expects the `$field_values` parameter to be an associative array. The commit here fixes that by using `parse_str()`.

#24038