### PR TITLE
Fixed compatibility issue with GF 2.5 where conditionally shown fields would cause the form to not render.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -157,6 +157,12 @@ class GW_Cache_Buster {
 					atts: '<?php echo json_encode( $attributes ); ?>'
 				}, function( response ) {
 					$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
+					<?php
+					// Manually trigger `gform_post_render` on GF 2.5
+					if ( version_compare( GFCommon::$version, '2.5', '>=' ) ) {
+						printf( "$(document).trigger('gform_post_render', [%d, 1]);\n", $form_id );
+					}
+					?>
 					if( window['gformInitDatepicker'] ) {
 						gformInitDatepicker();
 					}

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -158,7 +158,8 @@ class GW_Cache_Buster {
 				}, function( response ) {
 					$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
 					<?php
-					// Manually trigger `gform_post_render` on GF 2.5
+					// GF 2.5 doesn't seem to respond to the `gform_post_render` trigger in the response we're injecting
+					// This causes forms with conditional logic to remain hidden. See HS#24394
 					if ( version_compare( GFCommon::$version, '2.5', '>=' ) ) {
 						printf( "$(document).trigger('gform_post_render', [%d, 1]);\n", $form_id );
 					}


### PR DESCRIPTION
With GF 2.5, the `gform_post_render` trigger that gets appended with the markup doesn't seem to fire.

This causes forms with conditionally hidden fields to remain hidden (`style="display:none"`) as `conditionallogic.js` never gets notified to process the logic and show the form.

This PR gets around that by manually triggering `gform_post_render` if GF's version is `>=` 2.5.

#24394