### PR TITLE
Updated snippet documentation to reflect GF 2.5 changes.

### DIFF
--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -154,7 +154,7 @@ new GWAutoListFieldRows( array(
 ) );
 
 // EXAMPLE #2: Single Product Field's Quantity input as the "input_html_id"
-// Note: On Gravity Forms versions before 2.5 the input_html_id was in this format "#ginput_quantity_240_5"
+// Note: input_html_id has a format of "#ginput_quantity_240_5" if using Gravity Forms <2.5 or if Legacy Markup is enabled
 new GWAutoListFieldRows( array(
 	'form_id' => 240,
 	'list_field_id' => 6,

--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -16,47 +16,47 @@
 class GWAutoListFieldRows {
 
 	private static $_is_script_output;
-	
+
 	public function __construct( $args = array() ) {
- 
+
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
 			'form_id'       => false,
 			'input_html_id' => false,
 			'list_field_id' => false
 		) );
- 
+
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
 		add_action( 'init', array( $this, 'init' ) );
- 
+
 	}
- 
+
 	public function init() {
- 
+
 		// make sure we're running the required minimum version of Gravity Forms
 		if( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=' ) ) {
 			return;
 		}
- 
+
 		// time for hooks
 		add_filter( 'gform_pre_render', array( $this, 'load_form_script' ), 10, 2 );
 		add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ), 10, 2 );
- 
+
 	}
- 
+
 	public function load_form_script( $form, $is_ajax_enabled ) {
- 
+
 		if( $this->is_applicable_form( $form ) && ! has_action( 'wp_footer', array( $this, 'output_script' ) ) ) {
 			add_action( 'wp_footer', array( $this, 'output_script' ) );
 			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
 		}
- 
+
 		return $form;
 	}
- 
+
 	public function output_script() {
 		?>
- 
+
 		<script type="text/javascript">
 
             window.gwalfr;
@@ -115,16 +115,16 @@ class GWAutoListFieldRows {
             })(jQuery);
 
 		</script>
- 
+
 		<?php
 	}
- 
+
 	public function add_init_script( $form ) {
- 
+
 		if( ! $this->is_applicable_form( $form ) ) {
 			return;
 		}
- 
+
 		$args = array(
 			'formId'      => $this->_args['form_id'],
 			'listFieldId' => $this->_args['list_field_id'],
@@ -136,14 +136,14 @@ class GWAutoListFieldRows {
 
 		GFFormDisplay::add_init_script( $form['id'], 'gwalfr_' . $key , GFFormDisplay::ON_PAGE_RENDER, $script );
 	}
- 
+
 	public function is_applicable_form( $form ) {
- 
+
 		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
- 
+
 		return empty( $this->_args['form_id'] ) || $form_id == $this->_args['form_id'];
 	}
- 
+
 }
 
 // EXAMPLE #1: Number field for the "input_html_id"
@@ -154,8 +154,9 @@ new GWAutoListFieldRows( array(
 ) );
 
 // EXAMPLE #2: Single Product Field's Quantity input as the "input_html_id"
+// Note: On Gravity Forms versions before 2.5 the input_html_id was in this format "#ginput_quantity_240_5"
 new GWAutoListFieldRows( array(
 	'form_id' => 240,
 	'list_field_id' => 6,
-	'input_html_id' => '#ginput_quantity_240_5'
+	'input_html_id' => '#input_240_5_1'
 ) );


### PR DESCRIPTION
This PR updates the selector for the quantity field from `#ginput_quantity_240_5` to `#input_240_5_1` as the markup has changed in GF 2.5.

There's also a note in the documentation for GF 2.4 and earlier noting this change. But by default the example follows GF 2.5 now.

#24906