### PR TITLE
Fixed an issue with GF2.5 where rows were not counted correctly.

### DIFF
--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -16,146 +16,146 @@
 class GWAutoListFieldRows {
 
 	private static $_is_script_output;
-	
+
 	public function __construct( $args = array() ) {
- 
+
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
 			'form_id'       => false,
 			'input_html_id' => false,
-			'list_field_id' => false
+			'list_field_id' => false,
 		) );
- 
+
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
 		add_action( 'init', array( $this, 'init' ) );
- 
+
 	}
- 
+
 	public function init() {
- 
+
 		// make sure we're running the required minimum version of Gravity Forms
-		if( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=' ) ) {
+		if ( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=' ) ) {
 			return;
 		}
- 
+
 		// time for hooks
 		add_filter( 'gform_pre_render', array( $this, 'load_form_script' ), 10, 2 );
 		add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ), 10, 2 );
- 
+
 	}
- 
+
 	public function load_form_script( $form, $is_ajax_enabled ) {
- 
-		if( $this->is_applicable_form( $form ) && ! has_action( 'wp_footer', array( $this, 'output_script' ) ) ) {
+
+		if ( $this->is_applicable_form( $form ) && ! has_action( 'wp_footer', array( $this, 'output_script' ) ) ) {
 			add_action( 'wp_footer', array( $this, 'output_script' ) );
 			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
 		}
- 
+
 		return $form;
 	}
- 
+
 	public function output_script() {
 		?>
- 
+
 		<script type="text/javascript">
 
-            window.gwalfr;
+			window.gwalfr;
 
-            (function($){
+			(function($){
 
-                gwalfr = function( args ) {
+				gwalfr = function( args ) {
 
-                    this.formId      = args.formId,
-                        this.listFieldId = args.listFieldId,
-                        this.inputHtmlId = args.inputHtmlId;
+					this.formId      = args.formId,
+						this.listFieldId = args.listFieldId,
+						this.inputHtmlId = args.inputHtmlId;
 
-                    this.init = function() {
+					this.init = function() {
 
-                        var gwalfr = this,
-                            triggerInput = $( this.inputHtmlId );
+						var gwalfr = this,
+							triggerInput = $( this.inputHtmlId );
 
-                        // update rows on page load
-                        this.updateListItems( triggerInput, this.listFieldId, this.formId );
+						// update rows on page load
+						this.updateListItems( triggerInput, this.listFieldId, this.formId );
 
-                        // update rows when field value changes
-                        triggerInput.change(function(){
-                            gwalfr.updateListItems( $(this), gwalfr.listFieldId, gwalfr.formId );
-                        });
+						// update rows when field value changes
+						triggerInput.change(function(){
+							gwalfr.updateListItems( $(this), gwalfr.listFieldId, gwalfr.formId );
+						});
 
-                    }
+					}
 
-                    this.updateListItems = function( elem, listFieldId, formId ) {
+					this.updateListItems = function( elem, listFieldId, formId ) {
 
-                        var listField = $( '#field_' + formId + '_' + listFieldId ),
-                            count = parseInt( elem.val() );
-                        rowCount = listField.find( 'table.gfield_list tbody tr' ).length,
-                            diff = count - rowCount;
+						var listField = $( '#field_' + formId + '_' + listFieldId ),
+							count = parseInt( elem.val() );
+						rowCount = listField.find( 'table.gfield_list tbody tr' ).length,
+							diff = count - rowCount;
 
-                        if( diff > 0 ) {
-                            for( var i = 0; i < diff; i++ ) {
-                                listField.find( '.add_list_item:last' ).click();
-                            }
-                        } else {
+						if( diff > 0 ) {
+							for( var i = 0; i < diff; i++ ) {
+								listField.find( '.add_list_item:last' ).click();
+							}
+						} else {
 
-                            // make sure we never delete all rows
-                            if( rowCount + diff == 0 )
-                                diff++;
+							// make sure we never delete all rows
+							if( rowCount + diff == 0 )
+								diff++;
 
-                            for( var i = diff; i < 0; i++ ) {
-                                listField.find( '.delete_list_item:last' ).click();
-                            }
+							for( var i = diff; i < 0; i++ ) {
+								listField.find( '.delete_list_item:last' ).click();
+							}
 
-                        }
-                    }
+						}
+					}
 
-                    this.init();
+					this.init();
 
-                }
+				}
 
-            })(jQuery);
+			})(jQuery);
 
 		</script>
- 
+
 		<?php
 	}
- 
+
 	public function add_init_script( $form ) {
- 
-		if( ! $this->is_applicable_form( $form ) ) {
+
+		if ( ! $this->is_applicable_form( $form ) ) {
 			return;
 		}
- 
+
 		$args = array(
 			'formId'      => $this->_args['form_id'],
 			'listFieldId' => $this->_args['list_field_id'],
-			'inputHtmlId' => $this->_args['input_html_id']
+			'inputHtmlId' => $this->_args['input_html_id'],
 		);
 
-		$script = "new gwalfr(" . json_encode( $args ) . ");";
-		$key = implode( '_', $args );
+		$script = 'new gwalfr(' . json_encode( $args ) . ');';
+		$key    = implode( '_', $args );
 
-		GFFormDisplay::add_init_script( $form['id'], 'gwalfr_' . $key , GFFormDisplay::ON_PAGE_RENDER, $script );
+		GFFormDisplay::add_init_script( $form['id'], 'gwalfr_' . $key, GFFormDisplay::ON_PAGE_RENDER, $script );
 	}
- 
+
 	public function is_applicable_form( $form ) {
- 
+
 		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
- 
+
 		return empty( $this->_args['form_id'] ) || $form_id == $this->_args['form_id'];
 	}
- 
+
 }
 
 // EXAMPLE #1: Number field for the "input_html_id"
 new GWAutoListFieldRows( array(
-	'form_id' => 240,
+	'form_id'       => 240,
 	'list_field_id' => 3,
-	'input_html_id' => '#input_240_4'
+	'input_html_id' => '#input_240_4',
 ) );
 
 // EXAMPLE #2: Single Product Field's Quantity input as the "input_html_id"
 new GWAutoListFieldRows( array(
-	'form_id' => 240,
+	'form_id'       => 240,
 	'list_field_id' => 6,
-	'input_html_id' => '#ginput_quantity_240_5'
+	'input_html_id' => '#ginput_quantity_240_5',
 ) );

--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -62,7 +62,6 @@ class GWAutoListFieldRows {
 			window.gwalfr;
 
 			(function($){
-				var gf25 = <?php echo ( version_compare( GFForms::$version, '2.5.0', '>=' ) ) ? 'true' : 'false'; ?>;
 				gwalfr = function( args ) {
 
 					this.formId      = args.formId,
@@ -88,8 +87,8 @@ class GWAutoListFieldRows {
 
 						var listField = $( '#field_' + formId + '_' + listFieldId ),
 							count = parseInt( elem.val() );
-						// GF 2.5 doesn't use tables by default, look for `gfield_list_group` in that case with GF2.4 fallback
-						rowCount = ( gf25 ) ? listField.find('.gfield_list_group').length : listField.find( 'table.gfield_list tbody tr' ).length,
+						// `gfield_list_group` represents the rows in GF2.4 and 2.5. Use that instead of table markup.
+						rowCount = listField.find('.gfield_list_group').length;
 							diff = count - rowCount;
 
 						if( diff > 0 ) {

--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -62,7 +62,7 @@ class GWAutoListFieldRows {
 			window.gwalfr;
 
 			(function($){
-
+				var gf25 = <?php echo ( version_compare( GFForms::$version, '2.5.0', '>=' ) ) ? 'true' : 'false'; ?>;
 				gwalfr = function( args ) {
 
 					this.formId      = args.formId,
@@ -88,7 +88,8 @@ class GWAutoListFieldRows {
 
 						var listField = $( '#field_' + formId + '_' + listFieldId ),
 							count = parseInt( elem.val() );
-						rowCount = listField.find( 'table.gfield_list tbody tr' ).length,
+						// GF 2.5 doesn't use tables by default, look for `gfield_list_group` in that case with GF2.4 fallback
+						rowCount = ( gf25 ) ? listField.find('.gfield_list_group').length : listField.find( 'table.gfield_list tbody tr' ).length,
 							diff = count - rowCount;
 
 						if( diff > 0 ) {


### PR DESCRIPTION
Snippet: gw-set-list-field-rows-by-field-value.php

This PR fixes a markup issue with GF 2.5. By default, the new markup doesn't use tables for List fields.

This caused the snippet to add an unlimited number of fields with every interaction as it was not able to get the current number accurately.

With a version check, the updated snippet will now look for `.gfield_list_group` in GF 2.5 with a fallback to the table method for 2.4 and below.

[#24871](https://secure.helpscout.net/conversation/1527600936/24871/)