### PR TITLE
Initial support for rounding the total field

### DIFF
--- a/gravity-forms/gw-gravity-forms-rounding.php
+++ b/gravity-forms/gw-gravity-forms-rounding.php
@@ -152,8 +152,6 @@ class GW_Rounding {
 
 							var $targets;
 
-							debugger;
-
 							// Attempt to target only the quantity input of a Single Product field.
 							if( $( this ).hasClass( 'gfield_price' ) ) {
 								$targets = $( this ).find( '.ginput_quantity' );

--- a/gravity-forms/gw-gravity-forms-rounding.php
+++ b/gravity-forms/gw-gravity-forms-rounding.php
@@ -52,6 +52,12 @@ class GW_Rounding {
 		add_action( 'gform_pre_submission', array( $this, 'override_submitted_value' ), 10, 5 );
 		add_filter( 'gform_calculation_result', array( $this, 'override_submitted_calculation_value' ), 10, 5 );
 
+		add_filter( 'gform_product_info', function( $product_info, $form, $lead ) {
+			// TODO: Check total field for rounding classes and then find a sane way to
+			// update $product_info accordingly. We can't manipulate the total directly as this
+			// will break PayPal and other 3rd party payment gateways.
+			return $product_info;
+		}, 10, 3 );
 	}
 
 	public function prepare_form_and_load_script( $form, $is_ajax_enabled ) {
@@ -186,6 +192,15 @@ class GW_Rounding {
 							}
 
 							return result;
+						} );
+
+						// Check for rounding class and apply rounding in total field
+						gform.addFilter( 'gform_product_total', function(total, formId){
+							var $input_total = $('.ginput_total');
+							if ( $input_total.parents( '.gw-rounding').length ) {
+								total = self.getRoundedValue( $input_total, total );
+							}
+							return total;
 						} );
 
 					};


### PR DESCRIPTION
@claygriffiths This PR is a work in progress. I've hit a logical wall here with adding rounding support to total fields.

Rounding on the front-end is straight forward, I've added a JS hook [`gform_product_total`](https://docs.gravityforms.com/gform_product_total/) which then checks for the proper classes and rounds the total correctly.

The issue now is that this is just cosmetic. We need to implement [`gform_product_info`](https://docs.gravityforms.com/gform_product_info/) on the back-end to actually change the amount users will pay.

The problem here is that when applying the rounding to a total, there's no telling which product(s) prices should be affected.

My initial idea was to just split the rounded total by the quantity on the first product and then add an "adjusted rounded price" like `$product_info['products']['adjusted_rounded_price']` with the difference.

That will not work though if the form has more than one product and will also cause 3rd party processing to fail.

Any thoughts here about what can be done or is this just outside of the scope of what we can support?

[#24946](https://secure.helpscout.net/conversation/1531948301/24946?folderId=3808239)