### PR TITLE
Removed JS `debugger` from gw-gravity-forms-rounding.php.

### DIFF
--- a/gravity-forms/gw-gravity-forms-rounding.php
+++ b/gravity-forms/gw-gravity-forms-rounding.php
@@ -152,8 +152,6 @@ class GW_Rounding {
 
 							var $targets;
 
-							debugger;
-
 							// Attempt to target only the quantity input of a Single Product field.
 							if( $( this ).hasClass( 'gfield_price' ) ) {
 								$targets = $( this ).find( '.ginput_quantity' );


### PR DESCRIPTION
This PR removes a rogue `debugger` statement left in `gw-gravity-forms-rounding.php`.

[#24946](https://secure.helpscout.net/conversation/1531948301/24946?folderId=3808239)