### PR TITLE
Fixed an issue where "Order Summary" label would still appear when using `nopricingfields` modifier.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -240,7 +240,7 @@ class GW_All_Fields_Template {
 		// $field_id = $field->id;
 		// print_r( compact( 'modifiers', 'field_ids', 'field_id', 'value' ) );
 		// echo '<pre>';
-
+		remove_filter( 'gform_display_product_summary', '__return_false' );
 		return $value;
 	}
 

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -166,6 +166,8 @@ class GW_All_Fields_Template {
 					return '';
 				};
 				add_filter( 'gform_order_summary', $func );
+				// Hide "Order Summary" label if nopricingfields is used
+				add_filter( 'gform_display_product_summary', '__return_false' );
 			}
 
 			/**


### PR DESCRIPTION
The `nopricingfields` modifier doesn't seem to apply to the "Order Summary" label.

This PR uses a second filter `gform_display_product_summary` to ensure it's hidden.

Ticket: [#25152](https://secure.helpscout.net/conversation/1539696626/25152/)