### PR TITLE
Fixed an issue where `nopricingfields` may still show order summary when other modifiers are used.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -167,7 +167,11 @@ class GW_All_Fields_Template {
 				};
 				add_filter( 'gform_order_summary', $func );
 				// Hide "Order Summary" label if nopricingfields is used
-				add_filter( 'gform_display_product_summary', '__return_false' );
+				$gf_dps_func = function() use ( &$gf_dps_func ) {
+					remove_filter( 'gform_display_product_summary', $gf_dps_func );
+					return false;
+				};
+				add_filter( 'gform_display_product_summary', $gf_dps_func );
 			}
 
 			/**
@@ -240,7 +244,6 @@ class GW_All_Fields_Template {
 		// $field_id = $field->id;
 		// print_r( compact( 'modifiers', 'field_ids', 'field_id', 'value' ) );
 		// echo '<pre>';
-		remove_filter( 'gform_display_product_summary', '__return_false' );
 		return $value;
 	}
 


### PR DESCRIPTION
This PR amends #106 to ensure that "Order Summary" label is not displayed when using the `nopricingfields` modifier.

#106 failed as it removed the `gform_display_product_summary` filter prematurely which caused the label to show if other modifiers (e.g. `exclude`) are used along with `nopricingfields`.

The commit here uses a closure instead to ensure that the filter is only removed after it's been fired once.

Ticket: [#25152](https://secure.helpscout.net/conversation/1539696626/25152?folderId=3808239)