### PR TITLE
Add and fix gpuid-retroactively-populate-unique-ids.php

### DIFF
--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -3,7 +3,7 @@
  * Gravity Perks // GP Unique ID // Retroactively Populate Unique IDs
  * https://gravitywiz.com/documentation/gp-unique-id/
  *
- * 1. Copy and paste this code into your theme's functions.php file.
+ * 1. Install snippet using instructions at https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
  * 2. Go to your home page and add the following parameters to the query string:
  *
  *     gpui_retro_pop=1
@@ -14,6 +14,7 @@
  *     http://mysite.com/?gpui_retro_pop=1&form_id=123
  *
  * 3. Submit the updated URL. If everything is correct, you will be greeted with a success message and updated entry count.
+ * 4. Important! Remove snippet after verifying that unique IDs have been generated for previous entries.
  *
  * NOTE: This snippet has a hard-coded limit of 999 entries.
  */

--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -15,7 +15,6 @@
  *
  * 3. Submit the updated URL. If everything is correct, you will be greeted with a success message and updated entry count.
  * 4. Important! Remove snippet after verifying that unique IDs have been generated for previous entries.
- * 4. Important! Remove snippet after verifying that unique IDs have been generated for previous entries.
  *
  * NOTE: This snippet has a hard-coded limit of 999 entries.
  */

--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -17,60 +17,64 @@
  *
  * NOTE: This snippet has a hard-coded limit of 999 entries.
  */
-if( isset( $_GET['gpui_retro_pop'] ) && class_exists( 'GFAPI' ) ) {
+if ( isset( $_GET['gpui_retro_pop'] ) && class_exists( 'GFAPI' ) ) {
 
 	$form_id = rgget( 'form_id' );
-	$form = GFAPI::get_form( $form_id );
-	if( ! $form ) {
+	$form    = GFAPI::get_form( $form_id );
+	if ( ! $form ) {
 		echo 'Please provide a valid form ID.';
 		exit;
 	}
 
 	$unique_id_fields = GFCommon::get_fields_by_type( $form, array( 'uid' ) );
-	if( empty( $unique_id_fields ) ) {
+	if ( empty( $unique_id_fields ) ) {
 		echo 'There are no Unique ID fields on this form.';
 		exit;
 	}
 
 	$filters = array();
-	foreach( $unique_id_fields as $unique_id_field ) {
+	foreach ( $unique_id_fields as $unique_id_field ) {
 		$filters[] = array(
-			'key' => $unique_id_field->id,
-			'value' => null
+			'key'   => $unique_id_field->id,
+			'value' => null,
 		);
 	}
 	$filters['mode'] = 'any';
 
-	$entries = GFAPI::get_entries( $form['id'], array(
-		'field_filters' => $filters,
-	), null, array(
-		'offset' => 0,
-		'page_size' => 999
-	) );
+	$entries = GFAPI::get_entries(
+		$form['id'],
+		array(
+			'field_filters' => $filters,
+		),
+		null,
+		array(
+			'offset'    => 0,
+			'page_size' => 999,
+		)
+	);
 
-	if( empty( $entries ) ) {
+	if ( empty( $entries ) ) {
 		echo 'There are no entries requiring retroactive population.';
 		exit;
 	}
 
 	$count = 0;
 
-	foreach( $entries as $entry ) {
+	foreach ( $entries as $entry ) {
 
 		$has_update = false;
 
-		foreach( $unique_id_fields as $unique_id_field ) {
-			if( empty( $entry[ $unique_id_field->id ] ) ) {
+		foreach ( $unique_id_fields as $unique_id_field ) {
+			if ( empty( $entry[ $unique_id_field->id ] ) ) {
 				$entry[ $unique_id_field->id ] = gp_unique_id()->get_unique( $form['id'], $unique_id_field );
-				$has_update = true;
+				$has_update                    = true;
 			}
 		}
 
-		if( $has_update ) {
+		if ( $has_update ) {
 			GFAPI::update_entry( $entry );
-			$count++;
+			$count ++;
 		}
-
 	}
 
 	printf( '%d entries updated.', $count );

--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Gravity Perks // GP Unique ID // Retroactively Populate Unique IDs
+ * https://gravitywiz.com/documentation/gp-unique-id/
+ *
+ * 1. Copy and paste this code into your theme's functions.php file.
+ * 2. Go to your home page and add the following parameters to the query string:
+ *
+ *     gpui_retro_pop=1
+ *     form_id=123
+ *
+ *     Make sure you replace "123" with the ID of your form. Full URL should look like this:
+ *
+ *     http://mysite.com/?gpui_retro_pop=1&form_id=123
+ *
+ * 3. Submit the updated URL. If everything is correct, you will be greeted with a success message and updated entry count.
+ *
+ * NOTE: This snippet has a hard-coded limit of 999 entries.
+ */
+if( isset( $_GET['gpui_retro_pop'] ) && class_exists( 'GFAPI' ) ) {
+
+	$form_id = rgget( 'form_id' );
+	$form = GFAPI::get_form( $form_id );
+	if( ! $form ) {
+		echo 'Please provide a valid form ID.';
+		exit;
+	}
+
+	$unique_id_fields = GFCommon::get_fields_by_type( $form, array( 'uid' ) );
+	if( empty( $unique_id_fields ) ) {
+		echo 'There are no Unique ID fields on this form.';
+		exit;
+	}
+
+	$filters = array();
+	foreach( $unique_id_fields as $unique_id_field ) {
+		$filters[] = array(
+			'key' => $unique_id_field->id,
+			'value' => null
+		);
+	}
+	$filters['mode'] = 'any';
+
+	$entries = GFAPI::get_entries( $form['id'], array(
+		'field_filters' => $filters,
+	), null, array(
+		'offset' => 0,
+		'page_size' => 999
+	) );
+
+	if( empty( $entries ) ) {
+		echo 'There are no entries requiring retroactive population.';
+		exit;
+	}
+
+	$count = 0;
+
+	foreach( $entries as $entry ) {
+
+		$has_update = false;
+
+		foreach( $unique_id_fields as $unique_id_field ) {
+			if( empty( $entry[ $unique_id_field->id ] ) ) {
+				$entry[ $unique_id_field->id ] = gp_unique_id()->get_unique( $form['id'], $unique_id_field );
+				$has_update = true;
+			}
+		}
+
+		if( $has_update ) {
+			GFAPI::update_entry( $entry );
+			$count++;
+		}
+
+	}
+
+	printf( '%d entries updated.', $count );
+
+	exit;
+}

--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -17,67 +17,69 @@
  *
  * NOTE: This snippet has a hard-coded limit of 999 entries.
  */
-if ( isset( $_GET['gpui_retro_pop'] ) && class_exists( 'GFAPI' ) ) {
+add_action( 'init', function() {
+	if ( isset( $_GET['gpui_retro_pop'] ) && class_exists( 'GFAPI' ) ) {
 
-	$form_id = rgget( 'form_id' );
-	$form    = GFAPI::get_form( $form_id );
-	if ( ! $form ) {
-		echo 'Please provide a valid form ID.';
-		exit;
-	}
+		$form_id = rgget( 'form_id' );
+		$form    = GFAPI::get_form( $form_id );
+		if ( ! $form ) {
+			echo 'Please provide a valid form ID.';
+			exit;
+		}
 
-	$unique_id_fields = GFCommon::get_fields_by_type( $form, array( 'uid' ) );
-	if ( empty( $unique_id_fields ) ) {
-		echo 'There are no Unique ID fields on this form.';
-		exit;
-	}
+		$unique_id_fields = GFCommon::get_fields_by_type( $form, array( 'uid' ) );
+		if ( empty( $unique_id_fields ) ) {
+			echo 'There are no Unique ID fields on this form.';
+			exit;
+		}
 
-	$filters = array();
-	foreach ( $unique_id_fields as $unique_id_field ) {
-		$filters[] = array(
-			'key'   => $unique_id_field->id,
-			'value' => null,
-		);
-	}
-	$filters['mode'] = 'any';
-
-	$entries = GFAPI::get_entries(
-		$form['id'],
-		array(
-			'field_filters' => $filters,
-		),
-		null,
-		array(
-			'offset'    => 0,
-			'page_size' => 999,
-		)
-	);
-
-	if ( empty( $entries ) ) {
-		echo 'There are no entries requiring retroactive population.';
-		exit;
-	}
-
-	$count = 0;
-
-	foreach ( $entries as $entry ) {
-
-		$has_update = false;
-
+		$filters = array();
 		foreach ( $unique_id_fields as $unique_id_field ) {
-			if ( empty( $entry[ $unique_id_field->id ] ) ) {
-				$entry[ $unique_id_field->id ] = gp_unique_id()->get_unique( $form['id'], $unique_id_field );
-				$has_update                    = true;
+			$filters[] = array(
+				'key'   => $unique_id_field->id,
+				'value' => null,
+			);
+		}
+		$filters['mode'] = 'any';
+
+		$entries = GFAPI::get_entries(
+			$form['id'],
+			array(
+				'field_filters' => $filters,
+			),
+			null,
+			array(
+				'offset'    => 0,
+				'page_size' => 999,
+			)
+		);
+
+		if ( empty( $entries ) ) {
+			echo 'There are no entries requiring retroactive population.';
+			exit;
+		}
+
+		$count = 0;
+
+		foreach ( $entries as $entry ) {
+
+			$has_update = false;
+
+			foreach ( $unique_id_fields as $unique_id_field ) {
+				if ( empty( $entry[ $unique_id_field->id ] ) ) {
+					$entry[ $unique_id_field->id ] = gp_unique_id()->get_unique( $form['id'], $unique_id_field );
+					$has_update                    = true;
+				}
+			}
+
+			if ( $has_update ) {
+				GFAPI::update_entry( $entry );
+				$count ++;
 			}
 		}
 
-		if ( $has_update ) {
-			GFAPI::update_entry( $entry );
-			$count ++;
-		}
+		printf( '%d entries updated.', $count );
+
+		exit;
 	}
-
-	printf( '%d entries updated.', $count );
-
-	exit;
-}
+} );

--- a/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
+++ b/gp-unique-id/gpuid-retroactively-populate-unique-ids.php
@@ -15,6 +15,7 @@
  *
  * 3. Submit the updated URL. If everything is correct, you will be greeted with a success message and updated entry count.
  * 4. Important! Remove snippet after verifying that unique IDs have been generated for previous entries.
+ * 4. Important! Remove snippet after verifying that unique IDs have been generated for previous entries.
  *
  * NOTE: This snippet has a hard-coded limit of 999 entries.
  */


### PR DESCRIPTION
This PR adds the [`gpuid-retroactively-populate-unique-ids.php`](https://gist.github.com/spivurno/535b74a34c0830adf1b770fed0de7812) to the snippet library.

It also fixes an issue where the snippet may cause a PHP fatal error when used with the Code Snippets plugin by utilizing WordPress's `init` hook to ensure that GPUID is loaded.

Ticket: [#25217](https://secure.helpscout.net/conversation/1540675886/25217?folderId=3808239)