### PR TITLE
Fixed an issue where `gppa-populate-child-entries.php` may generate a JS error in multi-page forms.

### DIFF
--- a/gp-populate-anything/gppa-populate-child-entries.php
+++ b/gp-populate-anything/gppa-populate-child-entries.php
@@ -97,13 +97,14 @@ class GPPA_Populate_Child_Entries {
 									.val( gpnfCookie.hash )
 									.change();
 							}
-						} );
 
-						for ( var i = 0; i < self.nestedFormFieldIds.length; i++ ) {
-							window[ 'GPNestedForms_{0}_{1}'.format( self.formId, self.nestedFormFieldIds[ i ] ) ].viewModel.entries.subscribe( function( entries ) {
-								self.$peidField.data( 'lastValue', '' ).change();
-							} );
-						}
+							for ( var i = 0; i < self.nestedFormFieldIds.length; i++ ) {
+								window[ 'GPNestedForms_{0}_{1}'.format( self.formId, self.nestedFormFieldIds[ i ] ) ].viewModel.entries.subscribe( function( entries ) {
+									self.$peidField.data( 'lastValue', '' ).change();
+								} );
+							}
+
+						} );
 
 					};
 
@@ -122,7 +123,6 @@ class GPPA_Populate_Child_Entries {
 					}
 
 					self.init();
-
 				}
 
 			} )( jQuery );


### PR DESCRIPTION
This PR fixes an issue where [gppa-populate-child-entries](https://github.com/gravitywiz/snippet-library/blob/master/gp-populate-anything/gppa-populate-child-entries.php) would generate a JS error in multi-paged forms.

This snippet ([Loom demo by David](https://www.loom.com/share/7b26b18f78624e0ca4bcd2b574636b8b)) assumed that GPNF would have instantiated Knockout.JS on page load. It already used the correct filter `gpnf_session_initialized`, however, the for loop needed to be inside that closure as well.

Ticket: [#25190](https://secure.helpscout.net/conversation/1539872947/25190?folderId=3808239)