### PR TITLE
Fixed an issue in `gw-set-list-field-rows-by-field-value` where List field icons were not hidden.

### DIFF
--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -65,8 +65,8 @@ class GWAutoListFieldRows {
 				gwalfr = function( args ) {
 
 					this.formId      = args.formId,
-						this.listFieldId = args.listFieldId,
-						this.inputHtmlId = args.inputHtmlId;
+					this.listFieldId = args.listFieldId,
+					this.inputHtmlId = args.inputHtmlId;
 
 					this.init = function() {
 
@@ -80,6 +80,9 @@ class GWAutoListFieldRows {
 						triggerInput.change(function(){
 							gwalfr.updateListItems( $(this), gwalfr.listFieldId, gwalfr.formId );
 						});
+
+						// Hide add/remove buttons
+						$("#field_{0}_{1} .gfield_list_icons".format( this.formId, this.listFieldId ) ).css( 'display', 'none' );
 
 					}
 


### PR DESCRIPTION
This PR fixes an issue where the add/remove icons on a list field were still visible after activating this snippet.

I couldn't find an earlier version where we hid them, but the [demo on our site's documentation](http://demos.gravitywiz.com/set-number-of-list-field-rows-by-field-value/) has inline CSS that hides those icons.

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/2730108/122611672-b7d33c80-d04f-11eb-8045-42fd18a078e5.png)

#### After
![image](https://user-images.githubusercontent.com/2730108/122611592-97a37d80-d04f-11eb-9296-9f1b4b38ca95.png)

Ticket: [#25350](https://secure.helpscout.net/conversation/1546148997/25350?folderId=3808239)