### PR TITLE
Fixed the number of arguments used with the `gform_merge_tag_filter` filter.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -82,7 +82,7 @@ class GW_All_Fields_Template {
 	public function init() {
 
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_merge_tags' ), 9, 7 );
-		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 5 );
+		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 6 );
 
 	}
 
@@ -99,7 +99,7 @@ class GW_All_Fields_Template {
 	 * example: {all_fields:include[6]}
 	 * example: {all_fields:include[6],exclude[2,3]}
 	 */
-	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value ) {
+	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value, $format ) {
 
 		if ( ! is_a( $field, 'GF_Field' ) ) {
 			$field       = new GF_Field();
@@ -387,7 +387,7 @@ class GW_All_Fields_Template {
 						}
 					}
 
-					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $field_label );
+					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $field_label, 'html' );
 
 					//$field_data .= $field_value;
 
@@ -433,7 +433,7 @@ class GW_All_Fields_Template {
 						$field_value = false;
 					}
 
-					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value );
+					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value, 'html' );
 
 					if ( $field_value === false ) {
 						break;

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -82,7 +82,7 @@ class GW_All_Fields_Template {
 	public function init() {
 
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_merge_tags' ), 9, 7 );
-		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 6 );
+		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 5 );
 
 	}
 
@@ -99,7 +99,7 @@ class GW_All_Fields_Template {
 	 * example: {all_fields:include[6]}
 	 * example: {all_fields:include[6],exclude[2,3]}
 	 */
-	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value, $format ) {
+	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value ) {
 
 		if ( ! is_a( $field, 'GF_Field' ) ) {
 			$field       = new GF_Field();

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -387,7 +387,7 @@ class GW_All_Fields_Template {
 						}
 					}
 
-					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $field_label, 'html' );
+					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $field_label, $format );
 
 					//$field_data .= $field_value;
 
@@ -433,7 +433,7 @@ class GW_All_Fields_Template {
 						$field_value = false;
 					}
 
-					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value, 'html' );
+					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value, $format );
 
 					if ( $field_value === false ) {
 						break;


### PR DESCRIPTION
This PR fixes our `apply_filters()` calls as well as the listeners for [gform_merge_tag_filter](https://docs.gravityforms.com/gform_merge_tag_filter/).

It looks like the snippet was missing the 6th parameters (`$format`).

The commit here adds it to the parameters list and also passes '`html`' by default when applying the filter.

Ticket: [#25603](https://secure.helpscout.net/conversation/1557163349/25603/)