### PR TITLE
Fixed a compatibility issue between `gw-validate-that-a-value-exists.php` and GPPA.

### DIFF
--- a/gravity-forms/gw-validate-that-a-value-exists.php
+++ b/gravity-forms/gw-validate-that-a-value-exists.php
@@ -165,7 +165,8 @@ class GW_Value_Exists_Validation {
 
 	public function load_form_script( $form, $is_ajax_enabled ) {
 
-		if( $this->is_applicable_form( $form ) && ! self::$is_script_output && ! $this->is_ajax_submission( $form['id'], $is_ajax_enabled ) ) {
+		// Do not output main script if AJAX is enabled
+		if( ! $is_ajax_enabled && $this->is_applicable_form( $form ) && ! self::$is_script_output && ! $this->is_ajax_submission( $form['id'], $is_ajax_enabled ) ) {
 			$this->output_script();
 		}
 
@@ -348,7 +349,8 @@ class GW_Value_Exists_Validation {
 	}
 
 	public function is_ajax_submission( $form_id, $is_ajax_enabled ) {
-		return isset( GFFormDisplay::$submission[ $form_id ] ) && $is_ajax_enabled;
+		// Ensure GFFormDisplay is available before continuing to check (edge case with GPPA loading a pseudo form. See HS#25828)
+		return class_exists( 'GFFormDisplay' ) && isset( GFFormDisplay::$submission[ $form_id ] ) && $is_ajax_enabled;
 	}
 
 }


### PR DESCRIPTION
This PR fixes a compatibility issue with GPPA. Validate that a value exists injected JS in GPPA's XHR responses.

The issue was two fold:
1) GPPA did not indicate while loading psuedo form to hydrate that it's an AJAX call (while applying `gform_pre_render`).
2) We could skip all checks as soon as we know that `$is_ajax_enabled` is true in the snippet.

Also for safety, a check if `GFFormDisplay` exists. This seemed inconsistent while using GPPA and ended up causing 500 errors.

Ticket: [#25828](https://secure.helpscout.net/conversation/1567861775/25828?folderId=3808239)
[GPPA PR](https://github.com/gravitywiz/gp-populate-anything/pull/213).