### PR TITLE
Fixed an issue where `gw-create-coupon` scheduled coupons using GMT instead of the timezone configured in WordPress.

### DIFF
--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -185,7 +185,8 @@ class GW_Create_Coupon {
 
 		$start_date = rgar( $this->_args['meta'], 'start_date' );
 		if ( $start_date === '' || ! strtotime( $start_date ) ) {
-			$start_date = gmdate( 'Y-m-d H:i:s' );
+			$date       = current_datetime();
+			$start_date = $date->format( 'Y-m-d H:i:s' );
 		}
 
 		// WooCommerce coupon uses the Post Title as the coupon code hence $coupon_code is assigned to Post Title and $coupon_name is assigned to the Post Content

--- a/gravity-forms/gw-create-coupon.php
+++ b/gravity-forms/gw-create-coupon.php
@@ -4,7 +4,7 @@
  *
  * Create coupons via Gravity Forms submissions. Map the coupon code to a field on the GF form and voila!
  *
- * @version 1.2
+ * @version 1.2.1
  * @author  David Smith <david@gravitywiz.com>
  * @license GPL-2.0+
  * @link    WooCommerce:   http://gravitywiz.com/creating-coupons-woocommerce-gravity-forms/


### PR DESCRIPTION
This PR fixes an issue with the `gw-create-coupon` snippet's handling of start date with WooCommerce.

The snippet is supposed to set the coupons to start immediately, however if the timezone is behind GMT (e.g. `America/New_York`) the coupon gets scheduled to a time in the future and is not available for immediate use.

The fix here was to swap `gmdate()` with `current_datetime()` to respect the timezone set in WP.

Ticket: [#26099](https://secure.helpscout.net/conversation/1577829998/26099?folderId=3808239)