### PR TITLE
Added support for removing featured image if no value is submitted.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -17,15 +17,17 @@ class GW_Update_Posts {
 		$this->_args = wp_parse_args(
 			$args,
 			array(
-				'form_id'        => false,
-				'post_id'        => false,
-				'title'          => false,
-				'content'        => false,
-				'author'         => false,
-				'status'         => false,
-				'terms'          => array(),
-				'meta'           => array(),
-				'featured_image' => false,
+				'form_id'         => false,
+				'post_id'         => false,
+				'title'           => false,
+				'content'         => false,
+				'author'          => false,
+				'status'          => false,
+				'terms'           => array(),
+				'meta'            => array(),
+				'featured_image'  => false,
+				// If property is mapped but no entry value is submitted, delete the property. Currently only works with 'featured_image'.
+				'delete_if_empty' => false,
 			)
 		);
 
@@ -81,7 +83,7 @@ class GW_Update_Posts {
 				if ( $image_id ) {
 					set_post_thumbnail( $post, $image_id );
 				}
-			} else {
+			} elseif ( $this->_args['delete_if_empty'] ) {
 				delete_post_meta( $post->ID, '_thumbnail_id' );
 			}
 		}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -76,9 +76,13 @@ class GW_Update_Posts {
 		}
 
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {
-			$image_id = gp_media_library()->get_file_ids( $entry['id'], $this->_args['featured_image'], 0 );
-			if ( $image_id ) {
-				set_post_thumbnail( $post, $image_id );
+			if ( rgar( $entry, $this->_args['featured_image'] ) ) {
+				$image_id = gp_media_library()->get_file_ids( $entry['id'], $this->_args['featured_image'], 0 );
+				if ( $image_id ) {
+					set_post_thumbnail( $post, $image_id );
+				}
+			} else {
+				delete_post_meta( $post->ID, '_thumbnail_id' );
 			}
 		}
 


### PR DESCRIPTION
**[HS#26075](https://secure.helpscout.net/conversation/1576510052/26075/)**

This PR adds supports for removing the selected post's featured image if no value is submitted for featured image field specified in the configuration.

My primary concern with this is that we currently have no way to repopulate the current featured image from the post. It might be better to make this an opt-in feature with an additional configuration parameter. Thoughts?