### PR TITLE
Fixed an issue with GF 2.5 Checkbox fields and `gw-cache-buster`.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -187,7 +187,8 @@ class GW_Cache_Buster {
 		$atts = json_decode( rgpost( 'atts' ), true );
 		// GF expects an associative array for field values. Parse them before passing it on.
 		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
-		$_POST        = array();
+		// If `$_POST` is not an empty array GF 2.5 fails to select default values for checkbox fields. See HS#26188
+		$_POST = array();
 		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -187,6 +187,7 @@ class GW_Cache_Buster {
 		$atts = json_decode( rgpost( 'atts' ), true );
 		// GF expects an associative array for field values. Parse them before passing it on.
 		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
+		$_POST        = array();
 		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();


### PR DESCRIPTION
GF 2.5 expects `$_POST` to be an empty `Array` before applying defaults to Checkbox fields.

While this is a Gravity Forms core issue, emptying out `$_POST` in GWCB resolves this issue.

I've modified @claygriffiths's patch slightly by not retaining `$_POST` in a variable. We `die()` immediately after GF outputs the form's markup.

Ticket: [#26188](https://secure.helpscout.net/conversation/1580050306/26188/)