### PR TITLE
Added support for converting values fetched from GF Product fields to a numeric format.

### DIFF
--- a/gp-populate-anything/gppa-aggregate-functions.php
+++ b/gp-populate-anything/gppa-aggregate-functions.php
@@ -46,7 +46,7 @@ function gppa_aggr_get_value( $merge_tag, $object, $object_type ) {
 	if ( $object_type->id === 'gf_entry' && strpos( $merge_tag, 'gf_field_' ) !== false ) {
 		$input_id     = str_replace( 'gf_field_', '', $merge_tag );
 		$source_field = GFAPI::get_field( $object->form_id, $input_id );
-		if ( GFCommon::is_product_field( $source_field->get_input_type() ) ) {
+		if ( GFCommon::is_product_field( $source_field->type ) ) {
 			$value = GFCommon::to_number( $value, $object->currency );
 		}
 	}


### PR DESCRIPTION
[HS#26950](https://secure.helpscout.net/conversation/1612756083/26950)

This PR adds support for converting values fetched from GF Product fields, which are stored as currency, into raw numbers. 

The sample JSON ([gravityforms-export-2021-08-26.json.zip](https://github.com/gravitywiz/snippet-library/files/7062616/gravityforms-export-2021-08-26.json.zip)) is for a User Defined Price field. Specify any number into the **Price** field, submit the form, and reload the page. **Number B** will now contain the entered price. Repeat this process and **Number B** will update to sum the total of the prices you have entered.

This would benefit from testing with the other aggregrate functions (avg, min, and max).