### PR TITLE
Fix conflicts with other plugins

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -433,7 +433,7 @@ class GW_All_Fields_Template {
 						$field_value = false;
 					}
 
-					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value );
+					$field_value = apply_filters( 'gform_merge_tag_filter', $field_value, $merge_tag, $modifiers, $field, $raw_field_value, 'html' );
 
 					if ( $field_value === false ) {
 						break;


### PR DESCRIPTION
This plugin causes a conflict with other plugins and themes that use the `gform_merge_tag_filter` and require all 6 arguments, however this plugin does not supply the `$format` parameter.

    function my_gform_merge_tag_filter( $value, $merge_tag, $modifier, $field, $raw_value, $format ) {
        // Filter based on $format.
        return $value;
    }
    add_filter( 'gform_merge_tag_filter', 'my_gform_merge_tag_filter', 10, 6 );
    // PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function my_gform_merge_tag_filter

This should be a relatively simple change, by supplying that the format is "html".