### PR TITLE
Fixed a compatibility issue between the `gw-populate-date` snippet and newer versions of GPPA.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -308,6 +308,15 @@ class GW_Populate_Date {
 							self.populateDate( self.sourceFieldId, self.targetFieldId, self.getModifier(), self.format );
 						} );
 
+						// Listen for GPPA's new `gppa_updated_batch_fields`
+						$( document ).on( 'gppa_updated_batch_fields', function ( e, formId, updatedFieldIDs ) {
+							for ( var i = 0, max = updatedFieldIDs.length; i < max; i ++ ) {
+								if ( self.sourceFieldId === parseInt( updatedFieldIDs[i] ) ) {
+									self.populateDate( self.sourceFieldId, self.targetFieldId, self.getModifier(), self.format );
+								}
+							}
+						} );
+
 						if( typeof self.modifier == 'object' ) {
 							self.$modifierInputs = self.getInputs( self.modifier.inputId );
 							self.$modifierInputs.change( function() {


### PR DESCRIPTION
This PR fixes a compatibility issue with GPPA and gw-populate-date snippet when using a Field Value Object to populate the source field.

The commit here adds `gppa_updated_batch_fields` to the list of events the snippet listens to when updating the target field.

Ticket: [#27144](https://secure.helpscout.net/conversation/1619932499/27144/)