### PR TITLE
Fixed a compatibility issue between `gpep-edit-entry` and GPI.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -20,7 +20,8 @@ class GPEP_Edit_Entry {
 
 		add_filter( "gform_entry_id_pre_save_lead_{$this->form_id}", array( $this, 'update_entry_id' ), 10, 2 );
 		add_filter( "gpls_rule_groups_{$this->form_id}", array( $this, 'bypass_limit_submissions' ), 10, 2 );
-
+		// Enable edit view in GP Inventory
+		add_filter( "gpi_is_edit_view_{$this->form_id}", '__return_true' );
 	}
 
 	public function update_entry_id( $entry_id, $form ) {


### PR DESCRIPTION
This PR fixes a compatibility issue between the `gpep-edit-entry` snippet and GP Inventory.

Relies on GPI PR: https://github.com/gravitywiz/gp-inventory/pull/11

Ticket: [#27355](https://secure.helpscout.net/conversation/1629579038/27355?folderId=3808239)