### PR TITLE
Fixed issue where GPPA-populated fields (and Live Merge Tags) did not work when dependent on a GW-Populate-Date-populated field.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -51,7 +51,8 @@ class GW_Populate_Date {
 			add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ) );
 			add_filter( 'gform_enqueue_scripts', array( $this, 'enqueue_form_scripts' ) );
 		} else {
-			add_filter( 'gform_pre_render', array( $this, 'populate_date_on_pre_render' ) );
+			// Populate dates *before* Populate Anything so GPPA can use them in live merge tags and it's own pre render population.
+			add_filter( 'gform_pre_render', array( $this, 'populate_date_on_pre_render' ), 8 );
 		}
 
 		if ( $this->_args['override_on_submission'] ) {


### PR DESCRIPTION
This PR resolves an issue where GPPA-populated fields and Live Merge Tags did not work when they were dependent on a GW-Populate-Dates-populated field. GWPD was populating the fields _after_ Populate Anything had already done its magic. 

Video of the use case recorded for the customer here: https://www.loom.com/share/db373ccd9c274712bfd118d8bdc37a86