### PR TITLE
Fixed an issue in `gp-limit-choices/gplc-field-groups.php` snippet where multiple rules targeting the same field caused incorrect limits to show when used with GPNF.

### DIFF
--- a/gp-limit-choices/gplc-field-groups.php
+++ b/gp-limit-choices/gplc-field-groups.php
@@ -223,7 +223,7 @@ class GP_Limit_Choices_Field_Group {
 								continue;
 							}
 
-							for ( var j = 0, max = fieldIds.length; j < max; j ++ ) {
+							for ( var j = 0, maxJ = fieldIds.length; j < maxJ; j ++ ) {
 								var fieldId = parseInt( fieldIds[j] );
 								if ( fieldId === group.targetFieldId || $.inArray( fieldId, group.triggerFieldIds ) !== - 1 ) {
 									groupsToRefresh[formFieldId] = group;


### PR DESCRIPTION
This PR fixes an issue with how the `gplc-field-groups` handled conditional logic.

Initially we used the generic `gform_post_conditional_logic` which caused multiple XHR requests to fire when multiple field groups are configured.

This gets even worse when using GPLC with GPNF as every modal initialization doubles the number of event listeners.

The new approach here moves conditional logic processing to a global event handler (inside IIFE) with a GPLCFG registry for each group instance.

Ticket: [#26933](https://secure.helpscout.net/conversation/1612033687/26933?folderId=3808239)