### PR TITLE
Added support for `{all_fields}` merge tag in the `gw-multi-file-merge-tag` snippet.

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -13,7 +13,7 @@
  * Plugin URI:   https://gravitywiz.com/customizing-multi-file-merge-tag/
  * Description:  Enhance the merge tag for multi-file upload fields by adding support for outputting markup that corresponds to the uploaded file.
  * Author:       Gravity Wiz
- * Version:      1.7
+ * Version:      1.7.1
  * Author URI:   https://gravitywiz.com
  */
 class GW_Multi_File_Merge_Tag {

--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -84,15 +84,13 @@ class GW_Multi_File_Merge_Tag {
 
 	}
 
-	public function process_all_fields_merge_tag( $field_value, $merge_tag, $options, $field, $field_label, $format ) {
-		if ( $merge_tag === 'all_fields' && $this->is_applicable_field( $field ) ) {
-			$entry = GFFormsModel::get_current_lead();
-			$value = GFFormsModel::get_lead_field_value( $entry, $field );
-			$files = empty( $value ) ? array() : json_decode( $value, true );
+	public function process_all_fields_merge_tag( $field_value, $merge_tag, $modifiers, $field, $raw_value, $format ) {
+		if ( $merge_tag === 'all_fields' && ! rgblank( $raw_value ) && $this->is_applicable_field( $field ) ) {
+			$files = empty( $raw_value ) ? array() : json_decode( $raw_value, true );
 			$value = '';
 			if ( $files ) {
 				foreach ( $files as &$file ) {
-					$value .= $this->get_file_markup( $file, $entry['form_id'] );
+					$value .= $this->get_file_markup( $file, $field['formId'] );
 					$value  = str_replace( $file, $field->get_download_url( $file, false ), $value );
 				}
 			}


### PR DESCRIPTION
This PR adds support for the `{all_fields}` merge tag by utilizing the `gform_merge_tag_filter` filter.

Ticket: [#27719](https://secure.helpscout.net/conversation/1642757936/27719?folderId=3808239)