### PR TITLE
Added `gwaft_template_paths` filter to allow adding custom template paths.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -597,6 +597,13 @@ class GW_All_Fields_Template {
 
 		$template_dir = $this->get_theme_template_dir_name();
 
+		/**
+		 * Filter the paths that will be checked for a template file.
+		 *
+		 * @since 0.9.12
+		 *
+		 * @param array $file_paths An array of file paths. Key is the priority of the path. Value is an absolute path to a directory.
+		 */
 		$file_paths = apply_filters( 'gwaft_template_paths', array(
 			1  => trailingslashit( get_stylesheet_directory() ) . $template_dir,
 			10 => trailingslashit( get_template_directory() ) . $template_dir,

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -8,7 +8,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-all-fields-template/
  * Description:  Modify the {all_fields} merge tag output via a template file.
  * Author:       Gravity Wiz
- * Version:      0.9.11
+ * Version:      0.9.12
  * Author URI:   http://gravitywiz.com
  *
  * Usage:
@@ -597,10 +597,10 @@ class GW_All_Fields_Template {
 
 		$template_dir = $this->get_theme_template_dir_name();
 
-		$file_paths = array(
+		$file_paths = apply_filters( 'gwaft_template_paths', array(
 			1  => trailingslashit( get_stylesheet_directory() ) . $template_dir,
 			10 => trailingslashit( get_template_directory() ) . $template_dir,
-		);
+		) );
 
 		// sort the file paths based on priority
 		ksort( $file_paths, SORT_NUMERIC );


### PR DESCRIPTION
[HS#27798](https://secure.helpscout.net/conversation/1646375677/27798)

This PR adds the `gwaft_template_paths` filter to allow filtering the available template paths including the ability to add a new template path.

Customer is using a builder plugin with no active theme. Not even sure how that's possible but this filter should help. 😄