### PR TITLE
Added support for using the `:img` modifier with fields populated with URLs rather than attachment IDs as well.

### DIFF
--- a/gp-populate-anything/gppa-lmt-modifier-img.php
+++ b/gp-populate-anything/gppa-lmt-modifier-img.php
@@ -3,7 +3,7 @@
  * Gravity Perks // Populate Anything // Live Merge Tag Modifier: img
  * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
  *
- * Use the "img" modifier to output an image for any merge tag that returns an attachment ID.
+ * Use the "img" modifier to output an image, rather than the merge tag's default output.
  *
  * For example, here is a field configured to allow the user to select from a list of posts. The value of each choice is
  * the attachment ID of the featured image (e.g. "_thumbnail_id").
@@ -12,12 +12,29 @@
  *
  * In an HTML field on the same form, use the @{Field Label:1:value,img} to take the attachment ID (which is the value
  * of the choice) and output the image it references.
+ *
+ * This also works with any field that is populated with an image URL including comma-delimited lists of URLs. This is
+ * relevant when populating URLs into text inputs from a File Upload field.
  */
 add_filter( 'gppa_live_merge_tag_value', function( $value, $merge_tag, $form, $field_id, $entry_values ) {
-	$lmt = GP_Populate_Anything_Live_Merge_Tags::get_instance();
+
+	$lmt       = GP_Populate_Anything_Live_Merge_Tags::get_instance();
 	$modifiers = $lmt->extract_merge_tag_modifiers( $merge_tag );
-	if ( rgar( $modifiers, 'img' ) ) {
-		$value = wp_get_attachment_image( $value, 'thumbnail' );
+	if ( ! rgar( $modifiers, 'img' ) ) {
+		return $value;
 	}
+
+	// Check for Media Library attachment IDs.
+	if ( is_numeric( $value ) ) {
+		$value = wp_get_attachment_image( $value, 'thumbnail' );
+	} else {
+		$images = explode( ',', $value );
+		$values = array();
+		foreach ( $images as $image ) {
+			$values[] = sprintf( '<img src="%s" alt="" style="max-width:100%%;">', $image );
+		}
+		$value = implode( '', $values );
+	}
+
 	return $value;
 }, 10, 5 );

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -597,6 +597,13 @@ class GW_All_Fields_Template {
 
 		$template_dir = $this->get_theme_template_dir_name();
 
+		/**
+		 * Filter the paths that will be checked for a template file.
+		 *
+		 * @since 0.9.12
+		 *
+		 * @param array $file_paths An array of file paths. Key is the priority of the path. Value is an absolute path to a directory.
+		 */
 		$file_paths = apply_filters( 'gwaft_template_paths', array(
 			1  => trailingslashit( get_stylesheet_directory() ) . $template_dir,
 			10 => trailingslashit( get_template_directory() ) . $template_dir,

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -8,7 +8,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-all-fields-template/
  * Description:  Modify the {all_fields} merge tag output via a template file.
  * Author:       Gravity Wiz
- * Version:      0.9.11
+ * Version:      0.9.12
  * Author URI:   http://gravitywiz.com
  *
  * Usage:
@@ -597,10 +597,10 @@ class GW_All_Fields_Template {
 
 		$template_dir = $this->get_theme_template_dir_name();
 
-		$file_paths = array(
+		$file_paths = apply_filters( 'gwaft_template_paths', array(
 			1  => trailingslashit( get_stylesheet_directory() ) . $template_dir,
 			10 => trailingslashit( get_template_directory() ) . $template_dir,
-		);
+		) );
 
 		// sort the file paths based on priority
 		ksort( $file_paths, SORT_NUMERIC );


### PR DESCRIPTION
[HS#27799](https://secure.helpscout.net/conversation/1646377681/27799)

This PR updates GPPA's `:img` modifier snippet to support outputting raw URLs as images in addition to the existing functionality of outputting images for attachment ID values.

The field's value can be a single URL or a comma-delimited list of URLs. This is relevant when populating values from Single and Multi-file Upload fields into a text-based field (e.g. Single Line Text).