### PR TITLE
Added a new option `include_text_feeds` to parse merge tags in text feeds such as Gravity Forms Webhooks plugin.

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -13,7 +13,7 @@
  * Plugin URI:   https://gravitywiz.com/customizing-multi-file-merge-tag/
  * Description:  Enhance the merge tag for multi-file upload fields by adding support for outputting markup that corresponds to the uploaded file.
  * Author:       Gravity Wiz
- * Version:      1.7.1
+ * Version:      1.7.2
  * Author URI:   https://gravitywiz.com
  */
 class GW_Multi_File_Merge_Tag {


### PR DESCRIPTION
This PR adds a new option (`include_text_feeds`) to the `gw-multi-file-merge-tag.php` snippet that processes merge tags in text feeds.

By default, the snippet only parses merge tags when the format specified in the `gform_pre_replace_merge_tags` filter is `html`. This causes an issue with [Gravity Forms Webhooks](https://www.gravityforms.com/add-ons/webhooks/) plugin where multi file merge tags returns the empty string for the feed.

Ticket: [#27675](https://secure.helpscout.net/conversation/1640548947/27675/)