### PR TITLE
Fixed an issue where uploaded files were not attached to parent notification in `gp-nested-forms-auto-attach-child-files`.

### DIFF
--- a/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
+++ b/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
@@ -5,19 +5,18 @@
  */
 add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 
-	if( ! class_exists( 'GPNF_Entry' ) ) {
+	if ( ! class_exists( 'GPNF_Entry' ) ) {
 		return $notification;
 	}
 
 	$upload_fields = GFCommon::get_fields_by_type( $form, array( 'fileupload' ) );
 
 	// If parent form has upload fields, rely on the notification's Attachments setting.
-	if( ! empty( $upload_fields ) ) {
+	if ( ! empty( $upload_fields ) ) {
 		if ( ! rgar( $notification, 'enableAttachments', false ) ) {
 			return $notification;
 		}
-	}
-	// Otherwise, rely on a manually defined array of notification IDs.
+	} // Otherwise, rely on a manually defined array of notification IDs.
 	else {
 		$notification_ids = array( '5daaedb49dc32', '5dbce25cc21c2' );
 		if ( ! in_array( $notification['id'], $notification_ids ) ) {
@@ -25,12 +24,12 @@ add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 		}
 	}
 
-	$attachments =& $notification['attachments'];
+	$attachments  =& $notification['attachments'];
 	$parent_entry = new GPNF_Entry( $entry );
 
-	foreach( $form['fields'] as $field ) {
+	foreach ( $form['fields'] as $field ) {
 
-		if( $field->get_input_type() !== 'form' ) {
+		if ( $field->get_input_type() !== 'form' ) {
 			continue;
 		}
 
@@ -38,7 +37,7 @@ add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 		$upload_fields = GFCommon::get_fields_by_type( GFAPI::get_form( $field->gpnfForm ), array( 'fileupload' ) );
 		$child_entries = $parent_entry->get_child_entries( $field->id );
 
-		foreach( $child_entries as $child_entry ) {
+		foreach ( $child_entries as $child_entry ) {
 			foreach ( $upload_fields as $upload_field ) {
 
 				$attachment_urls = rgar( $child_entry, $upload_field->id );

--- a/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
+++ b/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
@@ -16,12 +16,6 @@ add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 		if ( ! rgar( $notification, 'enableAttachments', false ) ) {
 			return $notification;
 		}
-	} // Otherwise, rely on a manually defined array of notification IDs.
-	else {
-		$notification_ids = array( '5daaedb49dc32', '5dbce25cc21c2' );
-		if ( ! in_array( $notification['id'], $notification_ids ) ) {
-			return $notification;
-		}
 	}
 
 	$attachments  =& $notification['attachments'];

--- a/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
+++ b/gp-nested-forms/gp-nested-forms-auto-attach-child-files.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Auto-attach Uploaded Files from Child to Parent Notifications
+ * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ */
+add_filter( 'gform_notification', function( $notification, $form, $entry ) {
+
+	if( ! class_exists( 'GPNF_Entry' ) ) {
+		return $notification;
+	}
+
+	$upload_fields = GFCommon::get_fields_by_type( $form, array( 'fileupload' ) );
+
+	// If parent form has upload fields, rely on the notification's Attachments setting.
+	if( ! empty( $upload_fields ) ) {
+		if ( ! rgar( $notification, 'enableAttachments', false ) ) {
+			return $notification;
+		}
+	}
+	// Otherwise, rely on a manually defined array of notification IDs.
+	else {
+		$notification_ids = array( '5daaedb49dc32', '5dbce25cc21c2' );
+		if ( ! in_array( $notification['id'], $notification_ids ) ) {
+			return $notification;
+		}
+	}
+
+	$attachments =& $notification['attachments'];
+	$parent_entry = new GPNF_Entry( $entry );
+
+	foreach( $form['fields'] as $field ) {
+
+		if( $field->get_input_type() !== 'form' ) {
+			continue;
+		}
+
+		$upload_root   = GFFormsModel::get_upload_root();
+		$upload_fields = GFCommon::get_fields_by_type( GFAPI::get_form( $field->gpnfForm ), array( 'fileupload' ) );
+		$child_entries = $parent_entry->get_child_entries( $field->id );
+
+		foreach( $child_entries as $child_entry ) {
+			foreach ( $upload_fields as $upload_field ) {
+
+				$attachment_urls = rgar( $child_entry, $upload_field->id );
+				if ( empty( $attachment_urls ) ) {
+					continue;
+				}
+
+				$attachment_urls = $upload_field->multipleFiles ? json_decode( $attachment_urls, true ) : array( $attachment_urls );
+
+				foreach ( $attachment_urls as $attachment_url ) {
+					$attachment_url = preg_replace( '|^(.*?)/gravity_forms/|', $upload_root, $attachment_url );
+					$attachments[]  = $attachment_url;
+				}
+
+			}
+		}
+
+	}
+
+	return $notification;
+}, 10, 3 );


### PR DESCRIPTION
This PR migrates the `gp-nested-forms-auto-attach-child-files` snippet to the library.

It also fixes a configuration issue where uploaded files were not attached to the parent form due to a notification ID check. By removing this check, once the snippet is enabled, any form that contains a child form will have uploaded files attached when this snippet is enabled.

Source: https://gist.github.com/spivurno/89efb788d3dc54a35ac001ad13322a74
Ticket: [#27868[(https://secure.helpscout.net/conversation/1647973886/27868?folderId=3808239)