### PR TITLE
Fixed an issue in the new feature introduced in 1.7.2 where global formats setting could overwrite form specific settings.

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -13,7 +13,7 @@
  * Plugin URI:   https://gravitywiz.com/customizing-multi-file-merge-tag/
  * Description:  Enhance the merge tag for multi-file upload fields by adding support for outputting markup that corresponds to the uploaded file.
  * Author:       Gravity Wiz
- * Version:      1.7.2
+ * Version:      1.7.3
  * Author URI:   https://gravitywiz.com
  */
 class GW_Multi_File_Merge_Tag {


### PR DESCRIPTION
This PR fixes the way the new `formats` setting was being read and follows the `default_markup` settings format.

Tickets:
[#26765](https://secure.helpscout.net/conversation/1640548947/27675?folderId=3808239)
[#28170](https://secure.helpscout.net/conversation/1662946479/28170/)