### PR TITLE
Fixed a potential fatal crash if GPPA is disabled while using the `gppa-custom-database` snippet.

### DIFF
--- a/gp-populate-anything/gppa-custom-database.php
+++ b/gp-populate-anything/gppa-custom-database.php
@@ -30,5 +30,7 @@ class GPPA_Object_Type_Database_Testing extends GPPA_Object_Type_Database {
 }
 
 add_action('init', function() {
-	gp_populate_anything()->register_object_type( 'database-testing', 'GPPA_Object_Type_Database_Testing' );
+	if ( class_exists( 'GP_Populate_Anything' ) ) {
+		gp_populate_anything()->register_object_type( 'database-testing', 'GPPA_Object_Type_Database_Testing' );
+	}
 });


### PR DESCRIPTION
PR fixes a fatal crash when GPPA is not present/active while using this snippet.

Ticket: [#28260](https://secure.helpscout.net/conversation/1668026202/28260?folderId=3808239)