### PR TITLE
Added support for filtering times based on a Date field.

### DIFF
--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -30,7 +30,6 @@ class GW_Time_Sensitive_Choices {
 		$this->_args = wp_parse_args( $args, array(
 			'form_id'       => false,
 			'field_id'      => false,
-			'time_mod'      => false,
 			'date_field_id' => false,
 			'buffer'        => 0,
 		) );

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -184,17 +184,20 @@ class GW_Time_Sensitive_Choices {
 
 					self.getCurrentServerTime = function() {
 						var date = new Date();
-						return self.convertTimezone( date, self.serverTimezone );
+						return self.convertTimezone( date );
 					}
 
-					/**
-					 * @see https://stackoverflow.com/a/338439/227711
-					 * @param date
-					 * @param tzString
-					 * @returns {Date}
-					 */
-					self.convertTimezone = function( date, tzString ) {
-						return new Date( ( typeof date === 'string' ? new Date( date ) : date ).toLocaleString( 'en-US', { timeZone: tzString } ) );
+					self.convertTimezone = function( date ) {
+						if ( $.isNumeric( self.serverTimezone ) ) {
+							// Get the difference between the WP timezone and the user's local time in minutes.
+							var localDiff = date.getTimezoneOffset() + ( self.serverTimezone * 60 );
+							if ( localDiff ) {
+								date.setMinutes( localDiff );
+							}
+						} else {
+							date = new Date( ( typeof date === 'string' ? new Date( date ) : date ).toLocaleString( 'en-US', { timeZone: self.serverTimezone } ) );
+						}
+						return date;
 					}
 
 					self.init();
@@ -218,7 +221,7 @@ class GW_Time_Sensitive_Choices {
 			'formId'         => $this->_args['form_id'],
 			'fieldId'        => $this->_args['field_id'],
 			'dateFieldId'    => $this->_args['date_field_id'],
-			'serverTimezone' => get_option( 'timezone_string' ),
+			'serverTimezone' => get_option( 'timezone_string' ) ?: get_option( 'gmt_offset' ),
 			'buffer'         => $this->_args['buffer'],
 		);
 

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -113,7 +113,11 @@ class GW_Time_Sensitive_Choices {
 									isDisabled = true;
 									break;
 								default:
-									isDisabled = self.getChoiceTime( this.value ) < currentTime;
+									isDisabled = this.value && self.getChoiceTime( this.value ) < currentTime;
+							}
+							// This addresses placeholders specifically... not sure what other exceptions we'll need to make.
+							if ( this.value == '' ) {
+								isDisabled = false;
 							}
 							$( this ).prop( 'disabled', isDisabled );
 						} );

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -78,6 +78,8 @@ class GW_Time_Sensitive_Choices {
 
 						self.$target = $( '#input_{0}_{1}'.format( self.formId, self.fieldId ) );
 
+						self.bindEvents();
+
 						self.evaluateChoices();
 
 						if ( self.dateFieldId ) {
@@ -98,6 +100,15 @@ class GW_Time_Sensitive_Choices {
 						}
 
 					};
+
+					self.bindEvents = function() {
+						gform.addAction( 'gpi_field_refreshed', function( $targetField, $triggerField, initialLoad ) {
+							if ( gf_get_input_id_by_html_id( self.$target.attr( 'id' ) ) == gf_get_input_id_by_html_id( $targetField.attr( 'id' ) ) ) {
+								self.$target = $targetField;
+								self.evaluateChoices();
+							}
+						} );
+					}
 
 					self.evaluateChoices = function( mode ) {
 

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -79,8 +79,7 @@ class GW_Time_Sensitive_Choices {
 						self.$target = $( '#input_{0}_{1}'.format( self.formId, self.fieldId ) );
 
 						self.bindEvents();
-
-						self.evaluateChoices();
+						self.initializeChoices();
 
 						if ( self.dateFieldId ) {
 							self.$date = $( '#input_{0}_{1}'.format( self.formId, self.dateFieldId ) );
@@ -105,7 +104,7 @@ class GW_Time_Sensitive_Choices {
 						gform.addAction( 'gpi_field_refreshed', function( $targetField, $triggerField, initialLoad ) {
 							if ( gf_get_input_id_by_html_id( self.$target.attr( 'id' ) ) == gf_get_input_id_by_html_id( $targetField.attr( 'id' ) ) ) {
 								self.$target = $targetField;
-								self.evaluateChoices();
+								self.initializeChoices();
 							}
 						} );
 					}
@@ -130,6 +129,11 @@ class GW_Time_Sensitive_Choices {
 							if ( this.value == '' ) {
 								isDisabled = false;
 							}
+							// If choice was loaded from PHP disabled, always honor that. For example, GPI will load the
+							// choice as disabled if its inventory is exhausted.
+							if ( $( this ).data( 'gwtsc-disabled' ) ) {
+								isDisabled = true;
+							}
 							$( this ).prop( 'disabled', isDisabled );
 						} );
 
@@ -141,6 +145,15 @@ class GW_Time_Sensitive_Choices {
 
 					self.disableChoices = function() {
 						self.evaluateChoices( 'disable' );
+					}
+
+					self.initializeChoices = function() {
+						self.$target.find( 'option' ).each( function() {
+							if ( $( this ).prop( 'disabled' ) ) {
+								$( this ).data( 'gwtsc-disabled', true );
+							}
+						} );
+						self.evaluateChoices();
 					}
 
 					self.getChoiceTime = function( choiceTime ) {

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -163,8 +163,26 @@ class GW_Time_Sensitive_Choices {
 
 					self.getChoiceTime = function( choiceTime ) {
 						var date = self.parseTime( choiceTime );
+						// Ensure that times are always checked for the selected date. Without this, times will be based
+						// on the user's current date. This is only relevant when the user is in a different timezone
+						// than the server.
+						if ( self.dateFieldId ) {
+							var selectedDate = self.getSelectedDate();
+							if ( selectedDate ) {
+								var isMidnight = date.getDate() === selectedDate.getDate() + 1 && date.getHours() === 0;
+								// We're making an assumption here that if people will want midnight to be a future time
+								// and not midnight from the morning of the current date.
+								if ( ! isMidnight ) {
+									date.setDate( selectedDate.getDate() );
+								}
+							}
+						}
 						date.setMinutes( date.getMinutes() - self.buffer );
 						return date;
+					}
+
+					self.getSelectedDate = function() {
+						return self.$date.datepicker( 'getDate' );
 					}
 
 					/**


### PR DESCRIPTION
[HS#28731](https://secure.helpscout.net/conversation/1689485544/28731)

With the growing popularity of GP Inventory, more users were requesting the ability to filter a "time slot" field such that times before the current time were not available _but_ only if the selected date was the current date.

This PR majorly refactors our existing Time Sensitive Choices snippet to achieve this goal.