### PR TITLE
Added `gpepee_edit_entry_id` filter to allow modifying the entry ID used to target the entry to be edited.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -109,9 +109,14 @@ class GPEP_Edit_Entry {
 		}
 
 		$has_token           = ! empty( rgget( 'ep_token' ) );
-		$no_token_diff_forms = ! $has_token && (int) $target_form_id !== (int) $source_form_id;
+		$get_id_from_session = ! $has_token;
 
-		if ( ! $update_entry_id && ( $has_token || $no_token_diff_forms ) ) {
+		$allows_same_form_passthrough = ! gf_apply_filters( array( 'gpep_disable_same_form_passthrough', $target_form_id ), false );
+		if ( ! $allows_same_form_passthrough && (int) $target_form_id === (int) $source_form_id ) {
+			$get_id_from_session = false;
+		}
+
+		if ( ! $update_entry_id && $get_id_from_session ) {
 			$update_entry_id = isset( $session[ gp_easy_passthrough()->get_slug() . '_' . $source_form_id ] ) ? $session[ gp_easy_passthrough()->get_slug() . '_' . $source_form_id ] : false;
 		}
 


### PR DESCRIPTION
[HS#29155](https://secure.helpscout.net/conversation/1703886460/29155)

User wanted to conditionally edit the entry. This filter will allow him to do this with the following sample code:

```
add_filter( 'gpepee_edit_entry_id_123', function( $update_entry_id, $form_id ) {
	// Update "4" to the field ID you want to check the value of.
	if ( rgpost( 'input_1' ) === 'Add New' ) {
		$update_entry_id = false;
	}
	return $update_entry_id;
}, 10, 2 );
```

One sneaky but significant change I made in this PR (unrelated to the filter) is changing from which form the edit entry ID is fetched when fetching from the session. For some reason, it was setup to pull from the target form's session rather than the source form's session.

This doesn't make sense as the entire point of the snippet is to edit the same entry that has been populated into the form. I suspect most users are using the token or logged-in user's last entry option which were functioning correctly.