### PR TITLE
Added .jpeg extension to multi-file-merge default config

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -52,7 +52,7 @@ class GW_Multi_File_Merge_Tag {
 			'formats'            => array( 'html' ),
 			'markup'         => array(
 				array(
-					'file_types' => array( 'jpg', 'png', 'gif' ),
+					'file_types' => array( 'jpg', 'jpeg', 'png', 'gif' ),
 					'markup'     => '<img src="{url}" width="33%" />',
 				),
 				array(

--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -13,7 +13,7 @@
  * Plugin URI:   https://gravitywiz.com/customizing-multi-file-merge-tag/
  * Description:  Enhance the merge tag for multi-file upload fields by adding support for outputting markup that corresponds to the uploaded file.
  * Author:       Gravity Wiz
- * Version:      1.7.4
+ * Version:      1.7.5
  * Author URI:   https://gravitywiz.com
  */
 class GW_Multi_File_Merge_Tag {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1715878813/29602?folderId=5969086

💬 Slack: https://gravitywiz.slack.com/archives/G013UJV42D9/p1638560412001200

## Summary

The default config for the multi-form-merge snippet doesn't explicitly handle the .jpeg extension, which is a distinction from .jpg.