### PR TITLE
Fixed the URL to load the spinner animation from

### DIFF
--- a/gravity-forms/gw-validate-that-a-value-exists.php
+++ b/gravity-forms/gw-validate-that-a-value-exists.php
@@ -253,7 +253,7 @@ class GW_Value_Exists_Validation {
 
 					self.spinner = function( elem, imageSrc, inlineStyles ) {
 
-						imageSrc     = typeof imageSrc == 'undefined' || ! imageSrc ? self.gfBaseUrl + '/images/spinner.gif': imageSrc;
+						imageSrc     = typeof imageSrc == 'undefined' || ! imageSrc ? window.gf_global.spinnerUrl : imageSrc;
 						inlineStyles = typeof inlineStyles != 'undefined' ? inlineStyles : '';
 
 						this.elem = elem;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1736245847/30206?folderId=5969086

## Summary

This fixes (and future-proofs) the URL to load the spinner from for gravity-forms/gw-validate-that-a-value-exists.php