### PR TITLE
Added gpi_remove_choices fitler

### DIFF
--- a/gp-inventory/gpi-waiting-list.php
+++ b/gp-inventory/gpi-waiting-list.php
@@ -7,6 +7,7 @@
  * The choice will be selectable and submittable.
  */
 add_filter( 'gpi_disable_choices', '__return_false' );
+add_filter( 'gpi_remove_choices', '__return_false' );
 
 add_filter( 'gpi_pre_render_choice', function( $choice, $exceeded_limit, $field, $form, $count ) {
 


### PR DESCRIPTION
Although the exhausted choices were selectable, they were not submittable.  The additional gpi_remove_choices filter will ensure that the choices are not removed which will ensure that the validation is bypassed when the form is submitted. 
