### PR TITLE
Added support for wildcard scope (*).

### DIFF
--- a/gp-inventory/gpi-inventory-shortcode.php
+++ b/gp-inventory/gpi-inventory-shortcode.php
@@ -42,35 +42,50 @@ function gpi_inventory_shortcode( $output, $atts, $content ) {
 	 *
 	 * {scope}: {count}
 	 *
-	 * NOTE: This only works with non-choice-based inventories with a single scope. Will continue exploring this in the
-	 * future.
+	 * NOTE: This only works with inventories with a single scope. Will continue exploring this in the future.
 	 */
 	if ( $atts['scope_values'] && $atts['scope_values'] === '*' ) {
 		global $wpdb;
 
 		$resource_field_id = reset( $field->gpiResourcePropertyMap );
-		$sql               = $wpdb->prepare( "SELECT DISTINCT meta_value FROM {$wpdb->prefix}gf_entry_meta WHERE form_id = %d AND meta_key = %d", $form['id'], $resource_field_id );
+		$sql               = gf_apply_filters( array( 'gpis_scopes_sql', $form['id'], $resource_field_id ), $wpdb->prepare( "SELECT DISTINCT meta_value FROM {$wpdb->prefix}gf_entry_meta WHERE form_id = %d AND meta_key = %d", $form['id'], $resource_field_id ), $form, $field, $resource_field_id );
 		$items             = $wpdb->get_results( $sql );
 
 		if ( empty( $items ) ) {
 			return $content;
 		}
 
-		$output = array();
+		$output          = array();
+		$is_choice_field = ! empty( $field->choices );
 
 		if ( ! $content ) {
-			$content = '{scope}: {count}';
+			if ( $is_choice_field ) {
+				$content = '{label}: {count}';
+			} else {
+				$content = '{scope}: {count}';
+			}
 		}
 
 		foreach ( $items as $item ) {
+
 			$atts['scope_values'] = $item->meta_value;
 			$scope_display_value  = gf_apply_filters( array( 'gpis_scope_display_value', $form['id'], $resource_field_id ), $item->meta_value, $field, $resource_field_id, $atts );
-			$output[]             = str_replace( '{scope}', $scope_display_value, gpi_inventory_shortcode( null, $atts, $content ) );
+
+			$item_output = '';
+			if ( $is_choice_field ) {
+				$item_output = $scope_display_value;
+			}
+
+			$item_output .= str_replace( '{scope}', $scope_display_value, gpi_inventory_shortcode( null, $atts, $content ) );
+			$output[]     = $item_output;
+
 		}
 
+		$label = $field->get_field_label( false, '' );
+
 		$output = sprintf(
-			'<ul class="gpi-inventory-list gpi-inventory-list-%d-%d"><li>%s</li></ul>',
-			$form['id'], $field->id, implode( '</li><li>', $output )
+			'<strong>%s</strong><ul class="gpi-inventory-list gpi-inventory-list-%d-%d"><li>%s</li></ul>',
+			$label, $form['id'], $field->id, implode( '</li><li>', $output )
 		);
 
 		return $output;
@@ -161,7 +176,7 @@ function gpi_inventory_shortcode( $output, $atts, $content ) {
 			 */
 			remove_filter( 'gpi_query', array( gp_inventory_type_advanced(), 'resource_and_properties' ), 9 );
 			$count_current_field = gp_inventory_type_simple()->get_claimed_inventory( $field );
-			add_filter( 'gpi_query', array( gp_inventory_type_advanced(), 'resource_and_properties' ), 9 );
+			add_filter( 'gpi_query', array( gp_inventory_type_advanced(), 'resource_and_properties' ), 9, 2 );
 		} else {
 			$available           = gp_inventory_type_simple()->get_available_stock( $field );
 			$limit               = gp_inventory_type_simple()->get_stock_quantity( $field );

--- a/gp-inventory/gpi-inventory-shortcode.php
+++ b/gp-inventory/gpi-inventory-shortcode.php
@@ -16,13 +16,14 @@
  * @todo
  * - Add support for excluding field parameter and showing a consolidated list of all inventories.
  */
-add_filter( 'gform_shortcode_inventory', function ( $output, $atts, $content ) {
+add_filter( 'gform_shortcode_inventory', 'gpi_inventory_shortcode', 10, 3 );
+function gpi_inventory_shortcode( $output, $atts, $content ) {
 
 	$atts = shortcode_atts( array(
 		'id'           => false,
 		'field'        => false,
 		'scope_values' => false,
-	), $atts );
+	), $atts, 'gpi_inventory' );
 
 	if ( empty( $atts['id'] ) || empty( $atts['field'] ) ) {
 		return $content;
@@ -33,6 +34,46 @@ add_filter( 'gform_shortcode_inventory', function ( $output, $atts, $content ) {
 
 	if ( ! $field ) {
 		return $content;
+	}
+
+	/**
+	 * Some scopes have infinite values (i.e. Date fields). Use the * scope value to look up submitted scope values and
+	 * display the content template for each. Default template when using the * scope is:
+	 *
+	 * {scope}: {count}
+	 *
+	 * NOTE: This only works with non-choice-based inventories with a single scope. Will continue exploring this in the
+	 * future.
+	 */
+	if ( $atts['scope_values'] && $atts['scope_values'] === '*' ) {
+		global $wpdb;
+
+		$resource_field_id = reset( $field->gpiResourcePropertyMap );
+		$sql               = $wpdb->prepare( "SELECT DISTINCT meta_value FROM {$wpdb->prefix}gf_entry_meta WHERE form_id = %d AND meta_key = %d", $form['id'], $resource_field_id );
+		$items             = $wpdb->get_results( $sql );
+
+		if ( empty( $items ) ) {
+			return $content;
+		}
+
+		$output = array();
+
+		if ( ! $content ) {
+			$content = '{scope}: {count}';
+		}
+
+		foreach ( $items as $item ) {
+			$atts['scope_values'] = $item->meta_value;
+			$scope_display_value  = gf_apply_filters( array( 'gpis_scope_display_value', $form['id'], $resource_field_id ), $item->meta_value, $field, $resource_field_id, $atts );
+			$output[]             = str_replace( '{scope}', $scope_display_value, gpi_inventory_shortcode( null, $atts, $content ) );
+		}
+
+		$output = sprintf(
+			'<ul class="gpi-inventory-list gpi-inventory-list-%d-%d"><li>%s</li></ul>',
+			$form['id'], $field->id, implode( '</li><li>', $output )
+		);
+
+		return $output;
 	}
 
 	/**
@@ -84,7 +125,7 @@ add_filter( 'gform_shortcode_inventory', function ( $output, $atts, $content ) {
 
 				$limit     = (int) $choice['inventory_limit'];
 				$count     = (int) rgar( $counts, $choice['value'] );
-				$available = (int) $limit - $count;
+				$available = $limit - $count;
 
 				$items[] = gpis_get_item_markup( $content, array(
 					'limit'     => $limit,
@@ -147,7 +188,7 @@ add_filter( 'gform_shortcode_inventory', function ( $output, $atts, $content ) {
 	remove_filter( 'gpi_property_map_values_' . $form['id'] . '_' . $field->id, $map_property_values );
 
 	return $output;
-}, 10, 3 );
+}
 
 function gpis_get_item_markup( $template, $args ) {
 

--- a/gp-inventory/gpi-inventory-shortcode.php
+++ b/gp-inventory/gpi-inventory-shortcode.php
@@ -19,6 +19,10 @@
 add_filter( 'gform_shortcode_inventory', 'gpi_inventory_shortcode', 10, 3 );
 function gpi_inventory_shortcode( $output, $atts, $content ) {
 
+	if ( ! is_callable( 'gp_inventory' ) ) {
+		return $output;
+	}
+
 	$atts = shortcode_atts( array(
 		'id'           => false,
 		'field'        => false,

--- a/gp-inventory/gpi-inventory-shortcode.php
+++ b/gp-inventory/gpi-inventory-shortcode.php
@@ -84,8 +84,8 @@ function gpi_inventory_shortcode( $output, $atts, $content ) {
 		$label = $field->get_field_label( false, '' );
 
 		$output = sprintf(
-			'<strong>%s</strong><ul class="gpi-inventory-list gpi-inventory-list-%d-%d"><li>%s</li></ul>',
-			$label, $form['id'], $field->id, implode( '</li><li>', $output )
+			'<ul class="gpi-inventory-list gpi-inventory-list-%d-%d"><li>%s</li></ul>',
+			$form['id'], $field->id, implode( '</li><li>', $output )
 		);
 
 		return $output;


### PR DESCRIPTION
[HS#31028](https://secure.helpscout.net/conversation/1769445143/31028)

Customer is using a Date field scope on a Single Product field. I've added exploratory support for displaying all dates that have consumed inventory. 

**Editor**

![CleanShot 2022-02-04 at 15 46 39](https://user-images.githubusercontent.com/550549/152600810-0aa52513-8823-451a-ac0c-cc2288e3b5e1.png)

**Frontend**

![CleanShot 2022-02-04 at 15 46 54](https://user-images.githubusercontent.com/550549/152600836-6da957a5-2c3e-4974-a5e5-e9aaa3a3ea92.png)

This PR also includes a filter for modifying the scope's display value so that values can be easily formatted by need.

```php
add_filter( 'gpis_scope_display_value_848_2', function( $display_value ) {
	return date( 'M j, y', strtotime( $display_value ) );
} );
```

**Frontend**

![CleanShot 2022-02-04 at 15 49 03](https://user-images.githubusercontent.com/550549/152601069-f48e42de-8d72-442b-9565-8c16c4b02b3c.png)

## Updated

Added support for choice-based inventories.

**Editor**
![CleanShot 2022-02-16 at 14 22 09](https://user-images.githubusercontent.com/550549/154340033-34722024-d87b-4d63-ba4a-3116f537c236.png)

**Frontend**
![gpi-inventory-shortcode-choice-support](https://user-images.githubusercontent.com/550549/154340064-b431c367-3de9-48cd-b55e-56a050df24f8.png)

**Form Exports**
1. Single Product, Single Scope: https://gwiz.io/34Zfpfa
2. Choice Product, Single Scope: https://gwiz.io/3gQOR2p