### PR TITLE
GW Time Sensitive Choices: Added new `remove_choices` setting to remove past choices instead of disabling them

### DIFF
--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -28,11 +28,12 @@ class GW_Time_Sensitive_Choices {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
-			'form_id'        => false,
-			'field_id'       => false,
-			'date_field_id'  => false,
-			'remove_choices' => false,
-			'buffer'         => 0,
+			'form_id'                  => false,
+			'field_id'                 => false,
+			'date_field_id'            => false,
+			'buffer'                   => 0,
+			'remove_choices'           => false,
+			'no_times_available_label' => '&ndash; No times available &ndash;', // Only used if remove_choices is set to true
 		) );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -157,7 +158,7 @@ class GW_Time_Sensitive_Choices {
 						} );
 
 						if ( self.$target.find( 'option:not([hidden])' ).length === 0 ) {
-							self.$target.append( '<option value="" disabled selected class="gwtsc-no-times-available">&ndash; No times available &ndash;</option>' );
+							self.$target.append( '<option value="" disabled selected class="gwtsc-no-times-available"><?php echo $this->_args['no_times_available_label']; ?></option>' );
 						} else {
 							self.$target.find( '.gwtsc-no-times-available' ).remove();
 						}
@@ -261,7 +262,7 @@ class GW_Time_Sensitive_Choices {
 			'dateFieldId'    => $this->_args['date_field_id'],
 			'serverTimezone' => get_option( 'timezone_string' ) ?: get_option( 'gmt_offset' ),
 			'buffer'         => $this->_args['buffer'],
-            'removeChoices'  => $this->_args['remove_choices'],
+			'removeChoices'  => $this->_args['remove_choices'],
 		);
 
 		$script = 'new GWTimeSensitiveChoices( ' . json_encode( $args ) . ' );';

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -28,10 +28,11 @@ class GW_Time_Sensitive_Choices {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
-			'form_id'       => false,
-			'field_id'      => false,
-			'date_field_id' => false,
-			'buffer'        => 0,
+			'form_id'        => false,
+			'field_id'       => false,
+			'date_field_id'  => false,
+			'remove_choices' => false,
+			'buffer'         => 0,
 		) );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -148,8 +149,21 @@ class GW_Time_Sensitive_Choices {
 								isDisabled = true;
 							}
 							$( this ).prop( 'disabled', isDisabled );
+							$( this ).attr( 'hidden', false );
+
+							if ( self.removeChoices && isDisabled ) {
+								$( this ).attr( 'hidden', true );
+							}
 						} );
 
+						if ( self.$target.find( 'option:not([hidden])' ).length === 0 ) {
+							self.$target.append( '<option value="" disabled selected class="gwtsc-no-times-available">&ndash; No times available &ndash;</option>' );
+						} else {
+							self.$target.find( '.gwtsc-no-times-available' ).remove();
+						}
+
+						/* Force selection of first time available */
+						self.$target.val( self.$target.find( 'option:not([hidden])' ).first().val() );
 					}
 
 					self.initializeChoices = function() {
@@ -247,6 +261,7 @@ class GW_Time_Sensitive_Choices {
 			'dateFieldId'    => $this->_args['date_field_id'],
 			'serverTimezone' => get_option( 'timezone_string' ) ?: get_option( 'gmt_offset' ),
 			'buffer'         => $this->_args['buffer'],
+            'removeChoices'  => $this->_args['remove_choices'],
 		);
 
 		$script = 'new GWTimeSensitiveChoices( ' . json_encode( $args ) . ' );';
@@ -270,8 +285,9 @@ class GW_Time_Sensitive_Choices {
 }
 
 new GW_Time_Sensitive_Choices( array(
-	'form_id'       => 123,
-	'field_id'      => 4,
-	'date_field_id' => 5,
-	'buffer'        => 60,
+	'form_id'        => 123,
+	'field_id'       => 4,
+	'date_field_id'  => 5,
+	'buffer'         => 60,
+	'remove_choices' => false,
 ) );

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -19,7 +19,7 @@
  * Plugin URI:  https://gravitywiz.com
  * Description: Filter time-based choices based on the current time.
  * Author:      David Smith
- * Version:     1.2
+ * Version:     1.3
  * Author URI:  https://gravitywiz.com
  */
 class GW_Time_Sensitive_Choices {

--- a/gravity-forms/gw-time-sensitive-choices.php
+++ b/gravity-forms/gw-time-sensitive-choices.php
@@ -94,7 +94,7 @@ class GW_Time_Sensitive_Choices {
 
 						gform.addAction( 'gpi_field_refreshed', function( $targetField, $triggerField, initialLoad ) {
 							if ( gf_get_input_id_by_html_id( self.$target.attr( 'id' ) ) == gf_get_input_id_by_html_id( $targetField.attr( 'id' ) ) ) {
-								self.$target = $targetField;
+								self.$target = $targetField.find( '#input_{0}_{1}'.format( self.formId, self.fieldId ) );
 								self.initializeChoices();
 							}
 						} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1777997481/31297?folderId=1530128

## Summary

Add a setting to remove past choices instead of disabling them.

### Screenshots

_Without choices removed_

![CleanShot 2022-02-09 at 11 26 36](https://user-images.githubusercontent.com/375381/153256095-341f7ae7-ef9f-45c4-bd91-abda03be8d5e.png)

_Choices removed_

![CleanShot 2022-02-09 at 11 27 09](https://user-images.githubusercontent.com/375381/153256141-f97a3349-84c0-466c-b67d-09acfff56d34.png)
