### PR TITLE
Added support for both single column and multi-column lists.

### DIFF
--- a/experimental/gw-capture-list-field-column-as-comma-delimited-list.php
+++ b/experimental/gw-capture-list-field-column-as-comma-delimited-list.php
@@ -14,9 +14,15 @@ add_action( 'gform_pre_submission_123', function( $form ) {
 	$rows       = $list_field->create_list_array( $_POST["input_{$list_field_id}"] );
 	$values     = array();
 
-	foreach ( $rows as $row ) {
-		$row = array_values( $row );
-		$values[] = $row[ $column_number - 1 ];
+	if ( is_array($rows[0]) ) {
+		foreach ( $rows as $row ) {
+			$row = array_values( $row );
+			$values[] = $row[ $column_number -1 ];
+		}
+	} else {
+		foreach ( $rows as $row ) {
+			$values[] = $row;
+		}
 	}
 
 	$_POST[ "input_{$target_field_id}" ] = implode( ',', $values );


### PR DESCRIPTION
When I tested, this snippet only worked if _Enable multiple columns_ was activated on the List field.

In a single column list, Gravity Forms stores the values in an array, but Multi-column lists are stored in associative arrays.

Single column:

```
Array
(
    [0] => single column array
    [1] => second row single column array
)
```

Multi-column:

```
Array
(
    [0] => Array
        (
            [Column 1] => multi
            [Column 2] => column
            [Column 3] => array
        )

    [1] => Array
        (
            [Column 1] => second row multi
            [Column 2] => second row column
            [Column 3] => second row array
        )

)

```