### PR TITLE
Added checks to ensure that field exist before checking for input type

### DIFF
--- a/gravity-forms/gw-format-date-merge-tags.php
+++ b/gravity-forms/gw-format-date-merge-tags.php
@@ -21,10 +21,8 @@ add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $entry, $url
 		$input_id = $match[1];
 		$field    = GFFormsModel::get_field( $form, $input_id );
 
-		if ( $field ) {
-			if ( $field->get_input_type() !== 'date' ) {
-				continue;
-			}
+		if ( ! $field || $field->get_input_type() !== 'date' ) {
+			continue;
 		}
 
 		$i        = $match[0][0] === '{' ? 4 : 5;

--- a/gravity-forms/gw-format-date-merge-tags.php
+++ b/gravity-forms/gw-format-date-merge-tags.php
@@ -21,8 +21,10 @@ add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $entry, $url
 		$input_id = $match[1];
 		$field    = GFFormsModel::get_field( $form, $input_id );
 
-		if ( $field->get_input_type() !== 'date' ) {
-			continue;
+		if ( $field ) {
+			if ( $field->get_input_type() !== 'date' ) {
+				continue;
+			}
 		}
 
 		$i        = $match[0][0] === '{' ? 4 : 5;


### PR DESCRIPTION
[Ticket](https://secure.helpscout.net/conversation/1818729044/32606?folderId=14964#thread-5355725313)

The snippet causes a fatal error if $field is null. This PR fixes that issue by checking if $field exists before it checks for the input type.