### PR TITLE
Fixed errors generated when init scripts are included multiple times.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -4,18 +4,12 @@
  *
  * Bypass your website cache when loading a Gravity Forms form.
  *
- * @version 0.9
- * @author  David Smith <david@gravitywiz.com>
- * @license GPL-2.0+
- * @link    http://gravitywiz.com/
- *
  * Plugin Name: Gravity Forms Cache Buster
- * Plugin URI: http://gravitywiz.com/
+ * Plugin URI:  https://gravitywiz.com/
  * Description: Bypass your website cache when loading a Gravity Forms form.
- * Author: Gravity Wiz
- * Version: 0.8
- * Author URI: http://gravitywiz.com
- *
+ * Author:      Gravity Wiz
+ * Version:     0.11
+ * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
 
@@ -203,11 +197,15 @@ class GW_Cache_Buster {
 		 * Priority of this filter is set aggressively high to ensure it will take priority.
 		 */
 		add_filter( 'gform_init_scripts_footer', '__return_true', 987 );
+
 		$atts = json_decode( rgpost( 'atts' ), true );
+
 		// GF expects an associative array for field values. Parse them before passing it on.
 		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
+
 		// If `$_POST` is not an empty array GF 2.5 fails to select default values for checkbox fields. See HS#26188
 		$_POST = array();
+
 		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
 
 		die();


### PR DESCRIPTION
[HS#32379](https://secure.helpscout.net/conversation/1812782955/32379/)

Nested Forms wasn't playing nice with Cache Buster due to its init script being bound and called multiple times and the Nested Form field container not existing. The latter issue is addressed in this PR.

With the existing implementation, all init scripts were loaded and triggered in the footer on the initial page load and then were re-included and re-triggered in the AJAX request that fetches the form markup. I'm honestly surprised we haven't been running into more issues like this.

![image](https://user-images.githubusercontent.com/550549/159102738-0e9979eb-7faa-4fc3-a224-e9de9edf01ef.png)

My solution is to:

- allow the default init scripts to be output to the footer 
- suppress the default init script trigger (e.g. `gform_post_render`)
- suppress init scripts during the AJAX request so they are not re-included
- manually trigger init scripts (via `gform_post_render`) after we've included the fetched markup

An alternate approach would be to suppress both the init scripts and default init script trigger and allow both to be included/executed as part including the markup from the AJAX request in the page but there have been some ambiguous issues with this approach in the past. Nested Forms itself deliberately moved away from that flow and seems to be much more stable now.

My only lingering concern is that since the default init scripts are output to the footer on page load, they will be cached. This may be an issue for plugins like Populate Anything that output dynamic data. I couldn't recreate a specific issue though so let me know if you can.