### PR TITLE
~ Increased merge tag filter parameter number to 6

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -82,7 +82,7 @@ class GW_All_Fields_Template {
 	public function init() {
 
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_merge_tags' ), 9, 7 );
-		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 5 );
+		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 6 );
 
 	}
 
@@ -99,7 +99,7 @@ class GW_All_Fields_Template {
 	 * example: {all_fields:include[6]}
 	 * example: {all_fields:include[6],exclude[2,3]}
 	 */
-	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value ) {
+	public function all_fields_extra_options( $value, $merge_tag, $modifiers, $field, $raw_value, $format ) {
 
 		if ( ! is_a( $field, 'GF_Field' ) ) {
 			$field       = new GF_Field();


### PR DESCRIPTION
The [gform_merge_tag_filter](https://docs.gravityforms.com/gform_merge_tag_filter/) filter expects 6 parameters and according to [this user's comment](https://secure.helpscout.net/conversation/1833639630/33106/#thread-5401589427), they were experiencing a fatal error when the snippet is used together with Campaign Tracker plugin. 