### PR TITLE
List column titles alignment issue

### DIFF
--- a/gravity-forms/gw-set-list-field-rows-by-field-value.php
+++ b/gravity-forms/gw-set-list-field-rows-by-field-value.php
@@ -82,7 +82,8 @@ class GWAutoListFieldRows {
 						});
 
 						// Hide add/remove buttons
-						$("#field_{0}_{1} .gfield_list_icons".format( this.formId, this.listFieldId ) ).css( 'display', 'none' );
+						// Also align list column title
+						$("#field_{0}_{1}".format( this.formId, this.listFieldId ) ).find( '.gfield_header_item--icons, .gfield_list_icons' ).hide();
 
 					}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1862022699

## Summary

Fixed issue where list column titles are not aligned when +/- buttons are set to hidden.