### PR TITLE
Include CPT posts in Embed URL › Post/Page rule

### DIFF
--- a/gp-limit-submissions/gpls-include-cpt-in-embed-url-post-page-rule.php
+++ b/gp-limit-submissions/gpls-include-cpt-in-embed-url-post-page-rule.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Include Posts of a Custom Post Type in the Embed URL › Post/Page Rule
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ */
+add_filter( 'gpls_rule_get_post_args', function( $args ) {
+	// Change "my_custom_post_type" to the slug of your custom post type.
+	$args['post_type'][] = 'my_custom_post_type';
+	return $args;
+} );


### PR DESCRIPTION
Hook Documentation : https://gravitywiz.com/documentation/gpls_rule_get_post_args/#include-posts-of-a-custom-post-type-in-the-embed-url-post-page-rule
