### PR TITLE
Disable Passing Through Entries Without a Token

### DIFF
--- a/gp-easy-passthrough/gpep-disable-passing-through-entries-without-a-token.php
+++ b/gp-easy-passthrough/gpep-disable-passing-through-entries-without-a-token.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Gravity Perks // Easy Passthrough // Disable Passing Through Entries Without a Token
+ * https://gravitywiz.com/documentation/gravity-forms-easy-passthrough/
+ */
+add_filter( 'gpep_bypass_session_init', function() {
+	if ( ! rgget( 'ep_token' ) ) {
+		$session = gp_easy_passthrough()->session_manager();
+		$session->reset();
+	}
+} );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpep_bypass_session_init/#disable-passing-through-entries-without-a-token