### PR TITLE
Disable Same Form Passthrough Without a Token

### DIFF
--- a/gp-easy-passthrough/gpep-disable-same-form-passing-through-entries-without-a-token.php
+++ b/gp-easy-passthrough/gpep-disable-same-form-passing-through-entries-without-a-token.php
@@ -3,8 +3,8 @@
  * Gravity Perks // Easy Passthrough // Disable Same Form Passthrough Without a Token
  * https://gravitywiz.com/documentation/gravity-forms-easy-passthrough/
  *
- * This example will prevent GPEP from continuously passing through entries 
- * if the ep_token is not present in the URL and the source and target forms are the same.
+ * This example will prevent GPEP from continuously passing through entries if the `ep_token` is
+ * not present in the URL and the source and target forms are the same.
  */
 add_filter('gpep_disable_same_form_passthrough', function( $disable ) {
 	if ( ! rgget( 'ep_token' ) ) {


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpep_disable_same_form_passthrough/#disable-passing-through-entries-without-a-token