### PR TITLE
Disabling Passthrough With Query Parameter

### DIFF
--- a/gp-easy-passthrough/gpep-disable-passthrough-with-query-parameter.php
+++ b/gp-easy-passthrough/gpep-disable-passthrough-with-query-parameter.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Gravity Perks // Easy Passthrough // Disabling Passthrough With Query Parameter
+ * https://gravitywiz.com/documentation/gravity-forms-easy-passthrough/
+ */
+add_filter( 'gpep_field_values', function( $field_values, $form_id ) {
+	// If passthrough=0 is in the query parameters, return an empty array.
+	if ( '0' == rgget( 'passthrough' ) ) {
+		return array();
+	}
+	return $field_values;
+}, 10, 2 );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpep_field_values/#disabling-passthrough-with-query-parameter