### PR TITLE
Fixed issue where WPML's current language was not honored the first page load after switching languages.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -8,7 +8,7 @@
  * Plugin URI:  https://gravitywiz.com/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
- * Version:     0.12
+ * Version:     0.13
  * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
@@ -144,6 +144,10 @@ class GW_Cache_Buster {
 			}
 		}
 		$params = ( count( $params ) > 0 ) ? '&' . join( '&', $params ) : '';
+		if ( class_exists( 'Gravity_Forms_Multilingual' ) ) {
+			global $sitepress;
+			$lang = $sitepress->get_current_language();
+		}
 		?>
 		<script type="text/javascript">
 			( function ( $ ) {
@@ -151,7 +155,8 @@ class GW_Cache_Buster {
 				$.post( '<?php echo admin_url( 'admin-ajax.php' ); ?>?action=gfcb_get_form&form_id=<?php echo $form_id, $params; ?>', {
 					action: 'gfcb_get_form',
 					form_id: '<?php echo $form_id; ?>',
-					atts: '<?php echo json_encode( $attributes ); ?>'
+					atts: '<?php echo json_encode( $attributes ); ?>',
+					lang: '<?php echo $lang; ?>'
 				}, function( response ) {
 					$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
 					if( window['gformInitDatepicker'] ) {

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * Gravity Wiz // Gravity Forms // Cache Buster
+ * https://gravitywiz.com/cache-busting-with-gravity-forms/
  *
  * Bypass your website cache when loading a Gravity Forms form.
  *
  * Plugin Name: Gravity Forms Cache Buster
- * Plugin URI:  https://gravitywiz.com/
+ * Plugin URI:  https://gravitywiz.com/cache-busting-with-gravity-forms/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
  * Version:     0.13


### PR DESCRIPTION
[HS#36500](https://secure.helpscout.net/conversation/1942202155/36500/)

After switching languages via WPML, the current language was not honored when rendering the form via Cache Buster. 

WPML sets a cookie on the page load after switching languages but Cache Buster was triggering the AJAX request to fetch the form markup prior to that cookie being set. My solution was to simply pass the "lang" through as a parameter in the AJAX request which is automatically picked up by WPML allowing it to correctly identify the current language when the form is rendered via the Cache Buster AJAX request.