### PR TITLE
gp-pay-per-word fixes counting bug

### DIFF
--- a/gp-pay-per-word/gpppw-pay-per-character.js
+++ b/gp-pay-per-word/gpppw-pay-per-character.js
@@ -6,6 +6,5 @@
  */
 gform.addFilter( 'gpppw_word_count', function( wordCount, text, gwppw, ppwField, formId ) {
 	// Pay per character instead of words.
-	var words = text.split( '' );
-	return words == null ? 0 : words.length;
+	return [...text].length;
 } );

--- a/gp-pay-per-word/gpppw-pay-per-character.php
+++ b/gp-pay-per-word/gpppw-pay-per-character.php
@@ -7,6 +7,5 @@
  */
 add_filter( 'gpppw_word_count', function( $word_count, $words ) {
 	// Pay per character instead of words.
-	$words = str_split( trim( $words ) );
-	return count( $words );
+	return mb_strlen( trim( $words ) );
 }, 10, 2 );


### PR DESCRIPTION
The string splitting functions cannot handle non-ascii bytes like umlauts (äöü) or emojis and would generate more than one array element for them.
In result, this whole function would return a character count of 6 (or 5 in JS) for this String: `Hiö🍻`, which is only 4 long.

The solution would return 4 as length of the string above in both cases.

See this link for a Demo on the PHP-site: https://www.tehplayground.com/PdKHf9u7UNoYH6c5
And the JSFiddle for the js-site: https://jsfiddle.net/xjrqczh4/