### PR TITLE
Updated PHPCS GitHub Action to only run on blames in PRs rather than all files.

### DIFF
--- a/.github/workflows/php-lint-master.yml
+++ b/.github/workflows/php-lint-master.yml
@@ -1,6 +1,9 @@
 name: PHP Lint
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   PHPCS:
@@ -8,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress --no-suggest
+
       - name: PHPCS check
         uses: chekalsky/phpcs-action@v1
         with:

--- a/.github/workflows/php-lint-pr.yml
+++ b/.github/workflows/php-lint-pr.yml
@@ -1,0 +1,26 @@
+name: PHP Lint (PR)
+
+on: [pull_request]
+
+jobs:
+  PHPCS:
+    name: PHPCS (Files Changed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # The blame will not work without this
+
+      # PHP 8 will throw PHP Fatal error: Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given in ...
+      - uses: nanasess/setup-php@v3
+        with:
+          php-version: '7.4'
+
+      - name: Install dependencies
+        run: composer install --dev --prefer-dist --no-progress --no-suggest
+
+      - uses: thenabeel/action-phpcs@v8
+        with:
+          files: "**.php,**.js,**.css"
+          phpcs_path: ./vendor/bin/phpcs
+          standard: phpcs.xml


### PR DESCRIPTION
PHPCS was getting quite noisy in PRs since it was checking all files in the repository. This would cause PRs to fail checks even if everything in the PR was fine.

I decided to keep our existing action that checks all files and I set it to run on pushes to `master` that way we still have a global check.