### PR TITLE
Validate Minimum Limit Only When Field is Required

### DIFF
--- a/gp-limit-checkboxes/gplcb-validate-minimum-limit-when-required.php
+++ b/gp-limit-checkboxes/gplcb-validate-minimum-limit-when-required.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Gravity Perks // Limit Checkboxes // Validate Minimum Limit Only When Field is Required
+ * https://gravitywiz.com/documentation/gravity-forms-limit-checkboxes/
+ *
+ * Only validate minimum limit when field is required or
+ * when at least one checkbox has been checked.
+ */
+add_filter( 'gplcb_should_validate_minimum', function( $should_validate, $form, $field ) {
+	return $field->isRequired || gp_limit_checkboxes()->get_checkbox_count( $field->id, $form );
+}, 10, 3 );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gplcb_should_validate_minimum/#only-validate-minimum-limit-when-field-is-required-or-when-at-least-one-checkbox-has-been-checked