### PR TITLE
Update and rename gpld-automatically-show-linked-datepicker-for-linke…

### DIFF
--- a/gp-limit-dates/gpld-automatically-show-datepicker-for-linked-date-field-max.js
+++ b/gp-limit-dates/gpld-automatically-show-datepicker-for-linked-date-field-max.js
@@ -1,5 +1,5 @@
 /**
- * Gravity Perks // Limit Dates // Automatically Show Datepicker for Linked Date Field
+ * Gravity Perks // Limit Dates // Automatically Show Datepicker for Linked Date Field (Maximum Date)
  * https://gravitywiz.com/documentation/gravity-forms-limit-dates/
  *
  * When a date selected in Field A modifies the maximum date in Field B,


### PR DESCRIPTION
…d-date-field.js to gpld-automatically-show-datepicker-for-linked-date-field-max.js

There is another snippet with a similar name and functionality. Renamed the file to differentiate the two snippets. 

https://github.com/gravitywiz/snippet-library/pull/420
