### PR TITLE
Disable Submission From Last Page With Errors

### DIFF
--- a/gp-multi-page-navigation/gpmpn-disable-submission-from-last-page-with-errors.php
+++ b/gp-multi-page-navigation/gpmpn-disable-submission-from-last-page-with-errors.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Gravity Perks // Multi-Page Navigation // Disable Submission From Last Page With Errors
+ * https://gravitywiz.com/documentation/gravity-forms-multi-page-navigation/
+ */
+add_filter( 'gpmpn_enable_submission_from_last_page_with_errors', '__return_false' );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpmpn_enable_submission_from_last_page_with_errors/#examples
