### PR TITLE
Change the “Next Page with Errors” Button Label

### DIFF
--- a/gp-multi-page-navigation/gpmpn-change-the-next-page-with-errors-button-label.php
+++ b/gp-multi-page-navigation/gpmpn-change-the-next-page-with-errors-button-label.php
@@ -4,7 +4,7 @@
  * https://gravitywiz.com/documentation/gravity-forms-multi-page-navigation/
  */
 add_filter( 'gpmpn_frontend_labels', function( $labels ) {
-	// Change next page with errors button to be more verbose
+	// Change next page with errors button to be more verbose.
 	$labels['nextPageWithErrors'] = 'Skip to the next page with errors';
 	return $labels;
 } );

--- a/gp-multi-page-navigation/gpmpn-change-the-next-page-with-errors-button-label.php
+++ b/gp-multi-page-navigation/gpmpn-change-the-next-page-with-errors-button-label.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Gravity Perks // Multi-Page Navigation // Change the “Next Page with Errors” Button Label
+ * https://gravitywiz.com/documentation/gravity-forms-multi-page-navigation/
+ */
+add_filter( 'gpmpn_frontend_labels', function( $labels ) {
+	// Change next page with errors button to be more verbose
+	$labels['nextPageWithErrors'] = 'Skip to the next page with errors';
+	return $labels;
+} );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpmpn_frontend_labels/#examples