### PR TITLE
Disable Nested Form Field Dynamic Values

### DIFF
--- a/gp-nested-forms/gpnf-disable-nested-form-field-dynamic-values.php
+++ b/gp-nested-forms/gpnf-disable-nested-form-field-dynamic-values.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Disable Nested Form Field Dynamic Values
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * When existing child entries are populated into the nested form field of a different parent form,
+ * it will no longer be attached to the original parent entry when the new parent form is submitted.
+ * Use this snippet to attach the child entries to the new parent entry and also allow the
+ * child entries to remain attached to the original parent entry.
+ */
+add_filter( 'gpnf_should_use_static_value', '__return_true' );


### PR DESCRIPTION
Hook Documentation: https://gravitywiz.com/documentation/gpnf_should_use_static_value/#disable-nested-form-field-dynamic-values