### PR TITLE
Added Instructions

### DIFF
--- a/gp-copy-cat/gpcc-list-rows-as-new-lines.js
+++ b/gp-copy-cat/gpcc-list-rows-as-new-lines.js
@@ -8,8 +8,8 @@
  *
  * Instructions:
  * 
- * 1. Install this snippet with our free Custom JavaScript plugin.
- *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ * 1. Install this snippet with our free Code Chest plugin.
+ *    https://gravitywiz.com/gravity-forms-code-chest/
  */
 gform.addFilter( 'gpcc_copied_value', function( value, $targetElem, field, sourceValues ) {
 	// Update "3" to your Paragraph field ID.

--- a/gp-copy-cat/gpcc-list-rows-as-new-lines.js
+++ b/gp-copy-cat/gpcc-list-rows-as-new-lines.js
@@ -5,6 +5,11 @@
  * Use this snippet to copy List field rows as new lines into a Paragraph field.
  *
  * Screenshot: https://gwiz.io/3wWlUts
+ *
+ * Instructions:
+ * 
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-custom-javascript/
  */
 gform.addFilter( 'gpcc_copied_value', function( value, $targetElem, field, sourceValues ) {
 	// Update "3" to your Paragraph field ID.


### PR DESCRIPTION
We had a customer in the comment section who was getting an error message because they added the snippet as PHP instead of Javascript.

https://gravitywiz.com/gravity-wiz-weekly-155/comment-page-1/#comment-827773

Added the instruction on how to add the Javascript snippet to the form.