### PR TITLE
`gw-first-error-focus`: Fixed improper scrolling issue on multipage forms

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/gravity-forms/gw-first-error-focus.php
+++ b/gravity-forms/gw-first-error-focus.php
@@ -31,7 +31,13 @@ function gw_first_error_focus_script() {
 					// We need to reset our flag so that we can still do our focus action when the form conditional logic
 					// has been re-evaluated.
 					window['gwfef'] = false;
-					gwFirstErrorFocus();
+					var hasError = gwFirstErrorFocus().length;
+
+					if (!hasError) {
+						requestAnimationFrame(function() {
+							window.scrollTo(0, $('.gform_wrapper').offset().top);
+						});
+					}
 				});
 				$(document).on('gform_post_conditional_logic', function (event, formId, fields, isInit) {
 					if (!window['gwfef'] && fields === null && isInit === true) {
@@ -41,7 +47,7 @@ function gw_first_error_focus_script() {
 				});
 
 				function gwFirstErrorFocus() {
-					var $firstError = $('.gfield.gfield_error:first');
+					var $firstError = $('.gfield.gfield_error:visible:first');
 					if ($firstError.length > 0) {
 						// Without setTimeout or requestAnimationFrame, window.scroll/window.scrollTo are not taking
 						// effect on iOS and Android.
@@ -50,6 +56,8 @@ function gw_first_error_focus_script() {
 							$firstError.find('input, select, textarea').eq(0).focus();
 						});
 					}
+
+					return $firstError;
 				}
 			})(jQuery);
 		}


### PR DESCRIPTION
# Context

https://secure.helpscout.net/conversation/1963934628


# Summary

- Added `.editorconfig`
- Fixed issue with multi-page forms where validation error that is no longer active would be scroled to.
- Fixed issue where multi-page forms would not scroll to the top.

