### PR TITLE
Fixed issue in `gp-nested-forms/gpnf-triggered-population` where nested form entries were not removed when unselecting the configured checkbox

### DIFF
--- a/gp-nested-forms/gpnf-triggered-population.php
+++ b/gp-nested-forms/gpnf-triggered-population.php
@@ -81,7 +81,7 @@ class GPNF_Triggered_Population {
 							var value = input.val();
 							var checked = input[0].checked;
 
-							if ( checked && value === self.triggerFieldValue || ( value !== '' && self.triggerFieldValue === '_notempty_' ) ) {
+							if ( (checked && value === self.triggerFieldValue) || ( value !== '' && self.triggerFieldValue === '_notempty_' ) ) {
 								self.addChildEntry();
 							} else {
 								self.removeChildEntry();
@@ -164,7 +164,6 @@ class GPNF_Triggered_Population {
 
 		return empty( $this->_args['form_id'] ) || $form_id == $this->_args['form_id'];
 	}
-
 
 	public function ajax_add_child_entry() {
 

--- a/gp-nested-forms/gpnf-triggered-population.php
+++ b/gp-nested-forms/gpnf-triggered-population.php
@@ -77,8 +77,11 @@ class GPNF_Triggered_Population {
 						$form = $( '#gform_{0}'.format( self.formId ) );
 
 						$( '#field_{0}_{1}'.format( self.formId, self.triggerFieldId ) ).find( 'input' ).on( 'change', function() {
-							var value = $( this ).val();
-							if ( value === self.triggerFieldValue || ( value !== '' && self.triggerFieldValue === '_notempty_' ) ) {
+							var input = $( this );
+							var value = input.val();
+							var checked = input[0].checked;
+
+							if ( checked && value === self.triggerFieldValue || ( value !== '' && self.triggerFieldValue === '_notempty_' ) ) {
 								self.addChildEntry();
 							} else {
 								self.removeChildEntry();
@@ -98,6 +101,8 @@ class GPNF_Triggered_Population {
 
 						$.post( self.ajaxUrl, request, function( response ) {
 							if ( response.success ) {
+								// store the entry data for later for usage in the removeChildEntry method
+								window.gpnf_triggered_population_entry = response.data
 								GPNestedForms.loadEntry( response.data );
 							}
 						} );
@@ -105,7 +110,16 @@ class GPNF_Triggered_Population {
 					}
 
 					self.removeChildEntry = function() {
-						// @todo
+
+						var entryDataRowElem = $("tr[data-entryid='" + window.gpnf_triggered_population_entry.entryId + "']");
+						var item = Object.assign({}, window.gpnf_triggered_population_entry);
+						item.id = item.entryId;
+
+						GPNestedForms.deleteEntry(
+							item,
+							entryDataRowElem,
+						);
+
 					}
 
 					self.init();
@@ -149,6 +163,7 @@ class GPNF_Triggered_Population {
 
 		return empty( $this->_args['form_id'] ) || $form_id == $this->_args['form_id'];
 	}
+
 
 	public function ajax_add_child_entry() {
 
@@ -216,7 +231,6 @@ class GPNF_Triggered_Population {
 }
 
 # Configuration
-
 new GPNF_Triggered_Population( array(
 	'form_id'              => 123,
 	'trigger_field_id'     => 4,

--- a/gp-nested-forms/gpnf-triggered-population.php
+++ b/gp-nested-forms/gpnf-triggered-population.php
@@ -12,7 +12,7 @@
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-nested-form/
  * Description:  Auto-add a child entry to a Nested Form field, created with data from your parent form.
  * Author:       Gravity Wiz
- * Version:      0.1
+ * Version:      0.2
  * Author URI:   https://gravitywiz.com
  */
 class GPNF_Triggered_Population {

--- a/gp-nested-forms/gpnf-triggered-population.php
+++ b/gp-nested-forms/gpnf-triggered-population.php
@@ -118,6 +118,7 @@ class GPNF_Triggered_Population {
 						GPNestedForms.deleteEntry(
 							item,
 							entryDataRowElem,
+							{ showSpinner: false },
 						);
 
 					}


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1973533007/37541?folderId=6987275

## Summary

This snippet is supposed to add child form entries when a configured checkbox / radio button is selected and then remove that child entry item when de-selected.

There are a couple of items at play here that this PR addresses:

1. This was originally written to support radio buttons only and didn't work correctly with multi-select. The reason is because we weren't checking to see if the field was `checked` before calling `addChildEntry` in the `onchange` handler. Thus, when the field was de-selected (`!checked`), the add function would still be called.
2. The `removeChildEntry` function had not been implemented yet. Thus, even when it was called it didn't actually do anything.

Please note that this now relies on some new changes within the `gp-nested-forms` perk and consequently will require a new version of that perk to work correctly.

