### PR TITLE
Fix gppa-increase-query-limit.php to be correct snippet.

### DIFF
--- a/gp-populate-anything/gppa-increase-query-limit.php
+++ b/gp-populate-anything/gppa-increase-query-limit.php
@@ -2,9 +2,8 @@
 /**
  * Gravity Perks // GP Populate Anything // Change The Query Limit
  * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
- *
-// Replace "123" with your form ID and "4" with your field ID.
-add_filter( 'gppa_query_limit_123_4', function() {
-	// Update "1000" to whatever you would like the query limit to be.
-	return 1000;
+ */
+add_filter( 'gppa_query_limit', function() {
+	// Update "750" to whatever you would like the query limit to be.
+	return 750;
 } );


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/gppa_query_limit-577a20c4e27a48e98557d9b51d2d0a06

## Summary

The contents of the snippet were a duplicate of [another snippet](https://github.com/gravitywiz/snippet-library/blob/master/gp-populate-anything/gppa-change-query-limit-by-field.php). This corrects that to match the [example in the docs](https://gravitywiz.com/documentation/gppa_query_limit/#change-the-query-limit-to-750-for-all-dynamically-populated-fields).
