### PR TITLE
Added snippet that modifies the nested form button text content

### DIFF
--- a/gp-nested-forms/gpnf-nested-entries-max-message.php
+++ b/gp-nested-forms/gpnf-nested-entries-max-message.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Add Child Entry on Trigger
+ * https://gravitywiz.com/documentation/gravity-forms-nested-form/
+ *
+ * Instruction Video: https://www.loom.com/share/2d01000744354e7693ac4348f521992f
+ *
+ * This snippet allows overrides the default button message in the Nested Form Perk
+ * and shows the user the minimum and maximum number of entries that can be added.
+ *
+ * Plugin Name:  GP Nested Forms - Show Minimum and Maximum Entries Message
+ * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-nested-form/
+ * Description:  Override the message next to child field submit buttons and show the minimum/maximum number of child entries allowed.
+ * Author:       Gravity Wiz
+ * Version:      0.2
+ * Author URI:   https://gravitywiz.com
+ */
+
+
+function modify_child_form_button_messsage( $args ) {
+
+	add_filter('gpnf_add_button_max_message_' . $args['form_id'] . '_' . $args['child_form_field_id'], function( $message, $args ) {
+
+		// due to backwards compatibility, this hooks has the potential to be called without $args
+		if ( ! $args ) {
+			return $message;
+		}
+
+		$min = $args['form_field']->gpnfEntryLimitMin;
+		$max = $args['form_field']->gpnfEntryLimitMax;
+
+		if ( ! $min || $min === 0 || $min === '0' ) {
+			return 'You can add no more than ' . $args['form_field']->gpnfEntryLimitMax . ' entries.';
+		}
+
+		if ( ! $max ) {
+			return 'You must add at least ' . $args['form_field']->gpnfEntryLimitMin . ' entries.';
+		}
+
+		return 'You must add at least ' . $args['form_field']->gpnfEntryLimitMin . ' entries and no more than ' . $args['form_field']->gpnfEntryLimitMax . ' entries.';
+
+	}, 10, 4 );
+
+}
+
+
+# Example
+modify_child_form_button_messsage( array(
+	'form_id'             => 8,
+	'child_form_field_id' => 4,
+) );

--- a/gp-nested-forms/gpnf-nested-entries-max-message.php
+++ b/gp-nested-forms/gpnf-nested-entries-max-message.php
@@ -3,32 +3,14 @@
  * Gravity Perks // Nested Forms // Override Max Entries Message
  * https://gravitywiz.com/documentation/gravity-forms-nested-form/
  *
- * Instruction Video: https://www.loom.com/share/1ff5c50881134365b9bfd6b234a8c1c8
- *
  * This snippet allows overrides the default button message in the Nested Form Perk
  * and shows the user the minimum and maximum number of entries that can be added.
  *
- * Plugin Name:  GP Nested Forms - Show Minimum and Maximum Entries Message
- * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-nested-form/
- * Description:  Override the message next to child field submit buttons and show the minimum/maximum number of child entries allowed.
- * Author:       Gravity Wiz
- * Version:      0.1
- * Author URI:   https://gravitywiz.com
+ * @version 0.1
  */
-function override_child_form_max_entry_message( $field_configs = null ) {
 
-	// apply modified message to all child form fields if $field_configs is not passed in
-	if ( is_null( $field_configs ) ) {
-		add_filter( 'gpnf_template_args', 'template_args_filter', 10, 3 );
-		return;
-	}
-
-	foreach ( $field_configs as $config ) {
-		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], 'template_args_filter', 10, 3 );
-	}
-}
-
-function template_args_filter( $args, $form_field, $form ) {
+// Update "123" to your form ID and "4" to your field ID. Remove "_123_4" to apply this globally.
+add_filter( 'gpnf_template_args_123_4', function ( $args, $form_field ) {
 
 	// $args->add_button_message is not always present when this hook is applied
 	if ( ! array_key_exists( 'add_button_message', $args ) ) {
@@ -38,35 +20,25 @@ function template_args_filter( $args, $form_field, $form ) {
 	$min = $form_field->gpnfEntryLimitMin;
 	$max = $form_field->gpnfEntryLimitMax;
 
+	$message = null;
+
 	if ( ( empty( $min ) || $min === '0' ) && ! empty( $max ) ) {
-		$args['add_button_message'] = format_message( 'You can add no more than ' . $max . ' entries.' );
+		$message = 'You can add no more than ' . $max . ' entries.';
 	} elseif ( ( empty( $max ) || $max === '0' ) && ! empty( $min ) ) {
-		$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries.' );
+		$message = 'You must add at least ' . $min . ' entries.';
 	} elseif ( ! empty( $min ) && ! empty( $max ) ) {
-		$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries and no more than ' . $max . ' entries.' );
+		$message = 'You must add at least ' . $min . ' entries and no more than ' . $max . ' entries.';
+	}
+
+	if ( ! is_null( $message ) ) {
+		$args['add_button_message'] = sprintf(
+			'
+		 	<p class="gpnf-add-entry-max">
+		 		%s
+		 	</p>',
+			$message
+		);
 	}
 
 	return $args;
-
-}
-
-function format_message( $message ) {
-	return sprintf(
-		'
-	 	<p class="gpnf-add-entry-max">
-	 		%s
-	 	</p>',
-		$message
-	);
-}
-
-# Example adding message to all child form fields
-override_child_form_max_entry_message();
-
-# Example adding message to a list of child form fields
-// override_child_form_max_entry_message( array(
-// 	array(
-// 		'form_id'             => 8,
-// 		'child_form_field_id' => 4,
-// 	),
-// ) );
+}, 10, 2 );

--- a/gp-nested-forms/gpnf-nested-entries-max-message.php
+++ b/gp-nested-forms/gpnf-nested-entries-max-message.php
@@ -24,7 +24,7 @@ function override_child_form_max_entry_message( $field_configs = null ) {
 	}
 
 	foreach ( $field_configs as $config ) {
-		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], 'template_args_filter' , 10, 3 );
+		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], 'template_args_filter', 10, 3 );
 	}
 }
 

--- a/gp-nested-forms/gpnf-nested-entries-max-message.php
+++ b/gp-nested-forms/gpnf-nested-entries-max-message.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Gravity Perks // Nested Forms // Add Child Entry on Trigger
+ * Gravity Perks // Nested Forms // Override Max Entries Message
  * https://gravitywiz.com/documentation/gravity-forms-nested-form/
  *
- * Instruction Video: https://www.loom.com/share/2d01000744354e7693ac4348f521992f
+ * Instruction Video: https://www.loom.com/share/1ff5c50881134365b9bfd6b234a8c1c8
  *
  * This snippet allows overrides the default button message in the Nested Form Perk
  * and shows the user the minimum and maximum number of entries that can be added.
@@ -12,34 +12,42 @@
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-nested-form/
  * Description:  Override the message next to child field submit buttons and show the minimum/maximum number of child entries allowed.
  * Author:       Gravity Wiz
- * Version:      0.2
+ * Version:      0.1
  * Author URI:   https://gravitywiz.com
  */
-function modify_child_form_button_messsage( $field_configs ) {
-	foreach ( $field_configs as $config ) {
-		// $args = gf_apply_filters( array( 'gpnf_template_args', $this->formId, $this->id ), $args, $this, $form );
-		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], function( $args, $form_field, $form ) {
+function override_child_form_max_entry_message( $field_configs = null ) {
 
-			// $args->add_button_message is not always present when this hook is applied
-			if ( ! array_key_exists( 'add_button_message', $args ) ) {
-				return $args;
-			}
-
-			$min = $form_field->gpnfEntryLimitMin;
-			$max = $form_field->gpnfEntryLimitMax;
-
-			if ( ( empty( $min ) || $min === '0' ) && ! empty( $max ) ) {
-				$args['add_button_message'] = format_message( 'You can add no more than ' . $max . ' entries.' );
-			} elseif ( ( empty( $max ) || $max === '0' ) && ! empty( $min ) ) {
-				$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries.' );
-			} elseif ( ! empty( $min ) && ! empty( $max ) ) {
-				$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries and no more than ' . $max . ' entries.' );
-			}
-
-			return $args;
-
-		}, 10, 3 );
+	// apply modified message to all child form fields if $field_configs is not passed in
+	if ( is_null( $field_configs ) ) {
+		add_filter( 'gpnf_template_args', 'template_args_filter', 10, 3 );
+		return;
 	}
+
+	foreach ( $field_configs as $config ) {
+		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], 'template_args_filter' , 10, 3 );
+	}
+}
+
+function template_args_filter( $args, $form_field, $form ) {
+
+	// $args->add_button_message is not always present when this hook is applied
+	if ( ! array_key_exists( 'add_button_message', $args ) ) {
+		return $args;
+	}
+
+	$min = $form_field->gpnfEntryLimitMin;
+	$max = $form_field->gpnfEntryLimitMax;
+
+	if ( ( empty( $min ) || $min === '0' ) && ! empty( $max ) ) {
+		$args['add_button_message'] = format_message( 'You can add no more than ' . $max . ' entries.' );
+	} elseif ( ( empty( $max ) || $max === '0' ) && ! empty( $min ) ) {
+		$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries.' );
+	} elseif ( ! empty( $min ) && ! empty( $max ) ) {
+		$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries and no more than ' . $max . ' entries.' );
+	}
+
+	return $args;
+
 }
 
 function format_message( $message ) {
@@ -52,10 +60,13 @@ function format_message( $message ) {
 	);
 }
 
+# Example adding message to all child form fields
+override_child_form_max_entry_message();
 
-modify_child_form_button_messsage( array(
-	array(
-		'form_id'             => 8,
-		'child_form_field_id' => 4,
-	),
-) );
+# Example adding message to a list of child form fields
+// override_child_form_max_entry_message( array(
+// 	array(
+// 		'form_id'             => 8,
+// 		'child_form_field_id' => 4,
+// 	),
+// ) );

--- a/gp-nested-forms/gpnf-nested-entries-max-message.php
+++ b/gp-nested-forms/gpnf-nested-entries-max-message.php
@@ -15,37 +15,47 @@
  * Version:      0.2
  * Author URI:   https://gravitywiz.com
  */
+function modify_child_form_button_messsage( $field_configs ) {
+	foreach ( $field_configs as $config ) {
+		// $args = gf_apply_filters( array( 'gpnf_template_args', $this->formId, $this->id ), $args, $this, $form );
+		add_filter( 'gpnf_template_args_' . $config['form_id'] . '_' . $config['child_form_field_id'], function( $args, $form_field, $form ) {
 
+			// $args->add_button_message is not always present when this hook is applied
+			if ( ! array_key_exists( 'add_button_message', $args ) ) {
+				return $args;
+			}
 
-function modify_child_form_button_messsage( $args ) {
+			$min = $form_field->gpnfEntryLimitMin;
+			$max = $form_field->gpnfEntryLimitMax;
 
-	add_filter('gpnf_add_button_max_message_' . $args['form_id'] . '_' . $args['child_form_field_id'], function( $message, $args ) {
+			if ( ( empty( $min ) || $min === '0' ) && ! empty( $max ) ) {
+				$args['add_button_message'] = format_message( 'You can add no more than ' . $max . ' entries.' );
+			} elseif ( ( empty( $max ) || $max === '0' ) && ! empty( $min ) ) {
+				$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries.' );
+			} elseif ( ! empty( $min ) && ! empty( $max ) ) {
+				$args['add_button_message'] = format_message( 'You must add at least ' . $min . ' entries and no more than ' . $max . ' entries.' );
+			}
 
-		// due to backwards compatibility, this hooks has the potential to be called without $args
-		if ( ! $args ) {
-			return $message;
-		}
+			return $args;
 
-		$min = $args['form_field']->gpnfEntryLimitMin;
-		$max = $args['form_field']->gpnfEntryLimitMax;
+		}, 10, 3 );
+	}
+}
 
-		if ( ! $min || $min === 0 || $min === '0' ) {
-			return 'You can add no more than ' . $args['form_field']->gpnfEntryLimitMax . ' entries.';
-		}
-
-		if ( ! $max ) {
-			return 'You must add at least ' . $args['form_field']->gpnfEntryLimitMin . ' entries.';
-		}
-
-		return 'You must add at least ' . $args['form_field']->gpnfEntryLimitMin . ' entries and no more than ' . $args['form_field']->gpnfEntryLimitMax . ' entries.';
-
-	}, 10, 4 );
-
+function format_message( $message ) {
+	return sprintf(
+		'
+	 	<p class="gpnf-add-entry-max">
+	 		%s
+	 	</p>',
+		$message
+	);
 }
 
 
-# Example
 modify_child_form_button_messsage( array(
-	'form_id'             => 8,
-	'child_form_field_id' => 4,
+	array(
+		'form_id'             => 8,
+		'child_form_field_id' => 4,
+	),
 ) );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1976741186/37641/

## Summary

This adds a snippet that allows you to modify the "add" button message next to nested form entry tables.

As an example: 
![image](https://user-images.githubusercontent.com/21110659/185359835-98542df7-5871-4228-90f2-9d0b4c28cb51.png)



