### PR TITLE
Fixed `gw-choice-counter` bug where count would not update when choices were populated from GP Populate Anything.

### DIFF
--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -63,13 +63,7 @@ class GW_Choice_Count {
 						}
 					}
 
-					self.init = function() {
-
-						// Event handler for all listeners to avoid DRY
-						var updateChoiceEventHandler = function() {
-							self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId );
-						};
-
+					self.updateEventHandlers = function() {
 						for( var i = 0; i < self.choiceFieldIds.length; i++ ) {
 
 							var choiceFieldId       = self.choiceFieldIds[i],
@@ -77,20 +71,34 @@ class GW_Choice_Count {
 								$choiceField        = $(choiceFieldSelector),
 								$parentForm         = $choiceField.parents('form');
 
+							$parentForm.off( 'click', choiceFieldSelector, self.updateChoiceEventHander );
+							$parentForm.off( 'change', choiceFieldSelector, self.updateChoiceEventHander );
+
 							if ( self.isCheckboxField( $choiceField ) ) {
-								$parentForm.on( 'click', choiceFieldSelector, updateChoiceEventHandler );
+								$parentForm.on( 'click', choiceFieldSelector, self.updateChoiceEventHandler );
 							} else {
-								$parentForm.on( 'change', choiceFieldSelector, updateChoiceEventHandler );
+								$parentForm.on( 'change', choiceFieldSelector, self.updateChoiceEventHandler );
 							}
 
 						}
+					};
 
-						updateChoiceEventHandler();
+					// Event handler for all listeners to avoid DRY and to maintain a pointer reference to the function
+					// which we can use to explicity unbind event handlers
+					self.updateChoiceEventHandler = function() {
+						self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId );
+					};
+
+					self.init = function() {
+
+						self.updateEventHandlers();
+						self.updateChoiceEventHandler();
 
 						// Listen for `gppa_updated_batch_fields` and update count as GPPA may have re-written choice fields
 						$( document ).on( 'gppa_updated_batch_fields', function( e, formId ) {
 							if ( parseInt( formId ) === self.formId ) {
-								updateChoiceEventHandler();
+								self.updateEventHandlers();
+								self.updateChoiceEventHandler();
 							}
 						} );
 					};


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1975203407/37592?folderId=6987275


## Summary

The choice counter snippet was not working when counting from a field populated by Populate Anything. This was because, as the field changed (was repopulated), we did not update / rebind the event handler functions so when the choice fields changed (e.g. were checked) the count wouldn't get updated.

