### PR TITLE
gpep-edit-entry.php: Added support for releasing inventory reserved by the entry currently being edited.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -9,7 +9,7 @@
  * Plugin URI:   https://gravitywiz.com/edit-gravity-forms-entries-on-the-front-end/
  * Description:  Edit the entry that was passed through via GP Easy Passthrough rather than creating a new entry.
  * Author:       Gravity Wiz
- * Version:      1.4.1
+ * Version:      1.4.2
  * Author URI:   https://gravitywiz.com/
  */
 class GPEP_Edit_Entry {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1984777991/37879

## Summary

When using our [GPEP Edit Entries](https://gravitywiz.com/edit-gravity-forms-entries-on-the-front-end/) snippet, inventory reserved by entry being edited was not released, allowing the user to change their selection or even successfully submit the form (when using a Single Product field).

This PR adds support for that.

**Note:** Unlike other instances where we've adding support for releasing inventory (Nested Forms, GravityView), I opted to include this code here in the snippet rather than in GP Inventory itself. As we continue to develop and market Entry Blocks, it will replace this snippet so I'm hesitant to add code for a soon-to-be deprecated snippet in GP Inventory.
