### PR TITLE
All Fields Template: Fixed issue where the `:filter` modifier would not work for Product fields on Nested Forms.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -202,6 +202,11 @@ class GW_All_Fields_Template {
 			switch ( $modifier ) {
 				case 'filter':
 					if ( in_array( $field->id, $field_ids ) ) {
+						// In the case of a Single Product field, the $value is empty, but $raw_value contains an array.
+						if ( ! $value && is_array( $raw_value ) ) {
+							$value = GFCommon::get_lead_field_display( $field, $raw_value );
+						}
+
 						$value = $this->get_all_fields_field_value( $field, $value );
 					} else {
 						$value = false;
@@ -423,7 +428,12 @@ class GW_All_Fields_Template {
 
 						// ignore product fields as they will be grouped together at the end of the grid
 						$display_product_summary = apply_filters( 'gform_display_product_summary', true, $field, $form, $lead );
-						if ( $display_product_summary ) {
+
+						// Do not include product fields if the product/order summary will be included.
+						if (
+							$display_product_summary
+							&& $this->all_fields_extra_options( GFCommon::get_submitted_pricing_fields( $form, $lead, $format, $use_text, $use_admin_label ), $merge_tag, $modifiers, 'order_summary', null, $format )
+						) {
 							break;
 						}
 					} elseif ( GFFormsModel::is_field_hidden( $form, $field, array(), $lead ) ) {


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1980114178/37733?folderId=3808239

## Summary

Merge tags such as `{:4:index[0],filter[3]}` were not working for Product fields in Nested Forms, including user-defined and single products.
