### PR TITLE
Updated the snippet to also set the value property

### DIFF
--- a/gp-populate-anything/gppa-populate-from-multiple-forms.php
+++ b/gp-populate-anything/gppa-populate-from-multiple-forms.php
@@ -24,7 +24,8 @@ add_filter( 'gppa_input_choices_123_4', function ( $choices, $field, $objects ) 
 				$last_name  = $entry['3.6'];
 				break;
 		}
-		$choice['text'] = sprintf( '%s %s', $first_name, $last_name );
+		$choice['text']  = sprintf( '%s %s', $first_name, $last_name );
+		$choice['value'] = sprintf( '%s %s', $first_name, $last_name );
 	}
 
 	return $choices;


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1992124058/38187?folderId=14964

<!-- Briefly explain what's new in this pull request. -->

The snippet wasn't setting the value property of the choice-based field when populated. When a multi-select field is used, it displays the value property of the field on the entry page, and because the value property hasn't been set by the snippet it displays the entry ID. Added a line of code to also set the value. 
