### PR TITLE
Fixed issue where Auto Save & Continue would conflict with editing entries using GPEB

### DIFF
--- a/gravity-forms/gw-save-and-continue-auto-load.php
+++ b/gravity-forms/gw-save-and-continue-auto-load.php
@@ -144,6 +144,9 @@ class GW_Save_Continue_Auto_Load {
 	}
 
 
+	/**
+	 * Checks to see if the context is the GP Entry Block Editor.
+	 */
 	public function is_editing_entry( $form_id ) {
 		if ( ! method_exists( 'GP_Entry_Blocks\GF_Queryer', 'attach_to_current_block' ) ) {
 			return false;
@@ -151,7 +154,7 @@ class GW_Save_Continue_Auto_Load {
 
 		$entry_block = GP_Entry_Blocks\GF_Queryer::attach_to_current_block();
 
-		return $entry_block && $entry_block->is_edit_entry() && $entry_block->form_id === $form_id;
+		return $entry_block && $entry_block->is_edit_entry() && $entry_block->form_id == $form_id;
 	}
 
 	public function is_applicable_form( $form ) {

--- a/gravity-forms/gw-save-and-continue-auto-load.php
+++ b/gravity-forms/gw-save-and-continue-auto-load.php
@@ -68,6 +68,10 @@ class GW_Save_Continue_Auto_Load {
 			return;
 		}
 
+		if ( ! $this->is_applicable_form( $form['id'] ) ) {
+			return;
+		}
+
 		$submission               = GFFormDisplay::$submission[ $form['id'] ];
 		$is_successful_submission = $page_number == 0 && $submission['is_valid'];
 
@@ -139,9 +143,23 @@ class GW_Save_Continue_Auto_Load {
 		return $message;
 	}
 
-	public function is_applicable_form( $form ) {
 
+	public function is_editing_entry( $form_id ) {
+		if ( ! method_exists( 'GP_Entry_Blocks\GF_Queryer', 'attach_to_current_block' ) ) {
+			return false;
+		}
+
+		$entry_block = GP_Entry_Blocks\GF_Queryer::attach_to_current_block();
+
+		return $entry_block && $entry_block->is_edit_entry() && $entry_block->form_id === $form_id;
+	}
+
+	public function is_applicable_form( $form ) {
 		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
+
+		if ( $this->is_editing_entry( $form_id ) ) {
+			return false;
+		}
 
 		return empty( $this->_args['form_ids'] ) || in_array( $form_id, $this->_args['form_ids'] );
 	}


### PR DESCRIPTION
## Context


<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1989981370/38073/


## Summary

This was loading up incorrect draft entry data when in the GPEB editor context. The fix is to add a check to _not_ do that if in the GPEB editor context.

