### PR TITLE
gw-list-field-as-choices.php: Add `gwlfac_list_field_values` filter to allow filtering the List field values that will be used to populate choices.

### DIFF
--- a/gravity-forms/gw-list-field-as-choices-usage.php
+++ b/gravity-forms/gw-list-field-as-choices-usage.php
@@ -35,21 +35,18 @@ new GW_List_Field_As_Choices( array(
 	'value_template'   => '{Name}',
 ) );
 
+# Filter Usage
 
-/** Usage of filters in the snippet */
-
-//Customization values based on a user input step from Gravity Flow - The entry list field has already been populated.
-/*
-add_filter( 'gplibrary_list_field_choices', 'example_flow_list_choice_populate', 10, 3 );
-function example_flow_list_choice_populate( $values, $form, $args) {
+## Customize choices to be populated based on Gravity Flow User Input step.
+add_filter( 'gwlfac_list_field_choices', function( $values, $form, $args ) {
     if ( is_array( $values ) ) {
 		return $values;
 	}
 
-	//Confirm we are within a Gravity Flow Inbox
-    if( rgget( 'lid' ) && rgget( 'page') == 'gravityflow-inbox' ) {
-        $entry = GFAPI::get_entry( (int)rgget('lid') );
-        //Verify the entry list field has previously stored values to use.
+	// Confirm we are within a Gravity Flow Inbox.
+    if ( rgget( 'lid' ) && rgget( 'page') == 'gravityflow-inbox' ) {
+        $entry = GFAPI::get_entry( (int) rgget( 'lid' ) );
+        // Verify the entry list field has previously stored values to use.
         if ( $entry ) {
             $values = unserialize( $entry[ $args['list_field_id'] ] );
             if ( ! is_array( $values ) ) {
@@ -60,5 +57,4 @@ function example_flow_list_choice_populate( $values, $form, $args) {
         }
     }
 	return false;
-}
-*/
+}, 10, 3 );

--- a/gravity-forms/gw-list-field-as-choices-usage.php
+++ b/gravity-forms/gw-list-field-as-choices-usage.php
@@ -37,8 +37,8 @@ new GW_List_Field_As_Choices( array(
 
 # Filter Usage
 
-## Customize choices to be populated based on Gravity Flow User Input step.
-add_filter( 'gwlfac_list_field_choices', function( $values, $form, $args ) {
+## Customize List field values to be populated as choices based on Gravity Flow User Input step.
+add_filter( 'gwlfac_list_field_values', function( $values, $form, $args ) {
     if ( is_array( $values ) ) {
 		return $values;
 	}

--- a/gravity-forms/gw-list-field-as-choices-usage.php
+++ b/gravity-forms/gw-list-field-as-choices-usage.php
@@ -34,3 +34,31 @@ new GW_List_Field_As_Choices( array(
 	'label_template'   => '{Name} <span style="color:#999;font-style:italic;">({Age})</span>',
 	'value_template'   => '{Name}',
 ) );
+
+
+/** Usage of filters in the snippet */
+
+//Customization values based on a user input step from Gravity Flow - The entry list field has already been populated.
+/*
+add_filter( 'gplibrary_list_field_choices', 'example_flow_list_choice_populate', 10, 3 );
+function example_flow_list_choice_populate( $values, $form, $args) {
+    if ( is_array( $values ) ) {
+		return $values;
+	}
+
+	//Confirm we are within a Gravity Flow Inbox
+    if( rgget( 'lid' ) && rgget( 'page') == 'gravityflow-inbox' ) {
+        $entry = GFAPI::get_entry( (int)rgget('lid') );
+        //Verify the entry list field has previously stored values to use.
+        if ( $entry ) {
+            $values = unserialize( $entry[ $args['list_field_id'] ] );
+            if ( ! is_array( $values ) ) {
+                return false;
+            } else {
+                return $values;
+            }
+        }
+    }
+	return false;
+}
+*/

--- a/gravity-forms/gw-list-field-as-choices.php
+++ b/gravity-forms/gw-list-field-as-choices.php
@@ -48,6 +48,16 @@ class GW_List_Field_As_Choices {
 		$list_field = GFFormsModel::get_field( $form, $this->_args['list_field_id'] );
 		$values     = GFFormsModel::get_field_value( $list_field );
 
+		/**
+		 * Filter whether to return the form or continue with $values populated via filter.
+		 *
+		 * Allows 3rd parties to avoid customize values for choice use.
+		 *
+		 * @param array|mixed|string $values
+		 * @param array              $form
+		 * @param array				 $args
+		 */
+		$values = apply_filters( 'gplibrary_list_field_choices', $values, $form, $this->_args );
 		// if list field doesn't have any values, let's ditch this party
 		if ( ! is_array( $values ) ) {
 			return $form;

--- a/gravity-forms/gw-list-field-as-choices.php
+++ b/gravity-forms/gw-list-field-as-choices.php
@@ -49,15 +49,14 @@ class GW_List_Field_As_Choices {
 		$values     = GFFormsModel::get_field_value( $list_field );
 
 		/**
-		 * Filter whether to return the form or continue with $values populated via filter.
+		 * Filter the values from the List field that will be used to populate field choices.
 		 *
-		 * Allows 3rd parties to avoid customize values for choice use.
-		 *
-		 * @param array|mixed|string $values
-		 * @param array              $form
-		 * @param array				 $args
+		 * @param array|mixed|string $values The List field values that will be used to populate field choices.
+		 * @param array              $form   The current form.
+		 * @param array				 $args   The arguments used to initialize this instance of GW_List_Field_As_Choices.
 		 */
-		$values = apply_filters( 'gplibrary_list_field_choices', $values, $form, $this->_args );
+		$values = apply_filters( 'gwlfac_list_field_values', $values, $form, $this->_args );
+		
 		// if list field doesn't have any values, let's ditch this party
 		if ( ! is_array( $values ) ) {
 			return $form;


### PR DESCRIPTION
## Context
gravity-forms/gw-list-field-as-choices

## Summary
The current logic does not allow the $values array to be customized/populated from additional sources that in-progress initial form submission. The PR filter adds support for scenarios involving an existing entry or value array customization. The usage example shows how it can be used with an existing entry via a Gravity Flow User Input step.
