### PR TITLE
Removed code that removed the `:tinyml` modifier. Gravity Forms appears to support multiple modifiers for choice-based fields now!

### DIFF
--- a/gravity-forms/gw-tiny-mailing-list.php
+++ b/gravity-forms/gw-tiny-mailing-list.php
@@ -32,7 +32,6 @@ class GW_Tiny_Mailing_List {
 
 		add_filter( 'gform_notification', array( $this, 'send_individual_notifications' ), 10, 3 );
 		add_filter( 'gform_is_valid_notification_to', array( $this, 'allow_multiple_modifiers_in_notification_to_merge_tags' ), 10, 4 );
-		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'remove_tinyml_modifier' ) );
 
 	}
 
@@ -87,21 +86,6 @@ class GW_Tiny_Mailing_List {
 		}
 
 		return $is_valid;
-	}
-
-	/**
-	 * Gravity Forms doesn't support multiple modifiers on choice-based field types. Replace our modifier so it doesn't
-	 * conflict if there is another parameter present.
-	 *
-	 * For example, if we had ":value,tinyml" modifiers, the :value modifier would not be recognized when Gravity Forms
-	 * determined what to return for the field value.
-	 *
-	 * @param $text
-	 *
-	 * @return array|string|string[]|null
-	 */
-	public function remove_tinyml_modifier( $text ) {
-		return preg_replace( '/,?tinyml,?/', '', $text );
 	}
 
 }


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1991551454/38176

## Summary

In the past, Gravity Forms didn't support parsing multiple merge tags on choice-based fields. In order to work around this we removed the modifier in certain contexts. This created a conflict with a solution I'm working on for a customer that would allow them to use the All Fields Template plugin to filter a Nested Form field down to an Email field and a custom template that checks for the `:tinyml` modifier alter the markup to return a comma-delimited list rather than an unordered HTML list.

```php
<?php
/**
 * @var $items
 * @var $modifiers
 */
if ( function_exists( 'gw_all_fields_template' ) ) {
	$modifiers = gw_all_fields_template()->parse_modifiers( $modifiers );
	if ( array_key_exists( 'tinyml', $modifiers ) ) {
		echo implode( ', ', wp_list_pluck( $items, 'value' ) );
		return;
	}
}
?>

<ul>
	<?php foreach ( $items as $item ) : ?>
		<li><?php echo $item['value']; ?></li>
	<?php endforeach; ?>
</ul>
```
