### PR TITLE
Moved function_exists into add_hook function

### DIFF
--- a/gp-inventory/gpi-waiting-list.php
+++ b/gp-inventory/gpi-waiting-list.php
@@ -15,14 +15,14 @@ class GPI_Waiting_List {
 	public $waitlist_message = '(waiting list)';
 
 	public function __construct() {
-		if ( ! function_exists( 'gp_inventory_type_advanced' ) || ! function_exists( 'gp_inventory_type_simple' ) ) {
-			return;
-		}
-
 		add_action( 'init', array( $this, 'add_hooks' ), 20 ); // Wait for GPI to be instantiated
 	}
 
 	public function add_hooks() {
+		if ( ! function_exists( 'gp_inventory_type_advanced' ) || ! function_exists( 'gp_inventory_type_simple' ) ) {
+			return;
+		}
+
 		add_filter( 'gform_entry_post_save', array( $this, 'add_entry_meta' ), 10, 2 );
 
 		/*


### PR DESCRIPTION
Ticket: https://secure.helpscout.net/conversation/2004338008/38520/

The GPI waiting list snippet wasn't working and it appears to be because of the position of the function_exists statement. It looks like at the time this is checked GPI hasn't been instantiated so it returns false and doesn't run the code. The solution I applied is to move the function_exists check into the add_hook function, as its first statement.

