### PR TITLE
`gw-conditionally-disable-checkboxes.js`: Improve compatibility with GP Limit Choices and GP Inventory

### DIFF
--- a/gravity-forms/gw-conditionally-disable-checkboxes.js
+++ b/gravity-forms/gw-conditionally-disable-checkboxes.js
@@ -39,23 +39,23 @@ $cbs2.on( 'change', function() {
 } );
 
 function gwDisableCheckboxes( $triggerField, $targetField, exclusions ) {
-	
+
 	var checkedValues = [];
-	$.each( $triggerField.find( 'input:checked:not( .gplc-disabled )' ), function() {
+	$.each( $triggerField.find( 'input:checked:not( .gplc-disabled, .gwlc-disabled, .gpi-disabled )' ), function() {
 		checkedValues.push( $(this).val() );
 	} );
 
-	var $targetCheckboxes = $targetField.find( 'input[type="checkbox"]:not( .gplc-disabled )' );
+	var $targetCheckboxes = $targetField.find( 'input[type="checkbox"]:not( .gplc-disabled, .gwlc-disabled, .gpi-disabled )' );
 	$targetCheckboxes.prop( 'disabled', false );
-	
+
 	for ( const [ key, value ] of Object.entries( exclusions ) ) {
 		if ( $.inArray( key, checkedValues ) !== -1 ) {
 			for ( const targetValue of value ) {
 				$targetCheckboxes.filter( '[value="' + targetValue + '"]' )
-					.prop( 'checked', false )
-					.prop( 'disabled', true );
+				                 .prop( 'checked', false )
+				                 .prop( 'disabled', true );
 			}
 		}
 	}
-	
+
 }


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/1991229383/38164/

Related PRs:

https://github.com/gravitywiz/gwlimitchoices/pull/18
​https://github.com/gravitywiz/gp-inventory/pull/59

## Summary

Much like GP Limit Checkboxes is currently accounted for, add support for not un-disabling checkboxes disabled by GP Limit Choices or GP Inventory.
