### PR TITLE
Updated "Require Unique Values for Different Fields" snippet with case sensitive option

### DIFF
--- a/gravity-forms/gw-require-unique-values-usage.php
+++ b/gravity-forms/gw-require-unique-values-usage.php
@@ -12,6 +12,14 @@ new GW_Require_Unique_Values( array(
 	'validation_message' => 'My custom validation message!',
 ) );
 
+# Use Case Senstive Comparison
+
+new GW_Require_Unique_Values( array(
+	'form_id'            => 12,
+	'field_ids'          => array( 14, 15 ),
+	'case_sensitive'     => true,
+) );
+
 # Create Multiple Unique "Groups" on the Same Form
 
 new GW_Require_Unique_Values( array(

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -132,9 +132,7 @@ class GW_Require_Unique_Values {
 	public function get_value_hash( $value ) {
 
 		if ( ! $this->_args['case_sensitive'] ) {
-			foreach( $value as &$v ) {
-				$v = strtolower( $v );
-			}
+			$value = array_map( 'strtolower', $value );
 		}
 
 		// Replace values like "1.1" with "x.1" to make it generic for comparison.

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -25,6 +25,7 @@ class GW_Require_Unique_Values {
 			'validation_message'  => __( 'Please enter a unique value.' ),
 			'validate_all_fields' => false,
 			'mode'                => 'collective', // 'collective' or 'individual' (experimental)
+			'case_sensitive'      => false,
 		) );
 
 		$this->_args['master_field_id'] = array_shift( $this->_args['field_ids'] );
@@ -129,6 +130,12 @@ class GW_Require_Unique_Values {
 	}
 
 	public function get_value_hash( $value ) {
+
+		if ( ! $this->_args['case_sensitive'] ) {
+			foreach( $value as &$v ) {
+				$v = strtolower( $v );
+			}
+		}
 
 		// Replace values like "1.1" with "x.1" to make it generic for comparison.
 		if ( is_array( $value ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2015924398/38889?folderId=3808239

## Summary

[Gravity Forms: Require Unique Values for Different Fields](https://gravitywiz.com/gravity-forms-require-unique-values-for-different-fields/#download-snippet) makes the case-insensitive comparison. This update adds the case-sensitive argument, with its default as false.
