### PR TITLE
`gpnf-override-parent-merge-tag-on-submission`: Updated to a class and made configuration for multiple child forms easier.

### DIFF
--- a/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
+++ b/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
@@ -7,66 +7,150 @@
  *
  * Override all {Parent} merge tags when the parent form is submitted or a parent entry is updated.
  */
-function gpnf_override_parent_merge_tags( $entry, $form ) {
-	// Update '123' to the ID of the Child form. Set as false to apply to all child forms.
-	$id_of_child_form = 123;
-	// Updated '4, 5, 6' with the IDs of the fields you want to skip. Leave blank to apply to all fields.
-	$exclude_field_ids = array( 4, 5, 6 );
 
-	foreach ( $form['fields'] as $field ) {
-		if ( $field->get_input_type() === 'form' ) {
-			$child_form_id = $field->gpnfForm;
-			if ( $id_of_child_form ) {
-				if ( $child_form_id != $id_of_child_form ) {
-					return $entry;
-				}
-			}
-			$child_form = GFAPI::get_form( $child_form_id );
-			foreach ( $child_form['fields'] as $child_field ) {
-				if ( in_array( $child_field->id, $exclude_field_ids ) ) {
-					continue;
-				}
-				if ( $child_field->get_entry_inputs() ) {
-					foreach ( $child_field->get_entry_inputs() as $input ) {
-						gpnf_override_child_entry_input_value( $entry, $field, $input['id'], rgar( $input, 'defaultValue' ) );
-					}
-				} else {
-					gpnf_override_child_entry_input_value( $entry, $field, $child_field->id, $child_field->defaultValue );
-				}
-			}
+class GPNF_Override_Parent_Merge_Tags {
+
+	/**
+	 * @var int|null child form ID to apply the override to. If null, override will apply to all child forms.
+	 */
+	private $child_form_id = null;
+
+	/**
+	 * @var int[] array field ID's to exclude when overriding a child form's {Parent} merge tags.
+	 */
+	private $exclude_field_ids = array();
+
+	/**
+	 * @var int[] array field ID's to include when overriding a child form's {Parent} merge tags. If included, will override any usage of $exclude_field_ids.
+	 */
+	private $include_field_ids = array();
+
+	function __construct( $config = null ) {
+		$this->set_config_data( $config );
+		$this->init_hooks();
+	}
+
+	function set_config_data( $config ) {
+		if ( empty( $config ) ) {
+			return;
+		}
+
+		$this->child_form_id = $config['child_form_id'];
+
+		if ( isset( $config['exclude_field_ids'] ) ) {
+			$this->exclude_field_ids = $config['exclude_field_ids'];
+		}
+
+		if ( isset( $config['include_field_ids'] ) ) {
+			$this->include_field_ids = $config['include_field_ids'];
 		}
 	}
 
-	return $entry;
+	function init_hooks() {
+		add_filter( 'gform_entry_post_save', array( $this, 'override_parent_merge_tags' ), 11, 2 );
+
+		add_action( 'gform_after_update_entry', function ( $form, $entry_id ) {
+			$entry = GFAPI::get_entry( $entry_id );
+			$this->override_parent_merge_tags( $entry, $form );
+		}, 11, 2 );
+
+		add_filter( 'gravityview-inline-edit/entry-updated', function( $return, $entry, $form_id ) {
+			$this->override_parent_merge_tags( $entry, GFAPI::get_form( $form_id ) );
+			return $return;
+		}, 10, 3 );
+	}
+
+	function override_parent_merge_tags( $entry, $form ) {
+		foreach ( $form['fields'] as $field ) {
+			if ( $field->get_input_type() !== 'form' ) {
+				continue;
+			}
+
+			if ( $this->child_form_id !== null && $field->gpnfForm != $this->child_form_id ) {
+				continue;
+			}
+
+			$child_form = GFAPI::get_form( $field->gpnfForm );
+
+			foreach ( $child_form['fields'] as $child_field ) {
+				/**
+				 * note: if include_field_ids exists, we should ignore exclude_field_ids
+				 */
+				$should_include = in_array( $child_field->id, $this->include_field_ids );
+				$should_exclude = in_array( $child_field->id, $this->exclude_field_ids );
+
+				if ( empty( $this->include_field_ids ) && $should_exclude ) {
+					continue;
+				}
+
+				if ( ! $should_include ) {
+					continue;
+				}
+
+				if ( $child_field->get_entry_inputs() ) {
+					$inputs = $child_field->get_entry_inputs();
+				} else {
+					$inputs = array(
+						array(
+							'id'           => $child_field->id,
+							'defaultValue' => $child_field->defaultValue,
+						),
+					);
+				}
+
+				foreach ( $inputs as $input ) {
+					$this->override_child_entry_input_value( $entry, $field, $input['id'], rgar( $input, 'defaultValue' ) );
+				}
+			}
+		}
+
+		return $entry;
+	}
+
+	function override_child_entry_input_value( $entry, $field, $input_id, $default_value ) {
+
+		preg_match_all( '/{Parent:(\d+(\.\d+)?)[^}]*}/i', $default_value, $matches, PREG_SET_ORDER );
+		if ( empty( $matches ) ) {
+			return;
+		}
+
+		$value = $default_value;
+		foreach ( $matches as $match ) {
+			$value = str_replace( $match[0], rgar( $entry, $match[1] ), $value );
+		}
+
+		$child_entry_ids = explode( ',', rgar( $entry, $field->id ) );
+		foreach ( $child_entry_ids as $child_entry_id ) {
+			GFAPI::update_entry_field( $child_entry_id, $input_id, $value );
+		}
+
+	}
 }
 
-function gpnf_override_child_entry_input_value( $entry, $field, $input_id, $default_value ) {
+# -------------------------------------------------
+# Configuration Options:
+#
+# child_form_id      (int)   optional id of child form to apply this to. If excluded, then this will apply to all child forms
+# exclude_field_ids  (array) optional array of field IDs to exclude from the override.
+# included_field_ids (array) optional array of field IDs to apply this to. If included, then exclude_field_ids will be ignored.
+# -------------------------------------------------
 
-	preg_match_all( '/{Parent:(\d+(\.\d+)?)[^}]*}/i', $default_value, $matches, PREG_SET_ORDER );
-	if ( empty( $matches ) ) {
-		return;
-	}
+# Example - apply to all fields of a specific child form
+// new GPNF_Override_Parent_Merge_Tags( array(
+// 	'child_form_id' => 1,
+// ) );
 
-	$value = $default_value;
-	foreach ( $matches as $match ) {
-		$value = str_replace( $match[0], rgar( $entry, $match[1] ), $value );
-	}
+# Example - apply to all fields, except those in exclude_field_ids, of a specific child form
+// new GPNF_Override_Parent_Merge_Tags( array(
+// 	'child_form_id' => 1,
+// 	'exclude_field_ids' => array( 2, 3, 4 ), // optional fields to skip the override on
+// ) );
 
-	$child_entry_ids = explode( ',', rgar( $entry, $field->id ) );
-	foreach ( $child_entry_ids as $child_entry_id ) {
-		GFAPI::update_entry_field( $child_entry_id, $input_id, $value );
-	}
+# Example - apply to specific child and apply only to specified fields
+// new GPNF_Override_Parent_Merge_Tags( array(
+// 	'child_form_id'     => 1,
+// 	'include_field_ids' => array( 2 ), // optional fields to skip the override on
+// ) );
 
-}
-
-add_filter( 'gform_entry_post_save', 'gpnf_override_parent_merge_tags', 11, 2 );
-
-add_action( 'gform_after_update_entry', function ( $form, $entry_id ) {
-	$entry = GFAPI::get_entry( $entry_id );
-	gpnf_override_parent_merge_tags( $entry, $form );
-}, 11, 2 );
-
-add_filter( 'gravityview-inline-edit/entry-updated', function( $return, $entry, $form_id ) {
-	gpnf_override_parent_merge_tags( $entry, GFAPI::get_form( $form_id ) );
-	return $return;
-}, 10, 3 );
+# Example - apply to all fields in all child forms
+// new GPNF_Override_Parent_Merge_Tags();


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2015154047/38861/ 

It is difficult to configure `gpnf-override-parent-merge-tag-on-submission.php` for multiple child forms. This enables users to more easily apply the logic to multiple child forms.

## Summary

- Refactors the snippet to a class to match our preferred snippet style.
- Support instantiating one instance of `GPNF_Override_Parent_Merge_Tags` per child form a user wants to configure.
- Support instantiating a single instance of `GPNF_Override_Parent_Merge_Tags` with no arguments to apply this to all child forms.

