### PR TITLE
`gravity-forms/gw-limit-multiselect.js`: Fixed issue where multi select limit did not work correctly when going backwards on multi-page forms.

### DIFF
--- a/gravity-forms/gw-limit-multiselect.js
+++ b/gravity-forms/gw-limit-multiselect.js
@@ -4,26 +4,35 @@
  *
  * Limit how many options may be selected in a Multi Select field. Works with
  * regular Multi Select fields as well as fields with Enhanced UI enabled.
- * 
+ *
  * Instructions:
- * 
+ *
  * 1. Install this snippet with our free Custom JavaScript plugin.
  *    https://gravitywiz.com/gravity-forms-custom-javascript/
  * 2. Configure snippet per inline instructions.
  */
-// Update "1" to the ID of your Multi Select field.
-$( '#input_GFFORMID_1' ).on( 'change', function () {
-	// Update "2" to the max number of options that should be selectable.
+(function() {
+	// Update "1" to the ID of your Multi Select field.
+	var multiSelectId = '#input_GFFORMID_1';
 	var maxSelected = 2;
-	// Alternate: Set max number by the value of another field.
-	// var maxSelected = parseInt( $( '#input_GFFORMID_4' ).val() );
-	limitMultiSelect( $( this ), maxSelected );
-} );
+	var $select = $( multiSelectId );
 
-function limitMultiSelect( $select, maxSelected ) {
-	var disable = $select.find( 'option:checked' ).length === maxSelected;
-	$select
-		.find( 'option:not(:checked)' )
-		.prop( 'disabled', disable )
-		.trigger( 'chosen:updated' );
-}
+	limitMultiSelect( $select, maxSelected );
+
+	$select.on( 'change', function () {
+		// Update "2" to the max number of options that should be selectable.
+
+		// Alternate: Set max number by the value of another field.
+		// var maxSelected = parseInt( $( '#input_GFFORMID_4' ).val() );
+		limitMultiSelect( $( this ), maxSelected );
+	} );
+
+	function limitMultiSelect( $select, maxSelected ) {
+		var disable = $select.find( 'option:checked' ).length === maxSelected;
+		$select
+			.find( 'option:not(:checked)' )
+			.prop( 'disabled', disable )
+			.trigger( 'chosen:updated' );
+	}
+
+})();

--- a/gravity-forms/gw-limit-multiselect.js
+++ b/gravity-forms/gw-limit-multiselect.js
@@ -11,28 +11,26 @@
  *    https://gravitywiz.com/gravity-forms-custom-javascript/
  * 2. Configure snippet per inline instructions.
  */
-(function() {
-	// Update "1" to the ID of your Multi Select field.
-	var multiSelectId = '#input_GFFORMID_1';
-	var maxSelected = 2;
-	var $select = $( multiSelectId );
 
-	limitMultiSelect( $select, maxSelected );
+// Update "1" to the ID of your Multi Select field.
+var multiSelectId = '#input_GFFORMID_1';
+// Update "2" to the max number of options that should be selectable.
+var maxSelected = 2;
+// Alternate: Set max number by the value of another field.
+// var maxSelected = parseInt( $( '#input_GFFORMID_4' ).val() );
 
-	$select.on( 'change', function () {
-		// Update "2" to the max number of options that should be selectable.
+var $select = $( multiSelectId );
 
-		// Alternate: Set max number by the value of another field.
-		// var maxSelected = parseInt( $( '#input_GFFORMID_4' ).val() );
-		limitMultiSelect( $( this ), maxSelected );
-	} );
+limitMultiSelect( $select, maxSelected );
 
-	function limitMultiSelect( $select, maxSelected ) {
-		var disable = $select.find( 'option:checked' ).length === maxSelected;
-		$select
-			.find( 'option:not(:checked)' )
-			.prop( 'disabled', disable )
-			.trigger( 'chosen:updated' );
-	}
+$select.on( 'change', function () {
+	limitMultiSelect( $( this ), maxSelected );
+} );
 
-})();
+function limitMultiSelect( $select, maxSelected ) {
+	var disable = $select.find( 'option:checked' ).length === maxSelected;
+	$select
+		.find( 'option:not(:checked)' )
+		.prop( 'disabled', disable )
+		.trigger( 'chosen:updated' );
+}


### PR DESCRIPTION
## Context


⛑️ Ticket(s): https://secure.helpscout.net/conversation/2020716657/39063/

## Summary

The issue was occuring because the `limitMultiSelect()` logic was only running when the configured select field changed. This meant that when returning to the select on a multi-page form, the limit logic may not have run yet and thus the user would be able to select more than the limit.

The fix is to run `limitMultiSelect()` each time the configured select comes into view.

