### PR TITLE
`gpmpn-render-all-page-links-on-load.js`: Added new snippet to load all multi page navigation links when editing entries with GPEP.

### DIFF
--- a/gp-multi-page-navigation/gpmpn-render-all-page-links-on-load.js
+++ b/gp-multi-page-navigation/gpmpn-render-all-page-links-on-load.js
@@ -1,0 +1,23 @@
+/**
+ * Gravity Perks // Multi-Page Navigation // Load all links for Edit Entry
+ * https://gravitywiz.com/documentation/gravity-forms-multi-page-navigation/
+ * 
+ * Use the snippet with Gravity Perks Easy Pass Through Edit Entry Snippet
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-easy-passthrough/gpep-edit-entry.php
+ *
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ */
+
+var $formElem = $( 'form#gform_GFFORMID' );
+var $steps    = $formElem.find( '.gf_step' );
+
+// reload all step links
+$steps.each( function( index ) {
+	var stepNumber = index + 1;
+	$(this).html(getPageLinkMarkup(stepNumber, $(this).html())).addClass( 'gpmpn-step-linked' );
+} );
+
+function getPageLinkMarkup( stepNumber, content ) {
+	return '<a href="#' + stepNumber + '" class="gwmpn-page-link gwmpn-default gpmpn-page-link gpmpn-default">' + content + '</a>';
+};


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2025453715/39250?folderId=3808239

## Summary

With GPEP + GPMPN if we use the [snippet](https://github.com/gravitywiz/snippet-library/blob/master/gp-easy-passthrough/gpep-edit-entry.php) for GPEP Edit entry, the form entry load appears as if it still creating a new entry (not editing). This snippet reloads all the links, so the edit entry look is there.
