### PR TITLE
`gppa-include-static-choices.php`: Updated snippet to include sorting options for static choices.

### DIFF
--- a/gp-populate-anything/gppa-include-static-choices.php
+++ b/gp-populate-anything/gppa-include-static-choices.php
@@ -29,6 +29,18 @@ add_filter( 'gppa_input_choices', function( $choices, $field, $objects ) {
 
 	$choices = array_merge( $field->choices, $choices );
 
+	if ( strpos( $field->cssClass, 'gppa-sort-static-choices-asc' ) !== false ) {
+		usort( $choices, function ( $choice1, $choice2 ) {
+			return $choice1['text'] <=> $choice2['text'];
+		});
+	}
+
+	if ( strpos( $field->cssClass, 'gppa-sort-static-choices-desc' ) !== false ) {
+		usort( $choices, function ( $choice1, $choice2 ) {
+			return $choice2['text'] <=> $choice1['text'];
+		});
+	}	
+
 	if ( isset( $other_choice ) ) {
 		array_push( $choices, $other_choice );
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2030410700/39418?folderId=3808239

## Summary

This updates the snippet `gppa-include-static-choices.php` to include ascending and descending sorting options. Use the CSS class `gppa-sort-static-choices-asc` or `gppa-sort-static-choices-desc` to enable the sorting
