### PR TITLE
`gppa-filter-by-relative-dates.php`: Updated snippet to use custom values which are valid for strtotime.

### DIFF
--- a/gp-populate-anything/gppa-filter-by-relative-dates.php
+++ b/gp-populate-anything/gppa-filter-by-relative-dates.php
@@ -19,9 +19,11 @@
  *     Examples:
  *         {3 days ago}
  *         {2 hours ago}
- *           {1 month ago}
+ *         {1 month ago}
  *         {3 weeks ago}
  *         {1 year ago}
+ *
+ * Another possible way of passing the value is : {relative:valid_strtotime_value}
  *
  * Plugin Name: GP Populate Anything - Filter Results on Relative Dates
  * Plugin URI:  https://gravitywiz.com/documentation/gravity-forms-populate-anything/
@@ -30,11 +32,21 @@
  * Version: 0.1
  * Author URI: http://gravitywiz.com
  **/
-add_filter( 'gppa_replace_filter_value_variables_post', function ( $value ) {
+// {INTEGER UNIT ago}
+add_filter( 'gppa_replace_filter_value_variables_post', 'gppa_replace_int_unit_ago_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_gf_entry', 'gppa_replace_int_unit_ago_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_user', 'gppa_replace_int_unit_ago_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_term', 'gppa_replace_int_unit_ago_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_database', 'gppa_replace_int_unit_ago_merge_tags' );
+
+function gppa_replace_int_unit_ago_merge_tags( $value ) {
 	preg_match_all( '/{(\d+) ((week|day|month|year)s?) ago}/m', $value, $matches, PREG_SET_ORDER, 0 );
 
 	if ( ! $matches || ! count( $matches ) ) {
-		return $value;
+		$relative_time = explode( ':', substr( $value, 1, -1 ) );
+		if ( ! strtotime( $relative_time[1] ) ) {
+			return $value;
+		}
 	}
 
 	foreach ( $matches as $match ) {
@@ -43,4 +55,27 @@ add_filter( 'gppa_replace_filter_value_variables_post', function ( $value ) {
 	}
 
 	return $value;
-} );
+}
+
+// {relative:valid_strtotime_value}
+add_filter( 'gppa_replace_filter_value_variables_post', 'gppa_replace_relative_strtotime_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_gf_entry', 'gppa_replace_relative_strtotime_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_user', 'gppa_replace_relative_strtotime_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_term', 'gppa_replace_relative_strtotime_merge_tags' );
+add_filter( 'gppa_replace_filter_value_variables_database', 'gppa_replace_relative_strtotime_merge_tags' );
+
+function gppa_replace_relative_strtotime_merge_tags( $value ) {
+	preg_match_all( '/{relative:(.*?)}/m', $value, $matches, PREG_SET_ORDER, 0 );
+
+	if ( ! $matches || ! count( $matches ) ) {
+		return $value;
+	}
+
+	foreach ( $matches as $match ) {
+		if ( strtotime( $match[1] ) ) {
+			$value = str_replace( $match[0], wp_date( 'Y-m-d H:i:s', strtotime( $match[1] ) ), $value );
+		}
+	}
+
+	return $value;
+}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2030467703/39423?folderId=3808239

## Summary

This adds merge tags of the format `{relative:anything_accepted_by_strtotime}` to be usable with the relative date snippet.

Example usage:

![CleanShot 2022-10-17 at 14 03 11](https://user-images.githubusercontent.com/375381/196261000-182e4003-0003-4c69-845b-d883c1b34468.png)

