### PR TITLE
`gpaa-map-marker-placed-auto-zoom.js`: Added new snippet to automatically set new map zoom level when a marker is placed.

### DIFF
--- a/gp-address-autocomplete/gpaa-map-marker-placed-auto-zoom.js
+++ b/gp-address-autocomplete/gpaa-map-marker-placed-auto-zoom.js
@@ -1,0 +1,23 @@
+
+/**
+ * Gravity Perks // GP Address Autocomplete // Auto Zoom When Marker is Placed
+ *
+ * Easily set a new map zoom level when a marker is placed.
+ *
+ * http://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install our free Custom Javascript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+
+/**
+ * Adjust this value to customize the zoom level when a marker is placed.
+ * Smaller numbers are more zoomed out and larger numbers are more zoomed in.
+ */
+var zoomLevel = 20;
+
+window.gform.addAction('gpaa_marker_set', function(args) {
+	args.map.setZoom(zoomLevel);
+})


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2031360180/39451/


## Summary

Adds a snippet that automatically sets map zoom level each time a marker is placed on the Address Autocomplete Map Field.

