### PR TITLE
`gpep-edit-entry.php`: Fixed GPEP Edit Entry Failing on Multisite.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -18,6 +18,10 @@ class GPEP_Edit_Entry {
 
 	public function __construct( $options ) {
 
+		if ( ! function_exists( 'rgar' ) ) {
+			return;
+		}
+
 		$this->form_id        = rgar( $options, 'form_id' );
 		$this->delete_partial = rgar( $options, 'delete_partial', true );
 		$this->refresh_token  = rgar( $options, 'refresh_token', false );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2039412111/39736?folderId=7098280

## Summary

For multi-sites, GPEP Edit Entry crashes the website. This fix adds a check for Gravity Forms (`rgar` exists) to prevent the issue.
