### PR TITLE
Fixed issue where some interweek schedules did not work as expected.

### DIFF
--- a/gravity-forms/gw-daily-form-schedule.php
+++ b/gravity-forms/gw-daily-form-schedule.php
@@ -52,10 +52,19 @@ function gw_daily_form_schedule( $form ) {
 
 		if ( ! $form['scheduleStart'] || $form['scheduleStart'] <= 6 ) {
 			if ( ! rgblank( $form['scheduleStart'] ) && $form['scheduleStart'] <= 6 ) {
+
 				$is_interweek = $form['scheduleStart'] > $form['scheduleEnd'];
-				$week_phrase  = (int) $form['scheduleStart'] === 0 || $is_interweek ? 'last week' : 'this week';
+				$current_day  = (int) date( 'w' );
+
+				// If it's a Thursday and the schedule starts on Friday, assume the current schedule is for the previous week.
+				// Pro Tip: In PHP, Monday is the first day of the week.
+				$is_current_day_less_than_schedule_day = $current_day < $form['scheduleStart'] && $current_day !== 0;
+				$use_last_week                         = $is_interweek && $is_current_day_less_than_schedule_day;
+				$week_phrase                           = (int) $form['scheduleStart'] === 0 || $use_last_week ? 'last week' : 'this week';
+
 				// Sunday last week, Monday this week.
 				$time = strtotime( "{$days[ $form['scheduleStart'] ]} {$week_phrase}", $time );
+
 			}
 
 			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2044912193/39905/

## Summary

Customer had a [Daily Form Schedule](https://gravitywiz.com/gravity-forms-daily-form-schedule/) setup spanning from Friday to Tuesday. The form was incorrectly blocked on Friday's and Saturday's due to an issue in how the schedule start date was calculated for interweek schedules. It was returning the date for the previous Friday. 

I've updated the logic to compare the current day of the week with the scheduled day of the week. If the current day of the week is less than the scheduled day of the week, then we assume the schedule is for "last week". Otherwise, we assume it is for "this week".
