### PR TITLE
`gppa-conditional-logic-for-empty-dynamic-list.js`: Added snippet for empty dynamic list being used for conditional logic.

### DIFF
--- a/gp-populate-anything/gppa-conditional-logic-for-empty-dynamic-list.js
+++ b/gp-populate-anything/gppa-conditional-logic-for-empty-dynamic-list.js
@@ -1,0 +1,17 @@
+/**
+ * Gravity Perks // Populate Anything // Conditional Logic using a field that populates with no result
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ *
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ */
+
+gform.addAction('gform_post_conditional_logic_field_action', function (formId, action, targetId, defaultValues, isInit) {
+    // replace 26 with the field ID of the field that gets dynamically populated with No Results
+	var targetValue = $( '#input_GFFORMID_26 :selected' ).val();
+	if ( targetValue === 'Check' ) {
+        // replace 27 with the field ID of the field that needs to be displayed with conditional logic
+		$( '#field_GFFORMID_27' ).show();
+	}
+});
+


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2047842152/40019?folderId=3808239

## Summary

When the value of a Populate field is set using the filter [gppa_no_choices_value](https://gravitywiz.com/documentation/gppa_no_choices_value/) if there aren't any results, the value isn't detected in Conditional logic. This snippet detects the selected value after the empty load / set via snippet and processes the conditional logic for the field targeting that list.