### PR TITLE
`gw-set-post-status-by-field-value.php`: Migrated from GitHub Gists.

### DIFF
--- a/gravity-forms/gw-set-post-status-by-field-value-advanced.php
+++ b/gravity-forms/gw-set-post-status-by-field-value-advanced.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Set Post Status by Field Value (Advanced)
+ * https://gravitywiz.com/set-post-status-by-field-value-advanced/
+ */
+// update "123" to the ID of your form
+add_filter( 'gform_post_data_123', 'gform_dynamic_post_status', 10, 3 );
+function gform_dynamic_post_status( $post_data, $form, $entry ) {
+
+	// update "4" to the ID of your custom post status field
+	if ( $entry[4] ) {
+		switch ( $entry[4] ) {
+			case 'Yes, please review my post.':
+				$post_data['post_status'] = 'pending';
+				break;
+			case 'No, please publish my post.':
+				$post_data['post_status'] = 'publish';
+				break;
+		}
+	}
+	return $post_data;
+}

--- a/gravity-forms/gw-set-post-status-by-field-value.php
+++ b/gravity-forms/gw-set-post-status-by-field-value.php
@@ -1,22 +1,16 @@
 <?php
 /**
-* Gravity Wiz // Gravity Forms // Set Post Status by Field Value (Advanced)
-* https://gravitywiz.com/set-post-status-by-field-value-advanced/
-*/
-// update "3" to the ID of your form
-add_filter( 'gform_post_data_3', 'gform_dynamic_post_status', 10, 3 );
+ * Gravity Wiz // Gravity Forms // Set Post Status by Field Value
+ * https://gravitywiz.com/set-post-status-by-field-value/
+ */
+// update "123" to the ID of your form
+add_filter( 'gform_post_data_123', 'gform_dynamic_post_status', 10, 3 );
 function gform_dynamic_post_status( $post_data, $form, $entry ) {
 
-	// update "5" to the ID of your custom post status field
-	if ( $entry[5] ) {
-		switch ( $entry[5] ) {
-			case 'Yes, please review my post.':
-				$post_data['post_status'] = 'pending';
-				break;
-			case 'No, please publish my post.':
-				$post_data['post_status'] = 'publish';
-				break;
-		}
+	// update "4" to the ID of your custom post status field
+	if ( $entry[4] ) {
+		$post_data['post_status'] = $entry[4];
 	}
+
 	return $post_data;
 }


### PR DESCRIPTION
`gw-set-post-status-by-field-value-advanced.php`: Fixed filename to match snippet.

## Context

📓 Notion: 
- https://www.notion.so/gravitywiz/Set-Post-Status-by-Field-Value-493f586087464ae6af13094e20c659b8
- https://www.notion.so/gravitywiz/Set-Post-Status-by-Field-Value-Advanced-4e46fa7876bd4ffbb1ea5ba2611e99f9

## Summary

Renamed `gw-set-post-status-by-field-value.php` to `set-post-status-by-field-value-advanced.php` and migrated `gw-set-post-status-by-field-value.php` from Gists. Also updated Form and Field IDs to match [Snippet Library — Code Organization Formatting, and Naming](https://www.notion.so/gravitywiz/Snippet-Library-Code-Organization-Formatting-and-Naming-d5bee101d9674dfc98d7ec007867de2b) guidelines.