### PR TITLE
`gpnf-override-parent-merge-tag-on-submission.php`: Fixed override parent merge tag on submission.

### DIFF
--- a/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
+++ b/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
@@ -76,14 +76,10 @@ class GPNF_Override_Parent_Merge_Tags {
 				/**
 				 * note: if include_field_ids exists, we should ignore exclude_field_ids
 				 */
-				$should_include = in_array( $child_field->id, $this->include_field_ids );
+				$should_include = empty( $this->include_field_ids ) ? true : in_array( $child_field->id, $this->include_field_ids );
 				$should_exclude = in_array( $child_field->id, $this->exclude_field_ids );
 
-				if ( empty( $this->include_field_ids ) && $should_exclude ) {
-					continue;
-				}
-
-				if ( ! $should_include ) {
+				if ( ! $should_include || $should_exclude ) {
 					continue;
 				}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2042741038/39830?folderId=3808239

## Summary

This PR updates the should include and should exclude condition to fix the customer reported issue.
