### PR TITLE
`gw-populate-date.php`: Fixed multiple source fields targetting same target field.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1861,7 +1861,7 @@ class GW_Populate_Date {
 		);
 
 		$script = 'new GWPopulateDate( ' . json_encode( $args ) . ' );';
-		$slug   = implode( '_', array( 'gw_populate_date', $this->_args['form_id'], $this->_args['target_field_id'] ) );
+		$slug   = implode( '_', array( 'gw_populate_date', $this->_args['form_id'], $this->_args['source_field_id'], $this->_args['target_field_id'] ) );
 
 		GFFormDisplay::add_init_script( $this->_args['form_id'], $slug, GFFormDisplay::ON_PAGE_RENDER, $script );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2048953389/40044?folderId=3808239

## Summary

When the target field is the same, the script name for all cases gets parsed to the same value. Adding the source field in the name ensures the uniqueness of each script name (and thus makes sure all scripts do fire).
