### PR TITLE
`gw-export-multi-input-fields-single-column.php`: Migrated from GitHub Gists.

### DIFF
--- a/gravity-forms/gw-export-multi-input-fields-single-colum.php
+++ b/gravity-forms/gw-export-multi-input-fields-single-colum.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Export Multi-input Fields in a Single Column
+ *
+ * By default, Gravity Forms only allows you to export each input of a multi-input field (e.g. Checkbox field,
+ * Name Field, etc) as a separate column. This snippet allows you to export all inputs (of a specific field) in a
+ * single column.
+ *
+ * @version   1.2
+ * @author    David Smith <david@gravitywiz.com>
+ * @license   GPL-2.0+
+ * @link      http://gravitywiz.com/how-do-i-export-multi-input-fields-in-a-single-column-with-gravity-forms/
+ * @copyright 2015 Gravity Wiz
+ *
+ * Plugin Name: Gravity Forms - Export Multi-input Fields in Single Column
+ * Plugin URI: http://gravitywiz.com/how-do-i-export-multi-input-fields-in-a-single-column-with-gravity-forms/
+ * Description: Export multi-input Gravity Forms fields as a single column.
+ * Author: David Smith
+ * Version: 1.2
+ * Author URI: http://gravitywiz.com
+ */
+add_filter( 'gform_export_fields', function( $form ) {
+
+	// only modify the form object when the form is loaded for field selection; not when actually exporting
+	if ( rgpost( 'export_lead' ) || rgpost( 'action' ) == 'gf_process_export' ) {
+		return $form;
+	}
+
+	$fields = array();
+
+	foreach ( $form['fields'] as $field ) {
+		if ( is_a( $field, 'GF_Field' ) && is_array( $field->inputs ) ) {
+			$orig_field    = clone $field;
+			$field->inputs = null;
+			$fields[]      = $field;
+			$fields[]      = $orig_field;
+		} else {
+			$fields[] = $field;
+		}
+	}
+
+	$form['fields'] = $fields;
+
+	return $form;
+} );

--- a/gravity-forms/gw-export-multi-input-fields-single-colum.php
+++ b/gravity-forms/gw-export-multi-input-fields-single-colum.php
@@ -6,12 +6,6 @@
  * Name Field, etc) as a separate column. This snippet allows you to export all inputs (of a specific field) in a
  * single column.
  *
- * @version   1.2
- * @author    David Smith <david@gravitywiz.com>
- * @license   GPL-2.0+
- * @link      http://gravitywiz.com/how-do-i-export-multi-input-fields-in-a-single-column-with-gravity-forms/
- * @copyright 2015 Gravity Wiz
- *
  * Plugin Name: Gravity Forms - Export Multi-input Fields in Single Column
  * Plugin URI: http://gravitywiz.com/how-do-i-export-multi-input-fields-in-a-single-column-with-gravity-forms/
  * Description: Export multi-input Gravity Forms fields as a single column.


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/How-do-I-export-multi-input-fields-in-a-single-column-with-Gravity-Forms-e15b331d5a7c4ad1899a781ae8f4b111

## Summary

Migrated from [Gists](https://gist.github.com/spivurno/12031dcbaef3d87a8db5#file-gw-gravity-forms-export-multi-input-fields-single-colum-php)