### PR TITLE
Create gw-set-product-category.php

### DIFF
--- a/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
+++ b/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Map Multiple Fields w/ Advanced Post Creation
+ * https://gravitywiz.com/
+ *
+ * By default, the Advanced Post Creation add-on does not allow you to map multiple fields to a taxonomy nor does it 
+ * allow you to set terms by ID.
+ * 
+ * This snippet allows to specify multiple fields on a form that have been populated with term IDs (we recommend 
+ * [Populate Anything][1] for this) and to set the taxonomy/terms based on those IDs for the generated post.
+ *
+ * [1]: https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ */
+add_action( 'gform_advancedpostcreation_post_after_creation', function ( $post_id, $feed, $entry, $form ) {
+	
+	// Update "1", "2", "3" to the field IDs that have been populated with terms. Add additional IDs as needed.
+	$term_field_ids = array( 1, 2, 3 );
+	// Update "categories" to the name of the taxonomy to which the populated terms belong.
+	$taxonomy       = 'categories';
+	
+	$term_ids = array();
+	foreach ( $term_field_ids as $term_field_id ) {
+		$term_ids[] = $entry[ $term_field_id ];
+	}
+	
+	wp_set_object_terms( $post_id, $term_ids, $taxonomy );
+	
+}, 10, 4 );

--- a/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
+++ b/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
@@ -3,7 +3,7 @@
  * Gravity Wiz // Gravity Forms // Map Multiple Fields w/ Advanced Post Creation
  * https://gravitywiz.com/
  *
- * By default, the Advanced Post Creation add-on does not allow you to map multiple fields to a taxonomy nor does it 
+ * By default, the Advanced Post Creation add-on does not allow you to map multiple fields to a taxonomy nor does it
  * allow you to set terms by ID.
  * 
  * This snippet allows to specify multiple fields on a form that have been populated with term IDs (we recommend 
@@ -15,12 +15,13 @@ add_action( 'gform_advancedpostcreation_post_after_creation', function ( $post_i
 	
 	// Update "1", "2", "3" to the field IDs that have been populated with terms. Add additional IDs as needed.
 	$term_field_ids = array( 1, 2, 3 );
+
 	// Update "categories" to the name of the taxonomy to which the populated terms belong.
-	$taxonomy       = 'categories';
+	$taxonomy = 'categories';
 	
 	$term_ids = array();
 	foreach ( $term_field_ids as $term_field_id ) {
-		$term_ids[] = $entry[ $term_field_id ];
+		$term_ids[] = (int) $entry[ $term_field_id ];
 	}
 	
 	wp_set_object_terms( $post_id, $term_ids, $taxonomy );

--- a/gravity-forms/gw-set-product-category.php
+++ b/gravity-forms/gw-set-product-category.php
@@ -1,9 +1,0 @@
-<?php
-
-
-add_action( 'gform_advancedpostcreation_post_after_creation', 'update_product_information', 10, 4 );
-function update_product_information( $post_id, $feed, $entry, $form ){
-// Update "5" to the ID of the field whose value should be used for the minimum range.
-        $cat_ids = array( (int)$entry['1'],(int)$entry['3'],(int)$entry['4'],(int)$entry['5']//,and ect ); //setting your data $entry['5'] 5-ID fileld dropdown list
-        wp_set_object_terms( $post_id, $cat_ids, 'product_cat' );
-}

--- a/gravity-forms/gw-set-product-category.php
+++ b/gravity-forms/gw-set-product-category.php
@@ -1,0 +1,9 @@
+<?php
+
+
+add_action( 'gform_advancedpostcreation_post_after_creation', 'update_product_information', 10, 4 );
+function update_product_information( $post_id, $feed, $entry, $form ){
+// Update "5" to the ID of the field whose value should be used for the minimum range.
+        $cat_ids = array( (int)$entry['1'],(int)$entry['3'],(int)$entry['4'],(int)$entry['5']//,and ect ); //setting your data $entry['5'] 5-ID fileld dropdown list
+        wp_set_object_terms( $post_id, $cat_ids, 'product_cat' );
+}


### PR DESCRIPTION
There are several drop down fields. Each subsequent one is filled from the parent by Term_ID using populate anything. In the feed settings, when using this code, you can not specify in which categories the product will be recorded.

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

<!-- Briefly explain what's new in this pull request. -->
