### PR TITLE
`gplcb-set-max-by-field-value.js`: Updated snippet Set Max Limit by Field Value to work with product fields.

### DIFF
--- a/gp-limit-checkboxes/gplcb-set-max-by-field-value.js
+++ b/gp-limit-checkboxes/gplcb-set-max-by-field-value.js
@@ -34,7 +34,7 @@ gform.addFilter( 'gplc_group', function( group, fieldId, $elem, gplc ) {
 
 		// For Product field, get the value required by tokenizing the string.
 		if ( group.max.toString().indexOf('|') > -1 ) {
-			group.max = group.max.split(/|(.*)/s)[0];
+			group.max = group.max.split( '|' )[0];
 		}
 	}
 

--- a/gp-limit-checkboxes/gplcb-set-max-by-field-value.js
+++ b/gp-limit-checkboxes/gplcb-set-max-by-field-value.js
@@ -31,6 +31,11 @@ gform.addFilter( 'gplc_group', function( group, fieldId, $elem, gplc ) {
 		group.max = Math.max( 0, parseInt( $maxField.filter( ':checked' ).val() ) );
 	} else {
 		group.max = $maxField.val() ? $maxField.val() : 0;
+
+		// For Product field, get the value required by tokenizing the string.
+		if ( group.max.toString().indexOf('|') > -1 ) {
+			group.max = group.max.split(/|(.*)/s)[0];
+		}
 	}
 
 	// Only bind our event listener once.


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2057426842/40321?folderId=3808239

## Summary

Limit Number of Checkboxes depending on the selection made in the dropdown field did not work with Product Field. This update adds compatibility to the snippet for Product Field.