### PR TITLE
`gpaa-autocomplete-zip.js`: Migrated from GitHub Gists.

### DIFF
--- a/gp-address-autocomplete/gpaa-autocomplete-zip.js
+++ b/gp-address-autocomplete/gpaa-autocomplete-zip.js
@@ -1,0 +1,16 @@
+/**
+ * Gravity Perks // GP Address Autocomplete // Show ZIP as Results
+ * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install our free Custom JavaScript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ *     3. Install accompanying gpaa-autocomplete-zip.php snippet
+ *     4. Change addressFieldId to the Address Field's ID
+ */
+window.gform.addFilter( 'gpaa_autocomplete_options', function( options ) {
+	options.types = ['postal_code'];
+
+	return options;
+} );

--- a/gp-address-autocomplete/gpaa-autocomplete-zip.php
+++ b/gp-address-autocomplete/gpaa-autocomplete-zip.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Gravity Perks // GP Address Autocomplete // Show ZIP as Results
+ * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install snippet per https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *     2. Update FORMID to the Form ID and FIELDID to the Address Field ID.
+ *     3. Hide the Address Line 1, Address Line 2, City, and State inputs from the Form Editor if desired.
+ *     4. Install accompanying gpaa-autocomplete-zip.js snippet
+ */
+add_filter( 'gpaa_init_args_FORMID_FIELDID', function( $args ) {
+	$args['inputSelectors']['autocomplete'] = '#input_FORMID_FIELDID_5';
+
+	return $args;
+});


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/Add-gpaa-autocomplete-zip-to-Snippet-Library-5727b64b895b43a6a40441bc94f0abbe

## Summary

Migrating `gpaa-autocomplete-zip.js` and  `gpaa-autocomplete-zip.php` from [this Gist](https://gist.github.com/scyt/509118977b57f9f5581bbe804deb328c).
