### PR TITLE
`gw-zip-files.php`: Updated snippet to ensure all nested form entry uploads are added to zip.

### DIFF
--- a/experimental/gpi-gpnf-exclude-child-entries-when-attached-to-a-partial-entry.php
+++ b/experimental/gpi-gpnf-exclude-child-entries-when-attached-to-a-partial-entry.php
@@ -3,23 +3,23 @@
  * Gravity Perks // Inventory + Nested Forms // Exclude Child Entries of Partial Entry Parents from Inventory
  * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
  *
- * WIP: This provides very basic support for excluding child entries attached to a partial entry parent 
- * from inventory limits. 
- * 
+ * WIP: This provides very basic support for excluding child entries attached to a partial entry parent
+ * from inventory limits.
+ *
  * @todo
- * 
+ *
  * 1. Apply to all child forms without needing to specify a form ID.
- * 2. Count child entries attached to the current partial entry. 
- *    Support has been implemented when traversing between pages; however, the Nested Forms markup AJAX request 
- *    is not aware of the current partial entry ID. Will need to pass this via the `gpnf_session_script_data` 
- *    filter so it can be accessed 
+ * 2. Count child entries attached to the current partial entry.
+ *    Support has been implemented when traversing between pages; however, the Nested Forms markup AJAX request
+ *    is not aware of the current partial entry ID. Will need to pass this via the `gpnf_session_script_data`
+ *    filter so it can be accessed
  */
 // Update "123" to your child form ID.
 add_filter( 'gpi_query_123', function( $query, $field ) {
 	global $wpdb;
 	if ( class_exists( 'GF_Partial_Entries' ) ) {
 		if ( rgpost( 'partial_entry_id' ) ) {
-			$meta_value_clause = $wpdb->prepare( "AND meta_value != %s", rgpost( 'partial_entry_id' ) );
+			$meta_value_clause = $wpdb->prepare( 'AND meta_value != %s', rgpost( 'partial_entry_id' ) );
 		}
 		$query['where'] .= "
 			AND e.id IN (

--- a/experimental/gpnf-add-child-entry-on-render.php
+++ b/experimental/gpnf-add-child-entry-on-render.php
@@ -4,7 +4,7 @@
  * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
  *
  * Programattically create and attach a child entry to a Nested Form field when the parent form is rendered.
- * 
+ *
  * Please note: A new child entry will be added on every render. You will need to identify your own condition
  * for when a child entry should be generated and attached.
  */
@@ -44,7 +44,7 @@ if ( ! function_exists( 'gpnf_add_child_entry' ) ) {
 	function gpnf_add_child_entry( $parent_entry_id, $nested_form_field_id, $field_values = array(), $parent_form_id = false ) {
 
 		if ( ! $parent_form_id ) {
-			$parent_entry = GFAPI::get_entry( $parent_entry_id );
+			$parent_entry   = GFAPI::get_entry( $parent_entry_id );
 			$parent_form_id = $parent_entry['form_id'];
 		}
 

--- a/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
+++ b/experimental/gw-gfapc-map-multiple-fields-to-taxonomy.php
@@ -5,25 +5,25 @@
  *
  * By default, the Advanced Post Creation add-on does not allow you to map multiple fields to a taxonomy nor does it
  * allow you to set terms by ID.
- * 
- * This snippet allows to specify multiple fields on a form that have been populated with term IDs (we recommend 
+ *
+ * This snippet allows to specify multiple fields on a form that have been populated with term IDs (we recommend
  * [Populate Anything][1] for this) and to set the taxonomy/terms based on those IDs for the generated post.
  *
  * [1]: https://gravitywiz.com/documentation/gravity-forms-populate-anything/
  */
 add_action( 'gform_advancedpostcreation_post_after_creation', function ( $post_id, $feed, $entry, $form ) {
-	
+
 	// Update "1", "2", "3" to the field IDs that have been populated with terms. Add additional IDs as needed.
 	$term_field_ids = array( 1, 2, 3 );
 
 	// Update "categories" to the name of the taxonomy to which the populated terms belong.
 	$taxonomy = 'categories';
-	
+
 	$term_ids = array();
 	foreach ( $term_field_ids as $term_field_id ) {
 		$term_ids[] = (int) $entry[ $term_field_id ];
 	}
-	
+
 	wp_set_object_terms( $post_id, $term_ids, $taxonomy );
-	
+
 }, 10, 4 );

--- a/gp-populate-anything/gppa-multi-value-contains.php
+++ b/gp-populate-anything/gppa-multi-value-contains.php
@@ -2,8 +2,8 @@
 /**
  * Gravity Perks // Populate Anything // Search by Multiple Values w/ Contains
  * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
- * 
- * This snippet extends the "contains" operator to support comparisions where a multi-value field (like a Multi Select) 
+ *
+ * This snippet extends the "contains" operator to support comparisions where a multi-value field (like a Multi Select)
  * is the needle. Typically, the "in" operator would be used for this; however, it has the limitation of only being able
  * to match full values rather than checking if any of the needles are contained in the haystack.
  */

--- a/gp-unique-id/gpuid-use-uid-field-in-conditional-logic.php
+++ b/gp-unique-id/gpuid-use-uid-field-in-conditional-logic.php
@@ -11,6 +11,6 @@ add_action( 'admin_footer', function() {
 				return isConditionalLogicField || field.type === 'uid';
 			} );
 		</script>
-	<?php
+		<?php
 	endif;
 } );

--- a/gravity-forms/gw-zip-files.php
+++ b/gravity-forms/gw-zip-files.php
@@ -79,7 +79,7 @@ class GW_Zip_Files {
 				if ( is_wp_error( $nested_entry ) ) {
 					continue;
 				}
-				$nested_form          = GFAPI::get_form( $nested_entry['form_id'] );
+				$nested_form = GFAPI::get_form( $nested_entry['form_id'] );
 				// Add each nested entry files list as a separate array to avoid overriding previously saved files with the same associative array key (the field id).
 				$nested_archive_files = array_merge( $nested_archive_files, array( $this->get_entry_files( $nested_entry, $nested_form ) ) );
 			}

--- a/gravity-forms/gw-zip-files.php
+++ b/gravity-forms/gw-zip-files.php
@@ -80,17 +80,23 @@ class GW_Zip_Files {
 					continue;
 				}
 				$nested_form          = GFAPI::get_form( $nested_entry['form_id'] );
-				$nested_archive_files = array_merge( $nested_archive_files, $this->get_entry_files( $nested_entry, $nested_form ) );
+				// Add each nested entry files list as a separate array to avoid overriding previously saved files with the same associative array key (the field id).
+				$nested_archive_files = array_merge( $nested_archive_files, array( $this->get_entry_files( $nested_entry, $nested_form ) ) );
 			}
 		}
 
-		$archive_files = $this->get_entry_files( $entry, $form );
+		// For conformity with the $nested_archive_files, the current (parent) entry files are also loaded onto an array.
+		$archive_files = array( $this->get_entry_files( $entry, $form ) );
 		$archive_files = array_merge( $archive_files, $nested_archive_files );
 		if ( empty( $archive_files ) ) {
 			return;
 		}
 
-		$archive_file_paths = wp_list_pluck( $archive_files, 'path' );
+		$archive_file_paths = array();
+		foreach ( $archive_files as $archive_file ) {
+			$archive_file_path  = array_values( wp_list_pluck( $archive_file, 'path' ) );
+			$archive_file_paths = array_merge( $archive_file_paths, $archive_file_path );
+		}
 
 		$zip = $this->create_zip( $archive_file_paths, $this->get_zip_paths( $entry, 'path' ) );
 		if ( $zip ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2068662957/40696?folderId=3808239

## Summary

Nested form entries have their uploads overridden on `$nested_archive_files` (associative array in play) which causes only the last nested form entry to be sent via zip. This update first adds all entry files at separate array indexes, then when processing archive files, we pluck and only copy the values to avoid `[path]` overrides when prep-ing the archive files array. This ensure all files from each nested form entry are successfully added to the zip
