### PR TITLE
`gw-multi-file-merge-tag.php`: Added new "markup/container" property for specifying container markup that will contain all file markup.

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -230,12 +230,12 @@ class GW_Multi_File_Merge_Tag {
 			$markup_found = true;
 			$markup       = $file_type_markup['markup'];
 
-			$tags = array(
+			$tags = gf_apply_filters( array( 'gwmfmt_tags', $form_id ), array(
 				'{url}'      => $file,
 				'{filename}' => $filename,
 				'{basename}' => $basename,
 				'{ext}'      => $extension,
-			);
+			), $file, $file_info, $form_id );
 
 			foreach ( $tags as $tag => $tag_value ) {
 				$markup = str_replace( $tag, $tag_value, $markup );

--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -13,7 +13,7 @@
  * Plugin URI:   https://gravitywiz.com/customizing-multi-file-merge-tag/
  * Description:  Enhance the merge tag for multi-file upload fields by adding support for outputting markup that corresponds to the uploaded file.
  * Author:       Gravity Wiz
- * Version:      1.7.5
+ * Version:      1.8
  * Author URI:   https://gravitywiz.com
  */
 class GW_Multi_File_Merge_Tag {
@@ -48,9 +48,10 @@ class GW_Multi_File_Merge_Tag {
 			'form_id'        => false,
 			'field_ids'      => array(),
 			'exclude_forms'  => array(),
-			'default_markup' => '<li><a href="{url}">{filename}.{ext}</a></li>',
+			'default_markup' => '<a href="{url}">{filename}.{ext}</a>',
 			'formats'        => array( 'html' ),
 			'markup'         => array(
+				'container'      => false,
 				array(
 					'file_types' => array( 'jpg', 'jpeg', 'png', 'gif' ),
 					'markup'     => '<img src="{url}" width="33%" />',
@@ -162,6 +163,13 @@ class GW_Multi_File_Merge_Tag {
 
 			$has_value = ! empty( $value );
 
+			if ( $has_value ) {
+				$markup_settings = $this->get_markup_settings( $form['id'] );
+				if ( $markup_settings['container'] ) {
+					$value = sprintf( $markup_settings['container'], $value );
+				}
+			}
+
 			// Replace each instance of our merge tag individually so we can check if it is part of a [gf conditional]
 			// shortcode; if so, replace the value with 1 so it can correctly evaluate as having a value.
 			do {
@@ -208,6 +216,11 @@ class GW_Multi_File_Merge_Tag {
 		$markup_found = false;
 
 		foreach ( $markup_settings as $file_type_markup ) {
+
+			// Some properties like "container" are not arrays.
+			if ( ! is_array( $file_type_markup ) ) {
+				continue;
+			}
 
 			$file_types = array_map( 'strtolower', $file_type_markup['file_types'] );
 			if ( ! in_array( strtolower( $extension ), $file_types, true ) ) {


### PR DESCRIPTION
- Added new "markup/container" property for specifying container markup that will contain all file markup.
- Added `gwmfmt_tags` filter for creating custom tags (like {filesize}). 
- Fixed issue in default markup.

## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2065421606/40617/

## Summary

Customer wanted to more easily define a container as part of her Multi-file Merge Tag template and also to include the file's file size in the generated markup.

This snippet uses the new `gwmfmt_tags` filter to add a custom tag for {filesize} which renders the filesize in kb's.

```php
add_filter( 'gwmfmt_tags_123', function( $tags, $file ) {
	$tags['{filesize}'] = round( filesize( GFFormsModel::get_physical_file_path( $file ) ) / 1000 ) . 'KB';
	return $tags;
}, 10, 2 );
```

Example of the configuration that uses both new options:

```php
gw_multi_file_merge_tag()->register_settings( array(
	'form_id' => 2,
	'field_ids' => array( 4 ),
	'markup' => array(
		'container' => '<ul>%s</ul>',
		array(
			'file_types' => array( 'jpg', 'jpeg', 'png', 'gif' ),
			'markup'     => ' <li class="gw-file gw-image gw-{ext}" style="width: 100px; height: 100px;"> <a href="{url}"><img src="{url}"></a> <a href="{url}">{filename} ({filesize})</a> </li> '
		)
	)
) );
```