### PR TITLE
`gw-zip-files.php`: Updated snippet to ensure zip has renamed file names done with GP File Renamer.

### DIFF
--- a/gravity-forms/gw-zip-files.php
+++ b/gravity-forms/gw-zip-files.php
@@ -43,7 +43,7 @@ class GW_Zip_Files {
 		add_filter( 'gform_entry_meta', array( $this, 'register_entry_meta' ), 10, 2 );
 		add_filter( 'gform_entries_field_value', array( $this, 'modify_zip_display_value' ), 10, 3 );
 
-		add_action( 'gform_entry_created', array( $this, 'archive_files' ), 10, 2 );
+		add_filter( 'gform_entry_post_save', array( $this, 'archive_files' ), 10, 2 );
 		add_filter( 'gform_notification', array( $this, 'add_zip_as_attachment' ), 10, 3 );
 		add_filter( 'gform_replace_merge_tags', array( $this, 'all_files_merge_tag' ), 10, 7 );
 		add_filter( 'gform_replace_merge_tags', array( $this, 'zip_url_merge_tag' ), 10, 3 );
@@ -67,7 +67,7 @@ class GW_Zip_Files {
 	public function archive_files( $entry, $form ) {
 
 		if ( ! $this->is_applicable_form( $form ) || ! $this->has_applicable_field( $form ) ) {
-			return;
+			return $entry;
 		}
 
 		$nested_entries       = $this->get_nested_entries( $entry, $form );
@@ -89,7 +89,7 @@ class GW_Zip_Files {
 		$archive_files = array( $this->get_entry_files( $entry, $form ) );
 		$archive_files = array_merge( $archive_files, $nested_archive_files );
 		if ( empty( $archive_files ) ) {
-			return;
+			return $entry;
 		}
 
 		$archive_file_paths = array();
@@ -103,6 +103,7 @@ class GW_Zip_Files {
 			gform_update_meta( $entry['id'], $this->get_meta_key(), $this->get_zip_paths( $entry, 'url' ) );
 		}
 
+		return $entry;
 	}
 
 	/**


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2068662957/40696?folderId=3808239

## Summary

The `archive_files` method for the zip files snippet was hooked on `gform_entry_created`. The file renamer does the file renaming hooked at `gform_entry_post_save`. While the file entry still got the nested form renamed file pattern (entry save processed), the parent form did not because the zip was getting created before the file renamer operation was executed. The update here just makes the `archive_files` method execute on the same hook as the file rename operation but slightly later. The File Renamer has its filter hook call at priority 9, the snippet here does it at priority 10.