### PR TITLE
`gpecf-deduct-deposit.php`: Updated snippet to prevent fatal error when Gravity Forms is disabled.

### DIFF
--- a/gp-ecommerce-fields/gpecf-deduct-deposit.php
+++ b/gp-ecommerce-fields/gpecf-deduct-deposit.php
@@ -12,7 +12,7 @@
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-ecommerce-fields/
  * Description:  This snippet uses a Produdct field to create a deposit field and deducts the deposit from Order Summary
  * Author:       Gravity Wiz
- * Version:      0.2
+ * Version:      0.3
  * Author URI:   https://gravitywiz.com
  */
 class GW_Deduct_Deposit {
@@ -31,7 +31,7 @@ class GW_Deduct_Deposit {
 
 	public function init() {
 
-		if ( ! function_exists( 'gp_ecommerce_fields' ) ) {
+		if ( ! class_exists( 'Gravity_Forms' ) || ! function_exists( 'gp_ecommerce_fields' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2075899506/40995?folderId=3808239

## Summary

Check for Gravity Forms before initializing to prevent fatal errors, if Gravity Forms is not enabled.
