### PR TITLE
`gw-populate-date.php`: Updated snippet to fix the hour 12 not updating to PM with arithmetic.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1716,6 +1716,9 @@ class GW_Populate_Date {
 									} else if ( hours > 12 ) {
 										hours -= 12;
 										isPM   = true;
+									} else if ( hours == 12 ) {
+										// for 12 PM, the PM display should update
+										isPM = true;
 									}
 								}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2076433976/41028?folderId=3808239

## Summary

When the desired populate date arithmetic was computing Hours 1 and onwards, the AM to PM conversion happened fine. The only issue was with Hour 12. This PR adds a condition to the logic to check the hour "12" when AM to PM swap should occur.