### PR TITLE
`gw-require-unique-values.php`: Updated snippet to support checking over unique values on columns for List field type.

### DIFF
--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -29,7 +29,7 @@ class GW_Require_Unique_Values {
 		) );
 
 		// No validation when the field id list is empty.
-		if ( ! $this->_args['field_ids'] ) {
+		if ( empty( $this->_args['field_ids'] ) ) {
 			return;
 		}
 
@@ -99,9 +99,9 @@ class GW_Require_Unique_Values {
 		$is_unique = true;
 
 		// Multi-Column List
-		if ( is_array( $value[0] ) ) {
+		if ( is_array( rgar( $value, 0 ) ) ) {
 			foreach ( array_keys( $value[0] ) as $column_name ) {
-				$column_values = array_column( $value, $column_name );
+				$column_values = wp_list_pluck( $value, $column_name );
 				// Count unique values in each column.
 				if ( $rows != count( array_unique( $column_values ) ) ) {
 					$is_unique = false;

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -28,6 +28,11 @@ class GW_Require_Unique_Values {
 			'case_sensitive'      => false,
 		) );
 
+		// No validation when the field id list is empty.
+		if ( ! $this->_args['field_ids'] ) {
+			return;
+		}
+
 		$this->_args['master_field_id'] = array_shift( $this->_args['field_ids'] );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -111,7 +116,7 @@ class GW_Require_Unique_Values {
 
 		if ( $result['is_valid'] && ! $is_unique ) {
 			$result['is_valid'] = false;
-			$result['message']  = $this->_args['validation_message'] . ' All columns should have unique values.';
+			$result['message']  = $this->_args['validation_message'];
 		}
 
 		return $result;
@@ -186,7 +191,7 @@ class GW_Require_Unique_Values {
 	public function is_applicable_field( $field ) {
 
 		// A single list field can be used for validation (validation logic to use unique values check over columns).
-		if ( ! $this->_args['field_ids'] && $field->get_input_type() == 'list' ) {
+		if ( $field->id == $this->_args['master_field_id'] && ! $this->_args['field_ids'] && $field->get_input_type() == 'list' ) {
 			return true;
 		} elseif ( ! $this->_args['field_ids'] ) {
 			return false;

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -92,10 +92,19 @@ class GW_Require_Unique_Values {
 	public function validate_list( $result, $value ) {
 		$rows      = count( $value );
 		$is_unique = true;
-		foreach ( array_keys( $value[0] ) as $column_name ) {
-			$column_values = array_column( $value, $column_name );
-			// Count unique values in each column.
-			if ( $rows != count( array_unique( $column_values ) ) ) {
+
+		// Multi-Column List
+		if ( is_array( $value[0] ) ) {
+			foreach ( array_keys( $value[0] ) as $column_name ) {
+				$column_values = array_column( $value, $column_name );
+				// Count unique values in each column.
+				if ( $rows != count( array_unique( $column_values ) ) ) {
+					$is_unique = false;
+				}
+			}
+		} else {
+			// Count unique values in the Single Column List.
+			if ( $rows != count( array_unique( $value ) ) ) {
 				$is_unique = false;
 			}
 		}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2084259592/41399?folderId=3808239

## Summary

By default, the snippet is designed to compare the values in two different fields and confirm that they are different.

This alters the behavior if a single field ID is passed and that field is a List field, we would process it for unique values over columns. For example,

A | B | C
A | D | E
Fails. A is present multiple times in the first column.

A | B | C
D | A | E
Passes. A is present multiple times but in different columns.
