### PR TITLE
`gpcc-selectively-copy-based-on-radio-choice.js`: Added a snippet toselectively copy cat values.

### DIFF
--- a/gp-copy-cat/gpcc-selectively-copy-based-on-radio-choice.js
+++ b/gp-copy-cat/gpcc-selectively-copy-based-on-radio-choice.js
@@ -1,0 +1,31 @@
+/**
+* Gravity Perks // Copy Cat // Selectively Copy Based on Radio Button Choice
+* https://gravitywiz.com/documentation/gravity-forms-copy-cat/
+*
+* By default, the value of a source field is always fixed.
+* Use this snippet to target different source fields by specifying the source field IDs as choices of a radio button trigger field.
+*
+* Instructions:
+* 1. Install our free Custom Javascript for Gravity Forms plugin. 
+*    Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
+* 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+*/
+gform.addFilter( 'gpcc_copied_value', function( value, $elem, data ) {
+
+    // Get the radio button trigger field ID.
+	var trigger = data['trigger'];
+
+    // Check on all the radio button choices.
+	var radioButtons = $( 'input[id^=choice_GFFORMID_' + trigger + ']' );
+
+    // Loop and check which field should be used as the value to copy (based on the radio button selection)
+	$.each( radioButtons, function (i, radio) {
+		if ( radio.checked ) {
+			var newSourceId = $( radio ).val();
+			var newValue = $( '#input_GFFORMID_' + newSourceId ).val();
+			value = newValue;
+		}
+	});
+    
+    return value;
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2085288395/41436?folderId=3808239

https://www.loom.com/share/93e760f1004d402289151c57af780889

## Summary

The source field for the copy cat operation is static by default, this snippet gives the capability of dynamically selecting the source field over a radio button choice list. Ensure the field IDs are stored on the radio button values, the ones which need to be targetted for copying.
