### PR TITLE
`gpns-gravityview-notifications-on-approve.php`: Added a snippet for GravityView Notification Trigger.

### DIFF
--- a/gp-notification-scheduler/gpns-gravityview-notifications-on-approve.php
+++ b/gp-notification-scheduler/gpns-gravityview-notifications-on-approve.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Gravity Wiz // Notification Scheduler // Support Gravity View Notification Triggers
+ * https://gravitywiz.com/documentation/gravity-forms-notification-scheduler/
+ *
+ * Use this snippet when using Gravity View Notification Trigger with Gravity Perks Notification Scheduler.
+ */
+add_filter( 'gpns_schedule_timestamp', function ( $timestamp, $notification, $entry, $is_recurring, $current_time ) {
+	// Only process for GravityView notification events.
+	if ( strpos( $notification['event'], 'gravityview') === false ) {
+		return $timestamp;
+	}
+
+   return time() + 5; // Use current time plus a few seconds to force-schedule GravityView event.
+}, 10, 5 );

--- a/gp-notification-scheduler/gpns-gravityview-notifications-on-approve.php
+++ b/gp-notification-scheduler/gpns-gravityview-notifications-on-approve.php
@@ -7,9 +7,9 @@
  */
 add_filter( 'gpns_schedule_timestamp', function ( $timestamp, $notification, $entry, $is_recurring, $current_time ) {
 	// Only process for GravityView notification events.
-	if ( strpos( $notification['event'], 'gravityview') === false ) {
+	if ( strpos( $notification['event'], 'gravityview' ) === false ) {
 		return $timestamp;
 	}
 
-   return time() + 5; // Use current time plus a few seconds to force-schedule GravityView event.
+	return time() + 5; // Use current time plus a few seconds to force-schedule GravityView event.
 }, 10, 5 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2083497762/41364?folderId=3808239

## Summary

Using GPNS with GravityView's Approve/Disapprove is causing notifications to not send if the notification delay passes before the entry is approved. This snippet approach aims at overriding the notification delay timestamp comparison.
