### PR TITLE
`gpcc-custom-copy-text-to-list.js`: Added snippet to support Auto List Field with Copy Cat on a Text field.

### DIFF
--- a/gp-copy-cat/gpcc-custom-copy-text-to-list.js
+++ b/gp-copy-cat/gpcc-custom-copy-text-to-list.js
@@ -1,0 +1,22 @@
+/**
+* Gravity Perks // Copy Cat // Copy Text Value to List Field's first row without removing other List Rows
+* https://gravitywiz.com/documentation/gravity-forms-copy-cat/
+*
+* Instructions:
+* 1. Install our free Custom Javascript for Gravity Forms plugin. 
+*    Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
+* 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+*/
+gform.addFilter( 'gpcc_custom_copy', function( copyMode, id, sourceGroup, targetGroup, currentField ) {
+	// Get the source text field value.
+	var sourceValue = $(sourceGroup[0]).val();
+	
+	// Get the first list input.
+	var listFirstInput = $('.gfield_list_row_odd').find(':input')[0];
+	
+	// Set the source text field value to the first list input.
+	$( listFirstInput ).val(sourceValue);
+	
+	// Return copyMode as true indicating the default logic for this case is bypassed by the above overriden logic.
+	return true;
+});

--- a/gp-copy-cat/gpcc-custom-copy-text-to-list.js
+++ b/gp-copy-cat/gpcc-custom-copy-text-to-list.js
@@ -11,12 +11,9 @@ gform.addFilter( 'gpcc_custom_copy', function( copyMode, id, sourceGroup, target
 	// Get the source text field value.
 	var sourceValue = $(sourceGroup[0]).val();
 	
-	// Get the first list input.
-	var listFirstInput = $('.gfield_list_row_odd').find(':input')[0];
-	
-	// Set the source text field value to the first list input.
-	$( listFirstInput ).val(sourceValue);
-	
+	// Set the source text field value to the first row of list input.
+	$( '.gfield_list_row_odd' ).find(':input').first().val( sourceValue );
+
 	// Return copyMode as true indicating the default logic for this case is bypassed by the above overriden logic.
 	return true;
 });


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2085199023/41433?folderId=3808239

## Summary

Activating Copy Cat to copy a value to a list field that has Auto List Field active resets the number of list rows. This snippet overrides the standard logic with custom logic to only copy the value, and not reset the number of list rows.

https://www.loom.com/share/6e00d0f1edf54a7e8ff8fa0b38655ffd
