### PR TITLE
`gppa-strip-slashes-from-result-value.php`: Added snippet to strip slashes from GPPA populated value.

### DIFF
--- a/gp-populate-anything/gppa-strip-slashes-from-result-value.php
+++ b/gp-populate-anything/gppa-strip-slashes-from-result-value.php
@@ -3,7 +3,7 @@
  * Gravity Perks // Populate Anything // Strip slashes from result values
  * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
  */
-// Replace "123" with your form ID and "4" with your field ID.
-add_filter( 'gppa_get_input_values_123_4', function ( $value, $field, $template, $objects ) {
+// Replace "123" with your form ID and "5" with your field ID.
+add_filter( 'gppa_get_input_values_123_5', function ( $value, $field, $template, $objects ) {
 	return stripslashes( $value );
 }, 10, 4 );

--- a/gp-populate-anything/gppa-strip-slashes-from-result-value.php
+++ b/gp-populate-anything/gppa-strip-slashes-from-result-value.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Strip slashes from result values
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ */
+// Replace "123" with your form ID and "4" with your field ID.
+add_filter( 'gppa_get_input_values_123_4', function ( $value, $field, $template, $objects ) {
+	return stripslashes( $value );
+}, 10, 4 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2096156781/41821?folderId=3808239

## Summary

Strip slashes from GPPA populated value. Possible enhancements to look at could include running over all fields and detecting the existence of specific patterns of values which need to be decoded/strip slashes from.
