### PR TITLE
`gpfr-allow-commas.php`: Added initial support.

### DIFF
--- a/gp-file-renamer/gpfr-allow-commas.php
+++ b/gp-file-renamer/gpfr-allow-commas.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Gravity Perks // GP File Renamer // Allow Commas in Filenames
+ *
+ * https://gravitywiz.com/documentation/gravity-forms-file-renamer/
+ *
+ * This snippet allows commas (,) in files renamed with GPFR.
+ */
+
+add_filter(
+	'gpfr_sanitize_file_name_chars',
+	function ( $special_chars, $filename_raw ) {
+		return array_filter($special_chars, function ( $char ) {
+			return $char !== ',';
+		} );
+	},
+	10,
+	2
+);


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2103452211/42095/ 

## Summary

* Relies on a new, unreleased filter in GPFR called `gpfr_sanitize_file_name_chars`.
* Removes commas from the list of dissallowed characters when renaming files with GPFR.

