### PR TITLE
`gppa-force-gppa-on-save-and-continue.php`: Added snippet to force GPPA value over a Save & Continue Value.

### DIFF
--- a/gp-populate-anything/gppa-force-gppa-on-save-and-continue.php
+++ b/gp-populate-anything/gppa-force-gppa-on-save-and-continue.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Force GPPA value over a Save & Continue Value
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ */
+add_filter( 'gform_incomplete_submission_post_get', function( $submission_json, $resume_token, $form ) {
+	// Update "29" to your form ID, and "1" to your field ID
+    $target_form_id  = 29;
+    $target_field_id = 1;
+    static $_gppa_forcing_hydration;
+	if ( $form['id'] == $target_form_id && ! $_gppa_forcing_hydration ) {
+        $_gppa_forcing_hydration                          = true;
+		$submission                                       = json_decode( $submission_json, ARRAY_A );
+        $field                                            = GFAPI::get_field( $form, $target_field_id );
+        $hydrated_field                                   = gp_populate_anything()->hydrate_field( $field, $form, array(), null, false );
+		$submission['submitted_values'][$target_field_id] = $hydrated_field['field_value'];
+		$submission_json                                  = json_encode( $submission );
+        $_gppa_forcing_hydration                          = false;
+	}
+	return $submission_json;
+}, 10, 3 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2099104029/41936?folderId=3808239

## Summary

When resuming a Save & Continue session, GPPA-populated fields correctly honor the Save & Continue value. This snippet would force GPPA to repopulate the field, ignoring the Save & Continue value.

The snippet in Action: https://www.loom.com/share/6ccde3a615234810b086a41f3c029f2d

