### PR TITLE
`gw-choice-counter.php`: Added support for counting Radio Button choices.

### DIFF
--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -7,7 +7,7 @@
  * Get the total number of checkboxes checked or multi-select options selected. Useful when wanting to apply conditional
  * logic based on those totals.
  *
- * @version   1.1
+ * @version   1.2
  * @author    David Smith <david@gravitywiz.com>
  * @license   GPL-2.0+
  * @link      http://gravitywiz.com/

--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -75,7 +75,7 @@ class GW_Choice_Count {
 							$parentForm.off( 'click', choiceFieldSelector, self.updateChoiceEventHander );
 							$parentForm.off( 'change', choiceFieldSelector, self.updateChoiceEventHander );
 
-							if ( self.isCheckboxField( $choiceField ) ) {
+							if ( self.isCheckableField( $choiceField ) ) {
 								$parentForm.on( 'click', choiceFieldSelector, self.updateChoiceEventHandler );
 							} else {
 								$parentForm.on( 'change', choiceFieldSelector, self.updateChoiceEventHandler );
@@ -104,8 +104,8 @@ class GW_Choice_Count {
 						} );
 					};
 
-					self.isCheckboxField = function( $field ) {
-						return Boolean( $field.find( 'input[type="checkbox"]' ).length );
+					self.isCheckableField = function($field ) {
+						return Boolean( $field.find( ':checkbox, :radio' ).length );
 					}
 
 					self.updateChoiceCount = function( formId, choiceFieldIds, countFieldId, values ) {
@@ -118,15 +118,15 @@ class GW_Choice_Count {
 							var $choiceField = $( '#input_' + formId + '_' + choiceFieldIds[ i ] );
 							if ( ! values ) {
 								// If no values provided in the config, just get the number of checkboxes checked.
-								if ( self.isCheckboxField( $choiceField ) ) {
-									count += $choiceField.find( 'input[type="checkbox"]:checked' ).not(' #choice_' + choiceFieldIds[ i ] + '_select_all').length;
+								if ( self.isCheckableField( $choiceField ) ) {
+									count += $choiceField.find( ':checked' ).not(' #choice_' + choiceFieldIds[ i ] + '_select_all').length;
 								} else {
 									count += $choiceField.find( 'option:selected' ).length;
 								}
 							} else {
 								// When values are provided, match the values before adding them to count.
 								var selectedValues = [];
-								$choiceField.find( 'input[type="checkbox"]:checked' ).each( function( k, $selectedChoice ) {
+								$choiceField.find( ':checked' ).each( function( k, $selectedChoice ) {
 									selectedValues.push( $selectedChoice.value );
 								});
 								values.forEach( function( val ) {


### PR DESCRIPTION
Can be used to count  the number of Radio Button fields with a specific choice checked (e.g. "N/A").

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2105380160/42151/

## Summary

Customer needed a way to count the number of times an "N/A" choice was selected across a number of Radio Button fields. @saifsultanc recently added support for counting specific choices to this snippet (https://github.com/gravitywiz/snippet-library/pull/586) so it seemed like a natural extension to add support for Radio Buttons.