### PR TITLE
`gflow-force-read-only-not-editable-on-user-input-step.php`: Added snippet to prevent Read Only fields from being editable during Gravity Flow User Input Step.

### DIFF
--- a/gravity-flow/gflow-force-read-only-not-editable-on-user-input-step.php
+++ b/gravity-flow/gflow-force-read-only-not-editable-on-user-input-step.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Gravity Forms // Gravity Flow // Force Read Only Fields to not be editable on User Input Step
+ * https://gravitywiz.com/
+ */
+add_filter( 'gravityflow_editable_fields_user_input', function( $editable_fields, $step ) {
+	foreach ( $editable_fields as $key => $potential ) {
+		$field = GFFormsModel::get_field( $step->get_form_id(), $potential );
+		//Use cases may also want to evaluate $field['isRequired']
+		if ( $field['gwreadonly_enable'] ) {
+			unset( $editable_fields[ $key ] );
+		}
+	}
+
+	return $editable_fields;
+}, 10, 2 );


### PR DESCRIPTION
## Context
The immediate context was that a read-only perk setting is active on a checkbox field which was also set to required. The user input step "correctly" fails the validation when that field is set as editable if the value was not populated. This snippet expands to ensure that any field which is marked as read only does not get included as editable in a user input step.

💬 Slack: https://rocketgenius.slack.com/archives/D0465BGJ2CQ/p1672849144212349

If considering addressing within the read-only plugin, might suggest setting the field isRequired prop to false when readonly is enabled, either automatically in the form editor, or dynamically when submission is processed.