### PR TITLE
`gw-submit-to-access.php`: Added `cookie_expiration` parameter to allow setting a custom expiration for the cookie that tracks which forms have been submitted.

### DIFF
--- a/gravity-forms/gw-submit-to-access.php
+++ b/gravity-forms/gw-submit-to-access.php
@@ -8,7 +8,7 @@
  * Plugin URI:  https://gravitywiz.com/submit-gravity-form-access-content/
  * Description: Require that a form be submitted before a post or page can be accessed.
  * Author:      Gravity Wiz
- * Version:     1.11
+ * Version:     1.12
  * Author URI:  https://gravitywiz.com
  */
 class GW_Submit_Access {
@@ -24,6 +24,7 @@ class GW_Submit_Access {
 			'loading_message'             => '', // set later so we can use GFCommon to get URL to GF spinner,
 			'enable_user_meta'            => false,
 			'is_persistent'               => true,
+			'cookie_expiration'           => null,
 		) );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -355,7 +356,7 @@ class GW_Submit_Access {
 			if ( $this->_args['enable_user_meta'] && is_user_logged_in() ) {
 				update_user_meta( get_current_user_id(), 'gwsa_submitted_forms', $submitted_forms );
 			} else {
-				$expiration = $this->_args['is_persistent'] ? strtotime( '+1 year' ) : null;
+				$expiration = $this->_args['is_persistent'] ? strtotime( '+1 year' ) : $this->_args['cookie_expiration'];
 				setcookie( 'gwsa_submitted_forms', json_encode( $submitted_forms ), $expiration, '/' );
 			}
 		}

--- a/gravity-forms/gw-submit-to-access.php
+++ b/gravity-forms/gw-submit-to-access.php
@@ -356,7 +356,7 @@ class GW_Submit_Access {
 			if ( $this->_args['enable_user_meta'] && is_user_logged_in() ) {
 				update_user_meta( get_current_user_id(), 'gwsa_submitted_forms', $submitted_forms );
 			} else {
-				$expiration = $this->_args['is_persistent'] ? strtotime( '+1 year' ) : $this->_args['cookie_expiration'];
+				$expiration = $this->_args['is_persistent'] ? rgar( $this->_args, 'cookie_expiration', strtotime( '+1 year' ) ) : null;
 				setcookie( 'gwsa_submitted_forms', json_encode( $submitted_forms ), $expiration, '/' );
 			}
 		}


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2114674920/42374

## Summary

Customer required a way to expire the cookie at midnight every night. The new `cookie_expiration` parameter can be configured to do so with the following:

```php
if ( is_callable( 'gw_submit_to_access' ) ) {
	gw_submit_to_access( array(
		'is_persistent' => false,
		'cookie_expiration' => strtotime( 'midnight tomorrow' ),
	) );
}
```
