### PR TITLE
`gw-daily-form-schedule.php`: Updated snippet to skip when schedule start and end dates are set on Form Settings.

### DIFF
--- a/gravity-forms/gw-daily-form-schedule.php
+++ b/gravity-forms/gw-daily-form-schedule.php
@@ -42,6 +42,11 @@ add_filter( 'gform_pre_render', 'gw_daily_form_schedule' );
 add_filter( 'gform_pre_validation', 'gw_daily_form_schedule' );
 function gw_daily_form_schedule( $form ) {
 
+	// Skip "Gravity Forms Daily Form Schedule" for the forms having set schedule start and schedule end date via Form Settings.
+	if ( strstr( $form['scheduleStart'], '/' ) || strstr( $form['scheduleEnd'], '/' ) ) {
+		return $form;
+	}
+
 	$days = array( 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday' );
 
 	if ( rgar( $form, 'scheduleForm' ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2118691329/42505?folderId=3808239

## Summary

Add a check to skip processing for forms having set schedule start and end dates on Form Settings.