### PR TITLE
`gpuid-generate-new-uid-when-duplicated-with-gfapi.php`: Added snippet to regenerate Unique ID for GFAPI created entry.

### DIFF
--- a/gp-unique-id/gpuid-generate-new-uid-when-duplicated-with-gfapi.php
+++ b/gp-unique-id/gpuid-generate-new-uid-when-duplicated-with-gfapi.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Perks // Unique ID // Generate Unique ID when Entry is Duplicated in GravityView
+ * Gravity Perks // Unique ID // Generate Unique ID when Entry is Duplicated using GFAPI.
  * https://gravitywiz.com/documentation/gp-unique-id/
  *
  * When an entry is duplicated using GFAPI, the Unique ID value is copied to the duplicated entry.

--- a/gp-unique-id/gpuid-generate-new-uid-when-duplicated-with-gfapi.php
+++ b/gp-unique-id/gpuid-generate-new-uid-when-duplicated-with-gfapi.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Gravity Perks // Unique ID // Generate Unique ID when Entry is Duplicated in GravityView
+ * https://gravitywiz.com/documentation/gp-unique-id/
+ *
+ * When an entry is duplicated using GFAPI, the Unique ID value is copied to the duplicated entry.
+ * This snippet generates a new unique ID value for the duplicated entry.
+ */
+add_action( 'gform_post_add_entry', 'gw_regenerate_uid_for_duplicate_entry', 10, 2 );
+function gw_regenerate_uid_for_duplicate_entry( $entry, $form ) {
+	// Only process entry for a targeted form.
+	if ( $form['id'] != 165 ) {
+		return;
+	}
+
+	foreach ( $form['fields'] as $field ) {
+		if ( is_a( $field, 'GF_Field_Unique_ID' ) ) {
+			$uid = gp_unique_id()->get_unique( $form['id'], $field );
+			GFAPI::update_entry_field( $entry['id'], $field->id, $uid );
+			$entry[ $field->id ] = $uid;
+		}
+	}
+}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2126485010/42870/

## Summary

Inspired by [snippet](https://github.com/gravitywiz/snippet-library/blob/7dee45a52df562d9574b64d4a021aea0a95850b3/gp-unique-id/gpuid-generate-new-uid-when-duplicated.php), this snippet regenerates UID for newly created entries via GFAPI - this will get a unique ID for duplicated entries.
