### PR TITLE
`gw-update-posts.php`: Added support to update post date and time.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -97,7 +97,7 @@ class GW_Update_Posts {
 			$time = $this->_args['date_time']['time'];
 
 			$date = rgar( $entry, $date );
-			$time = rgar( $entry, $time );
+			$time = rgar( $entry, $time, '00:00 am' );
 
 			if ( empty( $date ) ) {
 				$date = explode( ' ', $post->post_date )[0];
@@ -108,12 +108,9 @@ class GW_Update_Posts {
 				if ( strtolower( $am_pm ) == 'pm' ) {
 					$hour += 12;
 				}
-			} else {
-				$hour = '00';
-				$min  = '00';
 			}
 
-			$new_date_time       = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$new_date_time       = gmdate( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
 			$post->post_date     = $new_date_time;
 			$post->post_date_gmt = get_gmt_from_date( $new_date_time );
 		}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -92,6 +92,31 @@ class GW_Update_Posts {
 			$post->post_name = rgar( $entry, $this->_args['slug'] );
 		}
 
+		if ( $this->_args['date_time'] ) {
+			$date = $this->_args['date_time']['date'];
+			$time = $this->_args['date_time']['time'];
+
+			$date = rgar( $entry, $date );
+			$time = rgar( $entry, $time );
+
+			if ( empty( $date ) ) {
+				$date = explode( ' ', $post->post_date )[0];
+			}
+
+			if ( $time ) {
+				list( $hour, $min, $am_pm ) = array_pad( preg_split( '/[: ]/', $time ), 3, false );
+				if ( strtolower( $am_pm ) == 'pm' ) {
+					$hour += 12;
+				}
+			} else {
+				$hour = '00';
+				$min  = '00';
+			}
+
+			$new_date_time   = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$post->post_date = $new_date_time;
+		}
+
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {
 			if ( rgar( $entry, $this->_args['featured_image'] ) ) {
 				$image_id = gp_media_library()->get_file_ids( $entry['id'], $this->_args['featured_image'], 0 );

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -113,8 +113,9 @@ class GW_Update_Posts {
 				$min  = '00';
 			}
 
-			$new_date_time   = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
-			$post->post_date = $new_date_time;
+			$new_date_time       = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$post->post_date     = $new_date_time;
+			$post->post_date_gmt = get_gmt_from_date( $new_date_time );
 		}
 
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2128193021/42965?folderId=3775888

## Summary

This pull request adds support for updating the Post date and time using the Date and Time fields, respectively. The parameter to set the post date and time will be an array named date_time, with two keys, namely date and time, and the value set to the date and time field, respectively. 

new GW_Update_Posts( array(
    'form_id' => 123,
    'post_id' => 1,
    'date_time'    => array(
       'date' => 2,
       'time' => 3,
    ),
) );
