### PR TITLE
`gw-multiple-entries-list-field.php`: Updated snippet to send notifications for created entries.

### DIFF
--- a/gravity-forms/gw-multiple-entries-list-field.php
+++ b/gravity-forms/gw-multiple-entries-list-field.php
@@ -60,6 +60,7 @@ class GW_Multiple_Entries_List_Field {
 
 		$data          = maybe_unserialize( $data );
 		$working_entry = $entry;
+		$form          = GFAPI::get_form( $entry['form_id'] );
 
 		if ( ! $this->_args['preserve_list_data'] ) {
 			$working_entry[ $this->_args['field_id'] ] = null;
@@ -91,6 +92,9 @@ class GW_Multiple_Entries_List_Field {
 				gform_add_meta( $entry_id, 'gwmelf_group_entry_id', $entry['id'] );
 
 			}
+
+			// send Gravity Form notifications
+			GFAPI::send_notifications( $form, $working_entry );
 		}
 
 		return $entry;

--- a/gravity-forms/gw-multiple-entries-list-field.php
+++ b/gravity-forms/gw-multiple-entries-list-field.php
@@ -93,8 +93,10 @@ class GW_Multiple_Entries_List_Field {
 
 			}
 
-			// send Gravity Form notifications
-			GFAPI::send_notifications( $form, $working_entry );
+			// send Gravity Forms notifications, if enabled
+			if ( $this->_args['send_notifications'] ) {
+				GFAPI::send_notifications( $form, $working_entry );
+			}
 		}
 
 		return $entry;
@@ -151,4 +153,5 @@ new GW_Multiple_Entries_List_Field( array(
 	),
 	'preserve_list_data' => true,
 	'append_list_data'   => true,
+	'send_notifications' => false,
 ) );


### PR DESCRIPTION
# Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2128964925/42994?folderId=7098280

## Summary

The snippet creates entries from the list fields as per the field mapping rules defined. However, any notifications assigned under Gravity Forms Settings are not fired. This snippet adds the call to Gravity Forms notifications to fire them if they are defined under settings.