### PR TITLE
Alter validation and code example at bottom to support the 2 state abbr

### DIFF
--- a/gravity-forms/gw-restrict-states-in-address-fields.php
+++ b/gravity-forms/gw-restrict-states-in-address-fields.php
@@ -62,7 +62,8 @@ class GW_Restrict_States_In_Address_Field {
 				continue;
 			}
 
-			if ( in_array( $selected_state, $this->_args['allowed_states'], true ) ) {
+			if ( in_array( $selected_state, $this->_args['allowed_states'], true )
+			  || array_key_exists( $selected_state, $this->_args['allowed_states'])) {
 				continue;
 			}
 
@@ -138,6 +139,14 @@ class GW_Restrict_States_In_Address_Field {
 //	'allowed_states' => array(
 //		'California',
 //		'Iowa',
+//	),
+//) );
+// Or when value is different, like using gform_us_states
+// (2 letter state values, full state name label).
+//new GW_Restrict_States_In_Address_Field( array(
+//	'allowed_states' => array(
+//		'CA' => 'California',
+//		'IA' => 'Iowa',
 //	),
 //) );
 


### PR DESCRIPTION
Alter validation and code example at bottom to support the 2 state abbreviation as key such as in example 1 of gform_us_states (https://docs.gravityforms.com/gform_us_states/).
