### PR TITLE
Update post date with either a date or time or both.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -97,7 +97,7 @@ class GW_Update_Posts {
 			$time = $this->_args['date_time']['time'];
 
 			$date = rgar( $entry, $date );
-			$time = rgar( $entry, $time );
+			$time = rgar( $entry, $time, '00:00 am' );
 
 			if ( empty( $date ) ) {
 				$date = explode( ' ', $post->post_date )[0];
@@ -108,12 +108,9 @@ class GW_Update_Posts {
 				if ( strtolower( $am_pm ) == 'pm' ) {
 					$hour += 12;
 				}
-			} else {
-				$hour = '00';
-				$min  = '00';
 			}
 
-			$new_date_time       = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$new_date_time       = gmdate( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
 			$post->post_date     = $new_date_time;
 			$post->post_date_gmt = get_gmt_from_date( $new_date_time );
 		}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -92,6 +92,31 @@ class GW_Update_Posts {
 			$post->post_name = rgar( $entry, $this->_args['slug'] );
 		}
 
+		if ( $this->_args['date_time'] ) {
+			$date = $this->_args['date_time']['date'];
+			$time = $this->_args['date_time']['time'];
+
+			$date = rgar( $entry, $date );
+			$time = rgar( $entry, $time );
+
+			if ( empty( $date ) ) {
+				$date = explode( ' ', $post->post_date )[0];
+			}
+
+			if ( $time ) {
+				list( $hour, $min, $am_pm ) = array_pad( preg_split( '/[: ]/', $time ), 3, false );
+				if ( strtolower( $am_pm ) == 'pm' ) {
+					$hour += 12;
+				}
+			} else {
+				$hour = '00';
+				$min  = '00';
+			}
+
+			$new_date_time   = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$post->post_date = $new_date_time;
+		}
+
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {
 			if ( rgar( $entry, $this->_args['featured_image'] ) ) {
 				$image_id = gp_media_library()->get_file_ids( $entry['id'], $this->_args['featured_image'], 0 );

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -113,8 +113,9 @@ class GW_Update_Posts {
 				$min  = '00';
 			}
 
-			$new_date_time   = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
-			$post->post_date = $new_date_time;
+			$new_date_time       = date( 'Y-m-d H:i:s', strtotime( sprintf( '%s %s:%s:00', $date, $hour, $min ) ) );
+			$post->post_date     = $new_date_time;
+			$post->post_date_gmt = get_gmt_from_date( $new_date_time );
 		}
 
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -27,6 +27,7 @@ class GW_Update_Posts {
 				'terms'           => array(),
 				'meta'            => array(),
 				'featured_image'  => false,
+				'post_date'       => false,
 				// If property is mapped but no entry value is submitted, delete the property.
 				// Currently only works with 'featured_image' and custom fields specified in 'meta'.
 				'delete_if_empty' => false,
@@ -92,16 +93,24 @@ class GW_Update_Posts {
 			$post->post_name = rgar( $entry, $this->_args['slug'] );
 		}
 
-		if ( $this->_args['date_time'] ) {
-			$date = $this->_args['date_time']['date'];
-			$time = $this->_args['date_time']['time'];
+		if ( $this->_args['post_date'] ) {
+			$post_date = array();
+			if ( ! is_array( $this->_args['post_date'] ) ) {
 
-			$date = rgar( $entry, $date );
-			$time = rgar( $entry, $time, '00:00 am' );
-
-			if ( empty( $date ) ) {
-				$date = explode( ' ', $post->post_date )[0];
+				$field_one = GFAPI::get_field( $form, $this->_args['post_date'] );
+				if ( $field_one->get_input_type() === 'date' ) {
+					$post_date['date'] = $this->_args['post_date'];
+					$post_date['time'] = '';
+				} elseif ( $field_one->get_input_type() === 'time' ) {
+					$post_date['time'] = $this->_args['post_date'];
+					$post_date['date'] = '';
+				}
+			} else {
+				$post_date = $this->_args['post_date'];
 			}
+
+			$date = rgar( $entry, $post_date['date'], gmdate( 'm/d/Y' ) );
+			$time = rgar( $entry, $post_date['time'], '00:00 am' );
 
 			if ( $time ) {
 				list( $hour, $min, $am_pm ) = array_pad( preg_split( '/[: ]/', $time ), 3, false );

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -211,8 +211,6 @@ class GW_Update_Posts {
 
 	public function get_post_date( $entry, $form ) {
 
-		$post_date = $this->_args['post_date'];
-
 		if ( ! is_array( $this->_args['post_date'] ) ) {
 			$post_date_field = GFAPI::get_field( $form, $this->_args['post_date'] );
 			if ( $post_date_field->get_input_type() === 'date' ) {


### PR DESCRIPTION
## Context
https://www.notion.so/gravitywiz/Update-How-to-Update-Posts-Update-Posts-Date-and-Time-2c6804a35da642eba85b49ffaec5b2aa

Added support to set the post date with a single value like 11 which can be a Date or Time field ID. If it is a Date field, the time is set to midnight. If it is a Time field, the date is set to the current date. 

new GW_Update_Posts( array(
	'form_id' => 123,
	'post_id' => 1,
	'post_date'  => 11, // This can be either the Date or Time field ID.
) );

It also supports setting the Post date with an array of Date and Time field IDs like so

new GW_Update_Posts( array(  
        'form_id' => 123,  
        'post_id' => 1,  
        'post_date' => array(  
                        'date' => 11,  
                        'time' => 12,  
        ),  
) );