### PR TITLE
`gppa-populate-all-results.php`: Updated to call `process_template()` so each object value is passed through all template filters.

### DIFF
--- a/gp-populate-anything/gppa-populate-all-results.php
+++ b/gp-populate-anything/gppa-populate-all-results.php
@@ -10,10 +10,13 @@
  * CSS Class Name setting.
  */
 add_filter( 'gppa_process_template_value', function( $template_value, $field, $template_name, $populate, $object, $object_type, $objects, $template ) {
-	if ( strpos( $field->cssClass, 'gppa-populate-all' ) !== false ) {
-		$values = array();
+	if ( ! empty( $objects ) && strpos( $field->cssClass, 'gppa-populate-all' ) !== false ) {
+		$values = array( $template_value );
 		foreach ( $objects as $_object ) {
-			$values[] = $object_type->get_object_prop_value( $_object, $template );
+			if ( $_object === $object ) {
+				continue;
+			}
+			$values[] = gp_populate_anything()->process_template( $field, $template_name, $_object, $populate, array() );
 		}
 		$template_value = implode( ', ', $values );
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2135407267/43315/

## Summary

Customer was attempting to use our "Populate All Results" snippet to populate all the names entered in a Name field across multiple child entries as a comma-delimited list in a Single Line Text field.

Previously, the snippet used the `$object_type->get_object_prop_value()` method which did not correctly handle joining the values for multi-input field's like Name fields. The `GPPA_Object_Type_GF_Entry::maybe_combine_multi_input_entry_template()` method bound to the `gppa_process_template` filter does but we need to call `GP_Populate_Anything::process_template()` to fetch the value so that it can be automatically applied.

@claygriffiths My specific concern here is just performance. I've already done my best to mitigate as much damage as possible but wanted to get your sign off that this won't be overly burdensome?
