### PR TITLE
`gw-update-posts.php`: Fixed an issue where the post time would not be updated if directly passing a Time field's ID in the snippet config.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -4,7 +4,7 @@
  *
  * Update existing post title, content, author and custom fields with values from Gravity Forms.
  *
- * @version 0.4.2
+ * @version 0.4.3
  * @author  Scott Buchmann <scott@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -220,6 +220,9 @@ class GW_Update_Posts {
 				$post_date['time'] = $this->_args['post_date'];
 				$post_date['date'] = '';
 			}
+		} else {
+			$post_date['date'] = $this->_args['post_date']['date'];
+			$post_date['time'] = $this->_args['post_date']['time'];
 		}
 
 		$date = rgar( $entry, $post_date['date'], gmdate( 'm/d/Y' ) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2149126204/43950?folderId=3808239

## Summary

On debugging, I found that `$post_date` array wasnt' populated with the `date` and `time` values (for the case when we have both date and time passed with the snippet). This update just adds those missing values.

A simple form export is attached. How I tested it:

new GW_Update_Posts( array(
	'form_id' => 221,
	'post_id' => 1,
	'post_date' => array(
			'date' => 3,
			'time' => 4,
	),
) );

To test, please update form_id and post_id as per your local setup.

[gravityforms-export-2023-02-08.json.zip](https://github.com/gravitywiz/snippet-library/files/10686402/gravityforms-export-2023-02-08.json.zip)
