### PR TITLE
`gw-currency-symbol-right-to-left.php`: Updated to include `code` parameter.

### DIFF
--- a/gravity-forms/gw-currency-symbol-right-to-left.php
+++ b/gravity-forms/gw-currency-symbol-right-to-left.php
@@ -12,6 +12,7 @@ add_filter( 'gform_currencies', function( $currencies ) {
 		'thousand_separator' => '.',
 		'decimal_separator'  => ',',
 		'decimals'           => 2,
+		'code'               => 'EUR',
 	);
 	return $currencies;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2154262234/44174?folderId=2844288

## Summary

Gravity Forms includes the `code` parameter in `gform_currencies`. Updating the snippet to also include that parameter.