### PR TITLE
`gw-random-fields.php`: Fixed an issue with pages not getting hidden.

### DIFF
--- a/gravity-forms/gw-random-fields.php
+++ b/gravity-forms/gw-random-fields.php
@@ -193,6 +193,8 @@ class GFRandomFields {
 	 * @return int|mixed
 	 */
 	public function modify_target_page( $page_number, $form, $current_page ) {
+		// Prevent recursion when getting info below.
+		remove_filter( "gform_target_page_{$form['id']}", array( $this, 'modify_target_page' ) );
 
 		$page_number = intval( $page_number );
 		$form        = $this->pre_render( $form );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2152014628/44086?folderId=3808239

## Summary

The next page requests weren't loading. On debugging, found a recursive/repeated call to `modify_target_page` which on repeating back at page number 2. Added the remove_filter for that to avoid the issue.

Also confirmed that the pages that should be hidden (because no field) are in fact hidden.

Possible future improvements to look at: For a form with 8 pages and only 4 made visible, the page numbers would display something like 'Step 1 of 8' then 'Step 2 of 8' then 'Step 7 of 8' and then 'Step 8 of 8'. Could be made better with 'Step 1 of 4', then 'Step 2 of 4', then 'Step 3 of 4', and then 'Step 4 of 4'.
