### PR TITLE
`gpnf-close-modal-on-esc-or-outside-click.js`: Added snippet to close modal when ESC key is pressed, or when mouse clicked outside modal area.

### DIFF
--- a/gp-nested-forms/gpnf-close-modal-on-esc-or-outside-click.js
+++ b/gp-nested-forms/gpnf-close-modal-on-esc-or-outside-click.js
@@ -6,20 +6,16 @@
  *
  * 1. Install this snippet with our free Custom JavaScript plugin.
  *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ * 2. Also add "Load Init Scripts Early" snippet to your theme's functions.php.
+ *    https://github.com/gravitywiz/snippet-library/blob/master/experimental/gfjs-early-init-scripts.php
  */
-// Replace 1 with Nested Form Field ID
-var gpnf = window['GPNestedForms_GFFORMID_1'];
-
-// Close the modal when Escape key is pressed
-document.addEventListener( 'keydown', function( event ) {
-    if ( event.key === 'Escape' ) {
-        gpnf.modal.close();
+window.gform.addFilter( 'gpnf_modal_args', function( args, formId, fieldId, gpnf ) {
+    // Only run for parent form ID 1. Remove this if the behavior is desired for all forms.
+    if ( formId != 1 ) {
+        return args;
     }
-});
 
-// Close the modal when clicking outside the modal box
-$( document ).on( 'click', function (event ) {
-    if ( $( event.target ).hasClass( 'tingle-modal--noOverlayClose' ) ) {
-        gpnf.modal.close();
-    }
-});
+    args.closeMethods = ['overlay', 'button', 'escape'];
+
+    return args;
+} );

--- a/gp-nested-forms/gpnf-close-modal-on-esc-or-outside-click.js
+++ b/gp-nested-forms/gpnf-close-modal-on-esc-or-outside-click.js
@@ -1,0 +1,25 @@
+/**
+ * Gravity Perks // Nested Forms // Close Nested Form modal when ESC key is pressed or when clicked outside modal
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ */
+// Replace 1 with Nested Form Field ID
+var gpnf = window['GPNestedForms_GFFORMID_1'];
+
+// Close the modal when Escape key is pressed
+document.addEventListener( 'keydown', function( event ) {
+    if ( event.key === 'Escape' ) {
+        gpnf.modal.close();
+    }
+});
+
+// Close the modal when clicking outside the modal box
+$( document ).on( 'click', function (event ) {
+    if ( $( event.target ).hasClass( 'tingle-modal--noOverlayClose' ) ) {
+        gpnf.modal.close();
+    }
+});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2158727063/44397?folderId=3808239

## Summary

Close the modal when either escape key is pressed, or any click is done outside the modal area.

Here is how it works (~15 seconds):
https://www.loom.com/share/ab0e3a42d9a64652bd485840c218d459
