### PR TITLE
`gpasc-radio-button-toggle.js`: Added snippet to toggle GPASC auto save client side using radio buttons.

### DIFF
--- a/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
+++ b/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
@@ -6,15 +6,14 @@
  * 
  * Instructions:
  *  1. Add snippet to form using https://gravitywiz.com/gravity-forms-custom-javascript/
- *  2. Customize formId for the form you want this to apply to.
- *  3. Customize radioButtonFieldId to the field you want this to apply to.
- *  4. Customize enableInputId and disableInputId per the comments above each variable.
+ *  2. Customize radioButtonFieldId to the field you want this to apply to.
+ *  3. Customize enableInputId and disableInputId per the comments above each variable.
  */
 
 // change this to match your form ID
-var formId = 1;
+var formId = GFFORMID;
 // change this to match the radio button field you'd like to use to control this
-var radioButtonFieldId = 2;
+var radioButtonFieldId = 1;
 // change this to match the radio button input ID you'd like to use to enable GPASC
 var enableInputId = 0;
 // change this to match the radio button input ID you'd like to use to disable GPASC
@@ -36,12 +35,9 @@ function disableGPASC() {
   }
 }
 
-var enabledRadioButton = $(enabledSelector)[0];
-var disabledRadioButton = $(disabledSelector)[0];
-
-if (enabledRadioButton && enabledRadioButton.checked ) {
+if ($(enabledSelector).prop('checked')) {
 	enableGPASC()
-} else if (disabledRadioButton && disabledRadioButton.checked) {
+} else if ($(disabledSelector).prop('checked')) {
 	disableGPASC();
 }
 

--- a/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
+++ b/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
@@ -1,0 +1,52 @@
+/**
+ * Gravity Perks // Advanced Save and Continue // Toggle GPASC with Radio Buttons
+ * https://gravitywiz.com/documentation/gravity-forms-advanced-save-continue/
+ *
+ * This snippet allows you to toggle GPASC client side with radio buttons.
+ */
+
+// change this to match your form ID
+var formId = 1;
+// change this to match the radio button field you'd like to use to control this
+var radioButtonFieldId = 2;
+// change this to match the radio button input ID you'd like to use to enable GPASC
+var enableInputId = 0;
+// change this to match the radio button input ID you'd like to use to disable GPASC
+var disableInputId = 1;
+
+var gpascInstanceKey = 'GPASC_' + formId;
+var enabledSelector = '#choice_' + formId + '_' + radioButtonFieldId + '_' + enableInputId;
+var disabledSelector = '#choice_' + formId + '_' + radioButtonFieldId + '_' + disableInputId;
+
+function enableGPASC() {
+  if (window[gpascInstanceKey] && window[gpascInstanceKey].enable) {
+    window[gpascInstanceKey].enable();
+  }
+}
+
+function disableGPASC() {
+  if (window[gpascInstanceKey] && window[gpascInstanceKey].enable) {
+    window[gpascInstanceKey].disable({ resetCookieModal: true });
+  }
+}
+
+var enabledRadioButton = $(enabledSelector)[0];
+var disabledRadioButton = $(disabledSelector)[0];
+
+if (enabledRadioButton && enabledRadioButton.checked ) {
+	enableGPASC()
+} else if (disabledRadioButton && disabledRadioButton.checked) {
+	disableGPASC();
+}
+
+$(enabledSelector).on('change', function(event) {
+  if (event.target.checked) {
+	enableGPASC();
+  }
+})
+
+$(disabledSelector).on('change', function(event) {
+  if (event.target.checked) {
+	disableGPASC();
+  }
+})

--- a/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
+++ b/gp-advanced-save-and-continue/gpasc-radio-button-toggle.js
@@ -3,6 +3,12 @@
  * https://gravitywiz.com/documentation/gravity-forms-advanced-save-continue/
  *
  * This snippet allows you to toggle GPASC client side with radio buttons.
+ * 
+ * Instructions:
+ *  1. Add snippet to form using https://gravitywiz.com/gravity-forms-custom-javascript/
+ *  2. Customize formId for the form you want this to apply to.
+ *  3. Customize radioButtonFieldId to the field you want this to apply to.
+ *  4. Customize enableInputId and disableInputId per the comments above each variable.
  */
 
 // change this to match your form ID


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2151546100/44070?folderId=6987275 

## Summary

Adds snippet to allow radio buttons to toggle ASC on/off.

See also the required sister code change within GPASC: https://github.com/gravitywiz/gp-advanced-save-and-continue/pull/9
