### PR TITLE
`gpasc-use-dropdown-to-toggle-enabled.js`: Added snippet to enable/disable GPASC based on a dropdown populated value.

### DIFF
--- a/gp-advanced-save-and-continue/gpasc-use-dropdown-to-toggle-enabled.js
+++ b/gp-advanced-save-and-continue/gpasc-use-dropdown-to-toggle-enabled.js
@@ -1,0 +1,54 @@
+/**
+ * Gravity Perks // Advanced Save and Continue // Toggle GPASC with a Dropdown
+ * https://gravitywiz.com/documentation/gravity-forms-advanced-save-continue/
+ *
+ * This snippet allows you to toggle GPASC client side with a dropdown.
+ */
+
+// change this to match your form ID
+var formId = 1;
+// change this to match the dropdown field you'd like to use to control this
+var dropdownFieldId = 1;
+
+var gpascInstanceKey = 'GPASC_' + formId;
+var dropdownSelector = '#input_' + formId + '_' + dropdownFieldId;
+
+function enableGPASC() {
+  if (window[gpascInstanceKey] && window[gpascInstanceKey].enable) {
+    window[gpascInstanceKey].enable();
+  }
+}
+
+function disableGPASC() {
+  if (window[gpascInstanceKey] && window[gpascInstanceKey].enable) {
+    window[gpascInstanceKey].disable({ resetCookieModal: true });
+  }
+}
+
+function getDropdownValue() {
+  return $(dropdownSelector).val();
+}
+
+function shouldEnable() {
+	return getDropdownValue() === '1';
+}
+
+window.gform.addAction('gpasc_js_init', function (formId) {
+	if (formId != formId) {
+		return;
+	}
+
+	if (shouldEnable()) {
+		enableGPASC();
+	} else {
+		disableGPASC();
+	}
+});
+
+$(dropdownSelector).on('change', function(event) {
+	if (event.target.value === '1') {
+		enableGPASC();
+	} else {
+		disableGPASC();
+	}
+});

--- a/gp-advanced-save-and-continue/gpasc-use-dropdown-to-toggle-enabled.js
+++ b/gp-advanced-save-and-continue/gpasc-use-dropdown-to-toggle-enabled.js
@@ -3,12 +3,23 @@
  * https://gravitywiz.com/documentation/gravity-forms-advanced-save-continue/
  *
  * This snippet allows you to toggle GPASC client side with a dropdown.
+ * 
+ * Instructions:
+ *  1. Add snippet to form using https://gravitywiz.com/gravity-forms-custom-javascript/
+ *  2. Customize formId to match the form you want to use this with.
+ *  3. Customize the dropdownFieldId to match the DropdownField you want to use this with.
+ *  4. Customize dropdownEnableValue to the HTML "value" attribute which you want GPASC to
+ *     be enabled with. For example, if you want GPASC to be enabled when a dropdown
+ *     </option> with HTML value of "enabled" is selected, set this to "enabled".
  */
 
 // change this to match your form ID
 var formId = 1;
 // change this to match the dropdown field you'd like to use to control this
 var dropdownFieldId = 1;
+// change this to match the desired "value" (e.g. HTML value attribute) of the Dropdown Field
+// that, when selected, should enable GPASC.
+var dropdownEnableValue = '1';
 
 var gpascInstanceKey = 'GPASC_' + formId;
 var dropdownSelector = '#input_' + formId + '_' + dropdownFieldId;
@@ -30,7 +41,7 @@ function getDropdownValue() {
 }
 
 function shouldEnable() {
-	return getDropdownValue() === '1';
+	return getDropdownValue() === dropdownEnableValue;
 }
 
 window.gform.addAction('gpasc_js_init', function (formId) {
@@ -46,7 +57,8 @@ window.gform.addAction('gpasc_js_init', function (formId) {
 });
 
 $(dropdownSelector).on('change', function(event) {
-	if (event.target.value === '1') {
+	console.log({ event })
+	if (event.target.value === dropdownEnableValue) {
 		enableGPASC();
 	} else {
 		disableGPASC();


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2151546100/44070?folderId=6987275 

## Summary

Allows you to enable/disable GPASC based on the current the `value` of a dropdown field.

:warning: This is reliant on this GPASC change: https://github.com/gravitywiz/gp-advanced-save-and-continue/pull/16

