### PR TITLE
Added support for skipping conditionally hidden Round Robin fields.

### DIFF
--- a/gp-populate-anything/gppa-use-choice-labels-when-populating-from-another-field.php
+++ b/gp-populate-anything/gppa-use-choice-labels-when-populating-from-another-field.php
@@ -3,19 +3,16 @@
  * Gravity Perks // Populate Anything // Populate choices using choice labels rather than values
  * http://gravitywiz.com/documentation/gravity-forms-populate-anything/
  *
- * Instruction Video: https://www.loom.com/share/0a3bc5ea99ee44f6acccceab3737101a
+ * Instruction Video: https://www.loom.com/share/0a3bc5ea99ee44f6acccceab3737101a (Out of date)
  *
- * Installation instructions:
- *   1. https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
- *   2. Update variables below accordingly.
+ * Instructions:
+ *  1. Install the snippet.
+ *     https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *  2. Add "gppa-use-choice-label" to the "Custom CSS Class" field setting of the target field.
  */
 add_filter( 'gppa_process_template', function ( $template_value, $field, $template_name, $populate, $object, $object_type, $objects, $template ) {
-	/* Variables to customize */
-	$populated_form_id  = 3;
-	$populated_field_id = 3;
-	/* End variables to customize */
 
-	if ( $template_name !== 'label' || $field->id !== $populated_field_id || $field->formId !== $populated_form_id ) {
+	if ( $template_name !== 'label' || strpos( $field->cssClass, 'gppa-use-choice-label' ) === false ) {
 		return $template_value;
 	}
 

--- a/gravity-forms/gw-round-robin.php
+++ b/gravity-forms/gw-round-robin.php
@@ -10,7 +10,7 @@
  * employees are assigned to the next available shift, and/or balancing the responsibility of any task-oriented
  * submission (e.g. support request, job application, contest entry).
  *
- * @version  1.5
+ * @version  1.6
  * @author   David Smith <david@gravitywiz.com>
  * @license  GPL-2.0+
  * @link     http://gravitywiz.com/
@@ -64,14 +64,22 @@ class GW_Round_Robin {
 			return $entry;
 		}
 
+		$field = GFAPI::get_field( $entry['form_id'], $this->_args['field_id'] );
+
+		// Ignore if Round Robin field is hidden by conditional logic.
+		if ( GFFormsModel::is_field_hidden( $form, $field, array() ) ) {
+			return $entry;
+		}
+
 		$rotation   = $this->get_rotation_values( $this->_args['field_id'], $form );
-		$last_entry = $this->get_last_entry( $entry, GFAPI::get_field( $entry['form_id'], $this->_args['field_id'] ) );
+		$last_entry = $this->get_last_entry( $entry, $field );
 
 		// Get the value submitted for our designated field in the last entry.
 		$last_value = rgar( $last_entry, $this->_args['field_id'] );
 
 		// Determine the next index at which to fetch our value.
-		$next_index = empty( $last_value ) ? 0 : array_search( $last_value, $rotation ) + 1;
+		$next_index = empty( $last_value ) ? array_search( $entry[ $this->_args['field_id'] ], $rotation ) : array_search( $last_value, $rotation ) + 1;
+
 		if ( $next_index > count( $rotation ) - 1 ) {
 			$next_index = 0;
 		}
@@ -90,7 +98,14 @@ class GW_Round_Robin {
 
 	public function get_last_entry( $entry, $field ) {
 
-		$field_filters = array();
+		// Find the last entry that has a value in our Round Robin field.
+		$field_filters = array(
+			array(
+				'key'      => $this->_args['field_id'],
+				'operator' => 'ISNOT',
+				'value'    => '',
+			),
+		);
 
 		// GPPA integration only supports the first group of filters and filters that are field-specific (no custom values).
 		if ( is_callable( 'gp_populate_anything' ) && $field->{'gppa-choices-enabled'} ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2164237011/44637/

## Summary

Customer wanted support for skipping conditionally hidden Round Robin fields. They had figured out how to skip the hidden field but the Round Robin sequence would restart on the next submission where the Round Robin field was not hidden.

This PR refactors their code and adds support for ensuring the Round Robin sequence is preserved when working with conditional fields.
