### PR TITLE
`gw-populate-date.php`: Fixed an issue with same source and target fields not working with different modifiers.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1864,7 +1864,7 @@ class GW_Populate_Date {
 		);
 
 		$script = 'new GWPopulateDate( ' . json_encode( $args ) . ' );';
-		$slug   = implode( '_', array( 'gw_populate_date', $this->_args['form_id'], $this->_args['source_field_id'], $this->_args['target_field_id'], rgar( $this->_args['modifier'], 'inputId' ) ) );
+		$slug   = implode( '_', array_filter( array( 'gw_populate_date', $this->_args['form_id'], $this->_args['source_field_id'], $this->_args['target_field_id'], rgar( $this->_args['modifier'], 'inputId' ) ) ) );
 
 		GFFormDisplay::add_init_script( $this->_args['form_id'], $slug, GFFormDisplay::ON_PAGE_RENDER, $script );
 

--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1864,7 +1864,7 @@ class GW_Populate_Date {
 		);
 
 		$script = 'new GWPopulateDate( ' . json_encode( $args ) . ' );';
-		$slug   = implode( '_', array( 'gw_populate_date', $this->_args['form_id'], $this->_args['source_field_id'], $this->_args['target_field_id'] ) );
+		$slug   = implode( '_', array( 'gw_populate_date', $this->_args['form_id'], $this->_args['source_field_id'], $this->_args['target_field_id'], rgar( $this->_args['modifier'], 'inputId' ) ) );
 
 		GFFormDisplay::add_init_script( $this->_args['form_id'], $slug, GFFormDisplay::ON_PAGE_RENDER, $script );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2177018899/45180?folderId=3808239

## Summary

The script slug generated only took into account the source field id and target field id. Thus, when we had a scenario wherein the same source and target fields were aimed at, but with different modifier fields only the first one programmatically would work. This adds the modifier input id to the script slug thus resolving the issue.

Here is how it works now:

https://www.loom.com/share/cde9a6c3f69d4be69238a1fc25c586dd
