### PR TITLE
`gw-prevent-duplicate-selections.js`: Improved compatibility with GP Limit Checkboxes.

### DIFF
--- a/gravity-forms/gw-prevent-duplicate-selections.js
+++ b/gravity-forms/gw-prevent-duplicate-selections.js
@@ -1,24 +1,29 @@
 /**
  * Gravity Wiz // Gravity Forms // Prevent Duplicate Selections
  * https://gravitywiz.com/
- * 
+ *
  * Prevent duplicate selections in choice-based fields. Currently works with Checkbox and
  * Radio Button fields with plans to support all choice-based fields (e.g. Drop Downs & Multi Selects).
- * 
- * For Drop Down field support, use this snippet: 
+ *
+ * For Drop Down field support, use this snippet:
  * https://github.com/gravitywiz/snippet-library/blob/master/experimental/gw-prevent-duplicate-drop-down-selections.js
- * 
+ *
  * Instructions:
- * 
+ *
  * 1. Install this snippet with our free Custom JavaScript plugin.
  *    https://gravitywiz.com/gravity-forms-custom-javascript/
  *
  * 2. Add 'gw-prevent-duplicates' to the CSS Class Name setting for any field in which duplicate selections
  *    should be prevented.
  */
+window.gform.addFilter( 'gplc_excluded_input_selectors', function( selectors ) {
+	selectors.push('.gw-disable-duplicates-disabled');
+	return selectors;
+});
+
 $inputs = $( '.gw-prevent-duplicates' ).find( 'input' );
 
-$inputs.click( function() {
+$inputs.change( function() {
 	gwDisableDuplicates( $( this ), $inputs );
 } );
 
@@ -27,15 +32,15 @@ $inputs.each( function() {
 } );
 
 function gwDisableDuplicates( $elem, $group ) {
-	
+
 	let value     = $elem.val();
-	let $targets  = $group.not( $elem );
+	let $targets  = $group.not( $elem ).not( '.gplc-disabled' );
 	let isChecked = $elem.is( ':checked' );
 	// We use this to instruct Gravity Forms not to re-enable disabled duplicate options when
 	// that option is revealed by conditional logic.
-	let disabledClass = 'gf-default-disabled';
+	let disabledClass = 'gf-default-disabled gw-disable-duplicates-disabled';
 	let previousValue;
-	
+
 	// Only one choice can be selected in a Radio Button field while multiple choices
 	// can be selected in a Checkbox field. This logic handles saving/retrieving the previous
 	// value and re-enabling inputs with the previous value.
@@ -44,20 +49,20 @@ function gwDisableDuplicates( $elem, $group ) {
 		$elem.parents( '.gfield' ).data( 'previous-value', $elem.val() );
 		if ( previousValue ) {
 			$targets
-			.filter( '[value="{0}"]'.format( previousValue ) )
-			.prop( 'disabled', false )
-			.removeClass( disabledClass );
+				.filter( '[value="{0}"]'.format( previousValue ) )
+				.prop( 'disabled', false )
+				.removeClass( disabledClass );
 		}
 	}
-	
+
 	let $filteredTargets = $targets
 		.filter( '[value="{0}"]'.format( value ) )
 		.prop( 'disabled', $elem.is( ':checked' ) );
-	
+
 	if ( isChecked ) {
 		$filteredTargets.addClass( disabledClass );
 	} else {
 		$filteredTargets.removeClass( disabledClass );
 	}
-	
+
 }


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

## Summary

Improve compatibility with GP Limit Checkboxes by utilizing new `gplc_excluded_input_selectors` JS filter hook added in https://github.com/gravitywiz/gwlimitcheckboxes/pull/17.

![CleanShot 2023-03-15 at 17 06 58](https://user-images.githubusercontent.com/375381/225454705-95d83482-1652-4b43-b6f2-98f6a2f459cf.gif)
