### PR TITLE
`gw-conditional-logic-operator-is-in.php`: Fixed PHP8 warnings for GW Conditional Logic Operator Is In.

### DIFF
--- a/gravity-forms/gw-conditional-logic-operator-is-in.php
+++ b/gravity-forms/gw-conditional-logic-operator-is-in.php
@@ -149,7 +149,7 @@ class GF_CLO_Is_In {
 
 	public function evaluate_operator( $is_match, $field_value, $target_value, $operation, $source_field, $rule ) {
 
-		if ( $rule['operator'] !== 'is_in' || $rule['gwcloinEvaluatingOperator'] ) {
+		if ( $rule['operator'] !== 'is_in' || rgar( $rule, 'gwcloinEvaluatingOperator' ) ) {
 			return $is_match;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2184530148/45561?folderId=3808239

## Summary

Fixing PHP8 warnings.
