### PR TITLE
`gw-manual-entries.php`: Fixed an issue with Manual Entries button diplaying on Stripe Sales View.

### DIFF
--- a/gravity-forms/gw-manual-entries.php
+++ b/gravity-forms/gw-manual-entries.php
@@ -42,6 +42,11 @@ class GW_Manual_Entries {
 			return;
 		}
 
+		// do not display the Add New Entry button for Stripe Sales Screen
+		if ( rgget( 'view' ) == 'gf_results_gravityformsstripe' ) {
+			return;
+		}
+
 		add_filter( 'admin_print_scripts-forms_page_gf_entries', array( $this, 'output_entry_button_script' ) );
 
 		add_filter( 'gpnf_template_args', array( $this, 'gpnf_add_entry_action' ), 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2182975851/45466?folderId=7098280

## Summary

 The "Add New Entry" button shows on the Stripe Sales screen when the snippet is enabled. This update fixes that.

**_BEFORE:_**
<img width="842" alt="Screenshot 2023-03-27 at 4 04 05 PM" src="https://user-images.githubusercontent.com/26293394/227917643-c7be1f41-2e63-4770-b9b5-f7b0de3e3a5e.png">

**_AFTER:_**
<img width="843" alt="Screenshot 2023-03-27 at 4 04 21 PM" src="https://user-images.githubusercontent.com/26293394/227917695-701f19c6-7d13-4bd0-9339-9b5bf6bf3203.png">
