### PR TITLE
`gw-save-and-continue-auto-load.php`: Fixed an issue with Save & Continue Auto Load snippet activating on forms it should not.

### DIFF
--- a/gravity-forms/gw-save-and-continue-auto-load.php
+++ b/gravity-forms/gw-save-and-continue-auto-load.php
@@ -166,7 +166,8 @@ class GW_Save_Continue_Auto_Load {
 	public function is_applicable_form( $form ) {
 		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
 
-		if ( $this->is_editing_entry( $form_id ) ) {
+		$form = GFAPI::get_form( $form_id );
+		if ( $this->is_editing_entry( $form_id ) || ! $form['save']['enabled'] ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2198642933/46143/

## Summary

There isn't an explicit “Save & Continue” feature for the form in process, which may cause multi-page forms to “remember” values from previous partial submissions when they shouldn’t. This update adds that check, keeping the functionality same.