### PR TITLE
`gpapf-disable-validation.php`: Fixed an issue with Advanced Phone Number Validation Snippet not working.

### DIFF
--- a/gp-advanced-phone-field/gpapf-disable-validation.php
+++ b/gp-advanced-phone-field/gpapf-disable-validation.php
@@ -16,5 +16,5 @@ add_action( 'init', function () {
 		return;
 	}
 
-	remove_filter( 'gform_validation', array( gp_advanced_phone_field(), 'validation' ) );
+	remove_filter( 'gform_field_validation', array( gp_advanced_phone_field(), 'validation' ) );
 }, 16 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2207029432/46494/

Related to https://github.com/gravitywiz/gp-advanced-phone-field/pull/14

## Summary

Fixed an issue with the Advanced Phone Number Validation snippet no longer working.

A ~1 min screencast of the old snippet, new snippet, and new snippet (when deactivated):
https://www.loom.com/share/b17ab80f4ba846bbaffde20e4930f3dc
