### PR TITLE
`gw-double-confirmation-fields.php`: Fixed an issue where the snippet would try to match for values of hidden fields.

### DIFF
--- a/gravity-forms/gw-double-confirmation-fields.php
+++ b/gravity-forms/gw-double-confirmation-fields.php
@@ -40,7 +40,7 @@ function gfcf_validation( $validation_result ) {
 		$confirm_error = true;
 
 		foreach ( $form['fields'] as &$field ) {
-			if ( ! in_array( $field['id'], $confirm_fields ) ) {
+			if ( ! in_array( $field['id'], $confirm_fields ) || RGFormsModel::is_field_hidden( $form, $confirm_field, array() ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2199448706/46185?folderId=3808239

## Summary

The snippet does not skip the value comparison for field(s) that are hidden. Thus, even if all other fields match a hidden field would still keep on trigerring the failed validation. This update adds a check to ensure if a field is hidden, it is not taken as part of the value comparison.

A quick screencast of how it works: https://www.loom.com/share/dcd24eea34454711baad66556e9b7a84
