### PR TITLE
`gppa-use-choice-labels-when-populating-from-another-field.php`: Fixed PHP 8 warnings.

### DIFF
--- a/gp-populate-anything/gppa-use-choice-labels-when-populating-from-another-field.php
+++ b/gp-populate-anything/gppa-use-choice-labels-when-populating-from-another-field.php
@@ -3,8 +3,6 @@
  * Gravity Perks // Populate Anything // Populate choices using choice labels rather than values
  * http://gravitywiz.com/documentation/gravity-forms-populate-anything/
  *
- * Instruction Video: https://www.loom.com/share/0a3bc5ea99ee44f6acccceab3737101a (Out of date)
- *
  * Instructions:
  *  1. Install the snippet.
  *     https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
@@ -19,10 +17,13 @@ add_filter( 'gppa_process_template', function ( $template_value, $field, $templa
 	$entry = (array) $object;
 
 	$populating_from_field_id = str_replace( 'gf_field_', '', $template );
-	$populating_from_field    = GFAPI::get_field( $entry['form_id'], $populating_from_field_id );
-
+	$populating_from_field    = GFAPI::get_field( rgar( $entry, 'form_id' ), $populating_from_field_id );
+	if( ! $populating_from_field ) {
+		// create an empty field if field doesn't exist (PHP 8 spec).
+		$populating_from_field = (object) [ 'choices' => [] ];
+	}
 	// For dynamically populated choices
-	$choice_text = gp_populate_anything()->get_submitted_choice_label( $template_value, $populating_from_field, $entry['id'] );
+	$choice_text = gp_populate_anything()->get_submitted_choice_label( $template_value, $populating_from_field, rgar( $entry, 'id' ) );
 
 	// Get label for static choices.
 	if ( $choice_text === $template_value ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2205739488/46442?folderId=3808239

## Summary

PHP8 warnings were noticed in the investigation of the ticket.

A before and after overview of the warnings (and confirmation that the functionality remains intact):

https://www.loom.com/share/667f4e2a5de045fe9290cca33a17710a
