### PR TITLE
`gw-inventory.php`: Added support for tracking "inventory" on currency-formatted Number fields.

### DIFF
--- a/gravity-forms/gw-inventory.php
+++ b/gravity-forms/gw-inventory.php
@@ -164,6 +164,10 @@ class GW_Inventory {
 			$requested_qty = rgpost( 'input_' . str_replace( '.', '_', $input_id ) );
 			$field_sum     = $this->get_sum();
 
+			if ( $field->get_input_type() === 'number' && $field->numberFormat === 'currency' ) {
+				$requested_qty = GFCommon::to_number( $requested_qty );
+			}
+
 			if ( rgblank( $requested_qty ) || $field_sum + $requested_qty <= $limit ) {
 				continue;
 			}
@@ -521,5 +525,5 @@ new GW_Inventory( array(
 	'not_enough_stock_message' => 'You ordered %1$s tickets. There are only %2$s tickets left.',
 	'approved_payments_only'   => false,
 	'hide_form'                => false,
-	'enable_notifications'     => true,
+	'enable_notifications'     => false,
 ) );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2220460632/47304/

## Summary

Customer has a form where users can request funding. There is a hard cap of $10,000 available for funding. He wants to prevent the total amount requested across all entries from exceeding this cap. 

This snippet is well equipped to handle this scenario except that it previously did not support currency-formatted Number fields. Now it does. 👨‍🏭
