### PR TITLE
`gw-update-user-password-after-submission.php`: Added new snippet for…

### DIFF
--- a/gravity-forms/gw-update-user-password-after-submission.php
+++ b/gravity-forms/gw-update-user-password-after-submission.php
@@ -7,8 +7,15 @@
  * 
  */
 
-// Update "123" to your form ID, "4" to your "Password" field ID, and "5" to your "New Password" field ID.
+// Update "123" to your form ID, "4" to your "Password" field ID, and "5" to your "Confirm Password" field ID.
+// If you're not using a "Confirm Password" field, change "$double_password_confirmation" from "true" to "false".
 add_filter( 'gform_field_validation_123_5', function( $result, $value, $form ) {
+
+    $double_password_confirmation = true;
+    
+    if( ! $double_password_confirmation ) {
+    	return;
+    }
 
     $master = rgpost( 'input_4' );
     if ( $result['is_valid'] && $value != $master ) {
@@ -20,6 +27,8 @@ add_filter( 'gform_field_validation_123_5', function( $result, $value, $form ) {
 }, 10, 4 );
 
 // Update "123" to your form ID, "4" to your "Email" field ID, and "5) to your "Password" field ID.
+// If you're using GP Nested Forms, set these to the Form and Field IDs of the child form that contains the email and password fields.
+// If you're using GP Populate Anything, make sure the "value" for the user email field is set to "User Email".
 add_action( 'gform_after_submission_123', function ( $entry, $form ) {
 
     $user = get_user_by( 'email', rgar( $entry, 4 ) );


### PR DESCRIPTION
… GF that validates two passwords are the same, and then updates the password for the provided email.

Source: https://gist.github.com/coulterpeterson/2d8cfbae77fd93bdd0744d4db4545daf

## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2223492574/47491/

## Summary

Pushing the initial version of this snippet. It updates the password for the user ID associated with the inputted email, allowing a custom password reset form.
