### PR TITLE
`gw-random-fields.php`: Fixed an issue with single page form and random fields.

### DIFF
--- a/gravity-forms/gw-random-fields.php
+++ b/gravity-forms/gw-random-fields.php
@@ -193,6 +193,10 @@ class GFRandomFields {
 	 * @return int|mixed
 	 */
 	public function modify_target_page( $page_number, $form, $current_page ) {
+		// For a single page form, no need to modify target page.
+		if ( GFFormDisplay::get_max_page_number( $form ) === 0 ) {
+			return $page_number;
+		}
 
 		$page_number = intval( $page_number );
 		$form        = $this->pre_render( $form );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2226609602/47623/

## Summary

The `modify_target_page` method gets stuck when the form is single page. This adds a check to skip that.

