### PR TITLE
`gw-all-fields-template`: Improved modifier regex to allow modifiers to contain underscores.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -331,7 +331,7 @@ class GW_All_Fields_Template {
 
 	public function parse_modifiers( $modifiers_str ) {
 
-		preg_match_all( '/([a-z]+)(?:(?:\[(.+?)\])|,?)/i', $modifiers_str, $modifiers, PREG_SET_ORDER );
+		preg_match_all( '/([a-z_]+)(?:(?:\[(.+?)\])|,?)/i', $modifiers_str, $modifiers, PREG_SET_ORDER );
 		$parsed = array();
 
 		foreach ( $modifiers as $modifier ) {


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2226818943/47628/

## Summary

I wanted to use an underscored modifier as part my solution for the above ticket like so:

`:my_custom_template`

Previously, the modifier regex would return three separate modifiers for that: "my", "custom", "template". This slight tweak to the modifier regex adds support for underscores.
