### PR TITLE
`gw-conditionally-disable-checkboxes.js`: Updated instructions for clarity on using choice values and handling values that contain prices.

### DIFF
--- a/gravity-forms/gw-conditionally-disable-checkboxes.js
+++ b/gravity-forms/gw-conditionally-disable-checkboxes.js
@@ -17,6 +17,7 @@ var $cbs1 = $( '#input_GFFORMID_1' );
 // Update "2" to your second Checkbox field's ID.
 var $cbs2 = $( '#input_GFFORMID_2' );
 // See video above for instructions on editing exclusions.
+// Note: This uses the choice value not the choice label. When targeting Product Option fields configured as a checkbox, you must include the price (e.g. 'First Choice B|15').
 var exclusions = {
 	// First Checkbox field exclusions.
 	'First Choice A': [ 'First Choice B' ],


### PR DESCRIPTION
## Context

⛑️ Ticket(s): Don't know.

## Summary

A customer was confused on how to use this snippet with a Option field configured as a Checkbox. Explained about needing to include the price in the specified choice value.
