### PR TITLE
`gw-merge-tag-tab.php`: Added merge tag `{tab}` for tabbed space.

### DIFF
--- a/gravity-forms/gw-merge-tag-tab.php
+++ b/gravity-forms/gw-merge-tag-tab.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Gravity Forms // Merge Tag: Add merge {tab} for tabbed space.
+ * https://gravitywiz.com/
+ */
+add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $lead, $url_encode, $esc_html, $nl2br, $format ) {
+	if ( strpos( $text, '{tab}' ) !== false ) {
+		$text = str_replace( '{tab}', ' ', $text );
+	}
+	return $text;
+}, 10, 7 );

--- a/gravity-forms/gw-merge-tag-tab.php
+++ b/gravity-forms/gw-merge-tag-tab.php
@@ -1,7 +1,11 @@
 <?php
 /**
  * Gravity Forms // Merge Tag: Add merge {tab} for tabbed space.
- * https://gravitywiz.com/
+ *
+ * Adds merge tags {tab}, {space}, and {newline}.
+ *
+ * Instructions:
+ *  1. Install per https://gravitywiz.com/how-do-i-install-a-snippet/
  */
 add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $lead, $url_encode, $esc_html, $nl2br, $format ) {
 	if ( strpos( $text, '{tab}' ) !== false ) {
@@ -14,6 +18,6 @@ add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $lead, $url_
 
 	if ( strpos( $text, '{newline}' ) !== false ) {
 		$text = str_replace( '{newline}', "\n", $text );
-	}    
+	}
 	return $text;
 }, 10, 7 );

--- a/gravity-forms/gw-merge-tag-tab.php
+++ b/gravity-forms/gw-merge-tag-tab.php
@@ -7,5 +7,13 @@ add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $lead, $url_
 	if ( strpos( $text, '{tab}' ) !== false ) {
 		$text = str_replace( '{tab}', ' ', $text );
 	}
+
+	if ( strpos( $text, '{space}' ) !== false ) {
+		$text = str_replace( '{space}', ' ', $text );
+	}
+
+	if ( strpos( $text, '{newline}' ) !== false ) {
+		$text = str_replace( '{newline}', "\n", $text );
+	}    
 	return $text;
 }, 10, 7 );

--- a/gravity-forms/gw-merge-tag-tab.php
+++ b/gravity-forms/gw-merge-tag-tab.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Forms // Merge Tag: Add merge {tab} for tabbed space.
+ * Gravity Wiz // Gravity Forms // Merge Tag: Add merge {tab} for tabbed space.
  *
  * Adds merge tags {tab}, {space}, and {newline}.
  *


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2220926133/47348?folderId=3808239

## Summary

This adds a merge tag `{tab}` for tabbed space. The context of adding this snippet is for usage with GP QR codes.

For a simple form with two text fields:
<img width="250" alt="Screenshot 2023-05-12 at 6 54 01 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/def13524-af1b-4b17-b463-ea40bdf7b5ff">

We are testing this with `[gpqr]{Single Line Text A:1}{tab}{Single Line Text B:2}{tab}[/gpqr] `

________________________________________________________________________________________________________________________________
**Before the merge tag added**
<img width="1143" alt="Screenshot 2023-05-12 at 6 53 03 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/57edbe2e-7112-4891-8b16-149652c8b6fe">

________________________________________________________________________________________________________________________________
**After the merge tag added (tabbed value is visible)**
<img width="1142" alt="Screenshot 2023-05-12 at 6 53 32 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/f639cf8f-d986-42de-b311-dfae6f033746">
