### PR TITLE
`gpml-apc-attach-files-to-post.php`: Added a snippet to attach files to posts created with Gravity Forms APC and ACF.

### DIFF
--- a/gp-media-library/gpml-apc-attach-files-to-post.php
+++ b/gp-media-library/gpml-apc-attach-files-to-post.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Gravity Wiz // Gravity Forms // Attach Files uploaded via GPML to Posts created with GFAPC + ACF
- * 
+ *
  * Attach Files uploaded via GPML to Posts created with GFAPC + ACF
  *
  * Instructions:
@@ -21,7 +21,6 @@ add_action( 'gform_advancedpostcreation_post_after_creation', function( $post_id
 					'post_parent' => $post_id,
 				) );
 			}
-			set_post_thumbnail( $post_id, $file_id );
 		}
 	}
 }, 10, 4 );

--- a/gp-media-library/gpml-apc-attach-files-to-post.php
+++ b/gp-media-library/gpml-apc-attach-files-to-post.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Attach Files uploaded via GPML to Posts created with GFAPC + ACF
+ * 
+ * Attach Files uploaded via GPML to Posts created with GFAPC + ACF
+ *
+ * Instructions:
+ *  1. Install per https://gravitywiz.com/how-do-i-install-a-snippet/
+ */
+add_action( 'gform_advancedpostcreation_post_after_creation', function( $post_id, $feed, $entry, $form ) {
+	foreach ( $feed['meta']['postMetaFields'] as $post_meta_field ) {
+		$field_id         = rgar( $post_meta_field, 'value' );
+		$field            = GFAPI::get_field( $form, $field_id );
+		$is_media_library = rgar( $field, 'uploadMediaLibrary' );
+
+		if ( $is_media_library ) {
+			$file_ids = gp_media_library()->get_file_ids( $entry['id'], $field->id );
+			foreach ( $file_ids as $file_id ) {
+				wp_update_post( array(
+					'ID'          => $file_id,
+					'post_parent' => $post_id,
+				) );
+			}
+			set_post_thumbnail( $post_id, $file_id );
+		}
+	}
+}, 10, 4 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2236815395/48148/

## Summary

Attach Files uploaded via GPML to Posts created with GFAPC + ACF.

https://www.loom.com/share/7087869f092c4b9ea5c18e92d7ca1469

https://www.loom.com/share/f2480807382f4fd2a622db0f89e65351
