### PR TITLE
Fixed issue where if no subview query arg was specified, the Custom Code setting did not appear.

### DIFF
--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -4,7 +4,7 @@
  *
  * Include custom Javascript with your form.
  *
- * @version  1.6.1
+ * @version  1.6.2
  * @author   David Smith <david@gravitywiz.com>
  * @license  GPL-2.0+
  * @link     http://gravitywiz.com/
@@ -13,7 +13,7 @@
  * Plugin URI:   http://gravitywiz.com/
  * Description:  Include custom Javascript with your form.
  * Author:       Gravity Wiz
- * Version:      1.6.1
+ * Version:      1.6.2
  * Author URI:   http://gravitywiz.com
  *
  * Usage:
@@ -94,7 +94,9 @@ class GF_Custom_JS {
 	}
 
 	public function add_custom_js_setting( $form_settings, $form ) {
-		if ( rgget( 'subview' ) !== 'settings' ) {
+		$is_settings_view = rgget( 'view' ) === 'settings';
+		$subview          = rgget( 'subview' );
+		if ( ! $is_settings_view || ( $subview && $subview !== 'settings' ) ) {
 			return $form_settings;
 		}
 		$form_settings['Custom Code'] = array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2254348243/49111

## Summary

When clicking on the "Settings" link in the form list, a `subview` query arg is not specified and as a result, the Custom Code setting does not appear when the Settings page loads. 

![CleanShot 2023-05-30 at 22 07 33](https://github.com/gravitywiz/snippet-library/assets/550549/af17b8ee-84f8-44a3-a908-592797d71930)

This PR adds support for confirming if we are on the Settings page regardless of the subview query arg.
