### PR TITLE
`gpnf-child-entry-id-modifier.php`: Fixed an issue with character encoding.

### DIFF
--- a/gp-nested-forms/gpnf-child-entry-id-modifier.php
+++ b/gp-nested-forms/gpnf-child-entry-id-modifier.php
@@ -19,7 +19,7 @@ add_filter( 'gpnf_all_entries_nested_entry_markup', function( $markup, $field, $
 	}
 
 	$dom = new DOMDocument();
-	$dom->loadHTML( $markup );
+	$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $markup );
 
 	$first_row  = $dom->getElementsByTagName( 'tr' )->item( 1 );
 	$header_row = clone $first_row;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2261594766/49479?folderId=3808239

## Summary

Fixed an issue with character encoding. Using `DOMDocument::load` implies the text will be regarded in ISO-8859-1, which is the HTTP/1.1 standard character set. This results in UTF-8 strings being misinterpreted. 

To resolve this, we prepend an XML encoding declaration to the text

**_BEFORE:_**
<img width="174" alt="Screenshot 2023-06-05 at 3 15 36 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/027e96ca-ba51-45bd-9bab-fd1a7f62e277">

**_AFTER:_**
<img width="194" alt="Screenshot 2023-06-05 at 3 15 17 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/582c3809-ba0b-4081-8b1e-ccb18d95ea21">
