### PR TITLE
`gw-edit-product-and-payment-details.php`: Fixed issue with GPECF where "subtotal" fields would not be saved correctly after editing a product field on an entry.

### DIFF
--- a/gravity-forms/gw-edit-product-and-payment-details.php
+++ b/gravity-forms/gw-edit-product-and-payment-details.php
@@ -106,8 +106,6 @@ class GW_Edit_Products {
 		}
 
 		if ( $has_product_field ) {
-			// calculate the total once product fields have been restored to their original types
-			$total = GFCommon::get_order_total( $form, $entry );
 			foreach ( $form['fields'] as &$field ) {
 				if ( $field->type == 'subtotal' ) {
 					$order            = GFCommon::get_product_fields( $form, $entry, false );
@@ -122,7 +120,14 @@ class GW_Edit_Products {
 					$subtotal = GF_Field_Subtotal::get_subtotal( $order, $exclude_products );
 
 					GFAPI::update_entry_field( $entry['id'], $field->id, $subtotal );
+				} elseif ( $field->type === 'discount' ) {
+					$order = GFCommon::get_product_fields( $form, $entry, false );
+					$discount = rgars( $order, "products/{$field->id}/price" );
+
+					GFAPI::update_entry_field( $entry['id'], $field->id, $discount );
 				} elseif ( $field->type == 'total' ) {
+					// calculate the total once product fields have been restored to their original types
+					$total = GFCommon::get_order_total( $form, $entry );
 					GFAPI::update_entry_field( $entry['id'], $field->id, $total );
 				}
 			}

--- a/gravity-forms/gw-edit-product-and-payment-details.php
+++ b/gravity-forms/gw-edit-product-and-payment-details.php
@@ -109,7 +109,20 @@ class GW_Edit_Products {
 			// calculate the total once product fields have been restored to their original types
 			$total = GFCommon::get_order_total( $form, $entry );
 			foreach ( $form['fields'] as &$field ) {
-				if ( $field->type == 'total' ) {
+				if ( $field->type == 'subtotal' ) {
+					$order            = GFCommon::get_product_fields( $form, $entry, false );
+					$exclude_products = array();
+
+					if ( $field->subtotalProductsType === 'exclude' ) {
+						$exclude_products = $field->subtotalProducts;
+					} elseif ( $field->subtotalProductsType === 'include' ) {
+						$exclude_products = array_diff( array_keys( $order['products'] ), $field->subtotalProducts );
+					}
+
+					$subtotal = GF_Field_Subtotal::get_subtotal( $order, $exclude_products );
+
+					GFAPI::update_entry_field( $entry['id'], $field->id, $subtotal );
+				} elseif ( $field->type == 'total' ) {
 					GFAPI::update_entry_field( $entry['id'], $field->id, $total );
 				}
 			}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2267707761/49837/

## Summary

This fixes an issue where `GW_Edit_Products` was not updating the "subtotal" fields when entries were being edited.

The result is that, after editing an entry, the subtotal columns in the entry table view would be blank like this:

<img width="1159" alt="image" src="https://github.com/gravitywiz/snippet-library/assets/21110659/7e4b3a94-bc65-4deb-bfbf-87268ac8edb0">

However, the entry table view should show a value in each subtotal cell like this:

<img width="1195" alt="Screenshot 2023-06-14 at 2 53 21 PM" src="https://github.com/gravitywiz/snippet-library/assets/21110659/1f0cbc70-055b-4ce8-8b90-aa13d1646cc4">
