### PR TITLE
Update GW_Coupons_Exclude_Products to support GF Coupons 3.1 and add new functionality

### DIFF
--- a/gravity-forms/gw-coupons-exclude-products.php
+++ b/gravity-forms/gw-coupons-exclude-products.php
@@ -6,24 +6,27 @@
  *
  * Requires Gravity Forms Coupons v1.1
  *
- * @version 1.2.1
+ * @version 1.3
  * @author  David Smith <david@gravitywiz.com>
+ * @author  James M. Joyce <james@flashpointcs.net>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com/...
  */
 class GW_Coupons_Exclude_Products {
 
 	protected static $is_script_output = false;
-	public static $excluded_total      = null;
 
-	public $_args = array();
+	public $_args          = array();
+	public $excluded_total = null;
 
 	public function __construct( $args ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
 		$this->_args = wp_parse_args( $args, array(
-			'form_id'        => false,
-			'exclude_fields' => array(),
+			'form_id'                => false,
+			'exclude_fields'         => array(),
+			'exclude_fields_by_form' => array(),
+			'skip_for_100_percent'   => false,
 		) );
 
 		// do version check in the init to make sure if GF is going to be loaded, it is already loaded
@@ -36,7 +39,7 @@ class GW_Coupons_Exclude_Products {
 		$has_gravity_forms = property_exists( 'GFCommon', 'version' ) && version_compare( GFCommon::$version, '1.8', '>=' );
 		$has_gf_coupons    = class_exists( 'GFCoupons' );
 
-		// make sure we're running the required minimum version of Gravity Forms and GF Coupons
+		// make sure we're running the required minimum version of Gravity Forms and that GF Coupons is installed
 		if ( ! $has_gravity_forms || ! $has_gf_coupons ) {
 			return;
 		}
@@ -63,23 +66,30 @@ class GW_Coupons_Exclude_Products {
 	function output_script() {
 		?>
 
-		<script type="text/javascript">
+		<script>
 
 			( function( $ ) {
 
 				if( window.gform ) {
 
-					gform.addFilter( 'gform_coupons_discount_amount', function( discount, couponType, couponAmount, price, totalDiscount ) {
+					gform.addFilter( 'gform_coupons_discount_amount', function( discount, couponType, couponAmount, price, totalDiscount, formId = null ) {
 
-						// pretty hacky... work our way up the chain to see if the 4th func up is the expected func
-						var caller = arguments.callee.caller.caller.caller.caller;
+						if( ! formId ) { // GF Coupons >= 3.0.1 adds formId param to this filter
+							// pretty hacky... work our way up the chain to see if the 4th func up is the expected func
+							var caller = arguments.callee.caller.caller.caller.caller;
 
-						if( caller.name != 'PopulateDiscountInfo' ) {
+							if( caller.name != 'PopulateDiscountInfo' ) {
+								return discount;
+							}
+
+							formId = caller.arguments[1];
+						}
+						
+						if( couponType == 'percentage' && couponAmount == 100 && gf_global.gfcep.skipFor100Percent ) {
 							return discount;
 						}
 
-						var formId = caller.arguments[1],
-							price  = price - getExcludedAmount( formId );
+						var price  = price - getExcludedAmount( formId );
 
 						if( couponType == 'percentage' ) {
 							discount = price * Number( ( couponAmount / 100 ) );
@@ -141,11 +151,12 @@ class GW_Coupons_Exclude_Products {
 			return;
 		}
 
+		$base_json           = json_encode( array( 'skipFor100Percent' => $this->_args['skip_for_100_percent'] ) );
 		$exclude_fields_json = json_encode( $this->_args['exclude_fields'] );
 
 		$script = "if( typeof gf_global != 'undefined' ) {
-			if( typeof gf_global.gwcep == 'undefined' ) {
-				gf_global.gfcep = [];
+			if( typeof gf_global.gfcep == 'undefined' ) {
+				gf_global.gfcep = {$base_json};
 			}
 			gf_global.gfcep[ {$this->_args['form_id']} ] = {$exclude_fields_json};
 		}";
@@ -160,11 +171,11 @@ class GW_Coupons_Exclude_Products {
 			return $product_data;
 		}
 
-		self::$excluded_total = 0;
+		$this->excluded_total = 0;
 
 		foreach ( $product_data['products'] as $field_id => $data ) {
 			if ( in_array( $field_id, $this->_args['exclude_fields'] ) ) {
-				self::$excluded_total += GFCommon::to_number( $data['price'] );
+				$this->excluded_total += GFCommon::to_number( $data['price'] );
 			}
 		}
 
@@ -173,15 +184,15 @@ class GW_Coupons_Exclude_Products {
 
 	function modify_coupon_discount_amount( $discount, $coupon, $price ) {
 
-		if ( ! self::$excluded_total ) {
+		if ( ! $this->excluded_total ) {
 			return $discount;
 		}
 
-		$price    = $price - self::$excluded_total;
+		$price    = $price - $this->excluded_total;
 		$currency = new RGCurrency( GFCommon::get_currency() );
 		$amount   = $currency->to_number( $coupon['amount'] );
 
-		if ( $coupon['type'] == 'percentage' ) {
+		if ( $coupon['type'] == 'percentage' && ! ( $amount == 100 && $this->_args['skip_for_100_percent'] ) ) {
 			$discount = $price * ( $amount / 100 );
 		} elseif ( $coupon['type'] == 'flat' ) {
 			$discount = $amount;
@@ -195,7 +206,16 @@ class GW_Coupons_Exclude_Products {
 
 	function is_applicable_form( $form ) {
 
-		$coupon_fields         = GFCommon::get_fields_by_type( $form, array( 'coupon' ) );
+		$coupon_fields = GFCommon::get_fields_by_type( $form, array( 'coupon' ) );
+
+		if( sizeof( $this->_args['exclude_fields_by_form']) > 0 ) {
+			$is_applicable_form_id = in_array( $form['id'], array_keys( $this->_args['exclude_fields_by_form'] ) );
+			if( $is_applicable_form_id && $form['id'] != $this->_args['form_id'] ) {
+				$this->_args['form_id'] = $form['id'];
+				$this->_args['exclude_fields'] = $this->_args['exclude_fields_by_form'][$form['id']];
+			}
+		}
+		
 		$is_applicable_form_id = $form['id'] == $this->_args['form_id'];
 
 		return $is_applicable_form_id && ! empty( $coupon_fields );
@@ -203,9 +223,27 @@ class GW_Coupons_Exclude_Products {
 
 }
 
-# Configuration
+/**
+ * Configuration
+ * - for a single form, set form_id to your form ID, and exclude_fields to an array of the fields you wish to exclude
+ * - for multiple forms, set exclude_fields_by_form to an array with form IDs as its keys, and arrays of field IDs as its values
+ * - set skip_for_100_percent to true to ignore these exclusions when a 100% off coupon is used
+ */
+
+// Single form
 
 new GW_Coupons_Exclude_Products( array(
-	'form_id'        => 123,
-	'exclude_fields' => array( 4, 5 ),
+	'form_id'              => 123,
+	'exclude_fields'       => array( 4, 5 ),
+	'skip_for_100_percent' => false
+) );
+
+// Multiple forms
+
+new GW_Coupons_Exclude_Products( array(
+	'exclude_fields_by_form' => array( 
+		123 => array( 4, 5 ),
+		456 => array( 7, 8 ),
+	),
+	'skip_for_100_percent'   => false
 ) );


### PR DESCRIPTION
## Context

The Gravity Forms team added formId as a parameter of the gform_coupons_discount_amount JS filter in GF Coupons 3.0.1. This snippet no longer works as of that version and above - arguments.callee.caller.caller.caller.caller causes a fatal error.

## Summary

This PR contains some extra goodies atop the GFC 3.1 support:

- Multi-form support: previously, to use this snippet with multiple forms, it would have to be instantiated multiple times, and in doing so the excluded total could be wrong in some rare edge cases. Now, it can be instantiated once (more efficient) with the exclude_fields_by_form param set.
- Optionally skip exclusion for 100% off coupons: it's likely (but not guaranteed) that an operator intends for a 100% off coupon to make products on the form fully free, which means even total from the excluded fields needs to be discounted. _Example:_ a calculation product is in place to pass along Stripe fees with the formula `((({subtotal} - {discounts}) + 0.30) / 0.965) - ({subtotal} - {discounts})`, and this product is excluded from coupons. This works correctly until a 100% off coupon is used - if the exclusions aren't skipped, the final total will be $0.30, not $0. Handling this scenario would otherwise require an extra field with `{subtotal}` in it, to enable conditional logic on the fee field, which is not ideal.
- Small fixes.