### PR TITLE
`gppa-object-type-json-api.php`: Fixed an issue with the snippet not working with GPPA 2.0+.

### DIFF
--- a/experimental/gppa-object-type-json-api.php
+++ b/experimental/gppa-object-type-json-api.php
@@ -143,6 +143,11 @@ class GPPA_Object_Type_JSON_API extends GPPA_Object_Type {
 	 */
 	public function search( $var, $search_params ) {
 		foreach ( $search_params as $search_group ) {
+			// For GPPA 2.0+, search_group may also read the numeric "limit" value, so skip for non-array values.
+			if ( ! is_array( $search_group ) ) {
+				continue;
+			}
+
 			$matches_group = true;
 
 			foreach ( $search_group as $search ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2273072569/50303/
https://secure.helpscout.net/conversation/2275362111/50406?folderId=3808239

## Summary

The snippet fails to work with GPPA 2.0, because GPPA 2.0 also stores the 'limit' value in the same array. A simple rule, would be as follows:

```
array(
    0 => array(
        0 => array(
            'property' => 'name',
            'operator' => 'contains',
            'value' => 'faa'
        )
    ),
    'limit' => 750
);
```

This update adds a conditional logic to skip processing for non-array values.