### PR TITLE
`gw-all-fields-template.php`: Fixed a conflict with GravityView.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -82,7 +82,7 @@ class GW_All_Fields_Template {
 	public function init() {
 
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_merge_tags' ), 9, 7 );
-		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 6 );
+		add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 21, 6 );
 
 	}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2282427365/50946?folderId=3808239

## Summary

On our snippet, we tap `gform_merge_tag_filter` at priority 11:
`add_filter( 'gform_merge_tag_filter', array( $this, 'all_fields_extra_options' ), 11, 6 );`

GravityView does it at priority 20:
`add_filter( 'gform_merge_tag_filter', array( 'GravityView_Merge_Tags', 'process_modifiers' ), 20, 5 );`
(gravityview/includes/class-gravityview-merge-tags.php)

To prevent GravityView from overriding the behaviour of GW All Fields Template, in this case specifically the List field, we should hook our filter call after what GravityView does.

**The "Child" form** and **The "Child" enter for testing**:
<img width="300" alt="Screenshot 2023-07-08 at 12 12 54 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/52a10fc9-7fec-4c20-9e0c-b2eaa2214e74"><img width="177" alt="Screenshot 2023-07-08 at 12 13 29 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/ba03b9ae-b6c3-406b-aa54-65bc53bd8bb3">

**GravityView set up with "Custom Content"**:
<img width="903" alt="Screenshot 2023-07-08 at 12 14 05 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c6c02144-cfe8-48ee-b88d-eeab48317f15">
<img width="362" alt="Screenshot 2023-07-08 at 12 14 26 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/60cd425c-744f-44c9-b1b8-31a33e57f033">

**_BEFORE:_**
<img width="872" alt="Screenshot 2023-07-08 at 12 14 53 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c198daf0-20e5-46f0-a229-594b601f14ce">

**_AFTER:_**
<img width="868" alt="Screenshot 2023-07-08 at 12 15 19 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/54ffe50e-d16c-4a9d-a09f-079ed1ac0a12">
