### PR TITLE
`gw-none-of-the-above-checkbox.js`: Fixed an issue with the snippet not firing for when None of the Above choice was selected by default.

### DIFF
--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -20,10 +20,18 @@
  *    any Checkbox field to which this should be applied.
  */
 $( '.gw-none-of-the-above' ).each( function() {
-	
+
 	var $field  = $( this );
 	var $last   = $field.find( '.gchoice:last-child input' );
 	var $others = $field.find( 'input' ).not( $last );
+
+	// If "None of the Above" choice is checked by default.
+	if ( $last[0].checked ) {
+		var $checkboxes = $field.find( 'input' ).not( $last )
+		$checkboxes
+			.prop( 'checked', false )
+			.prop( 'disabled', true );
+	}
 
 	$last.on( 'click', function() {
 		var $checkboxes = $field.find( 'input' ).not( $( this ) )

--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -26,7 +26,7 @@ $( '.gw-none-of-the-above' ).each( function() {
 	var $others = $field.find( 'input' ).not( $last );
 
 	// If "None of the Above" choice is checked by default.
-	if ( $last[0].checked ) {
+	if ( $( last ).prop( 'checked' ) ) {
 		var $checkboxes = $field.find( 'input' ).not( $last )
 		$checkboxes
 			.prop( 'checked', false )


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2296570360/52069?folderId=3808239

## Summary

The snippet did not fire when "None" choice was selected by default.

**_BEFORE (on page load):_**
<img width="224" alt="Screenshot 2023-07-11 at 4 35 07 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/d2a71158-bf49-4b98-8a6b-9e0932afa0b0">

**_AFTER (on page load):_**
<img width="224" alt="Screenshot 2023-07-11 at 4 34 47 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/ac8fe76a-21d6-481d-b105-76c645798bb0">

**Screencast with the update:**
https://www.loom.com/share/49355316a09d41e3bcb22f9649730846