### PR TITLE
`gw-limit-multiselect.js`: Fixed an issue with limit multi-select not working with GP Advanced Select.

### DIFF
--- a/gravity-forms/gw-limit-multiselect.js
+++ b/gravity-forms/gw-limit-multiselect.js
@@ -63,6 +63,12 @@ function limitMultiSelect( $select, max ) {
 			.find( 'option:not(:checked)' )
 			.prop( 'disabled', selectedCount >= max )
 			.trigger( 'chosen:updated' );
+
+		// For Tom Select (GP Advanced Select)
+		// Update "1" to the ID of your Multi Select field.
+		if ( $( '#input_GFFORMID_1-ts-dropdown' ) ) {
+			$( '#input_GFFORMID_1-ts-dropdown .option' ).removeAttr( 'data-selectable' );
+		}
 	}
 }
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2301130622/52247/

## Summary

Add support for Tom Select (GP Advanced Select) to work with the Limit Multi-Select snippet.

After the update, standard behaviour (without GPAS) still works fine:
https://www.loom.com/share/a8bbd3644f074653a756523d99541c5a

After the update, the behaviour with GPAS is fixed:
https://www.loom.com/share/8d6463d62cfe47d8884783e1471d3a77
