### PR TITLE
`gfoai-process-shortcodes-on-prompt.php`: Added a snippet to process shortcodes on the Message Prompts.

### DIFF
--- a/gravityforms-openai/gfoai-process-shortcodes-on-prompt.php
+++ b/gravityforms-openai/gfoai-process-shortcodes-on-prompt.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms OpenAI // Process shortcodes on Message Prompts
+ *
+ * Processing of shortcodes on the message prompts is disabled by default. Use this snippet to enable it
+ *
+ * Instructions:
+ *  1. Install per https://gravitywiz.com/how-do-i-install-a-snippet/
+ */
+add_filter( 'gform_gravityforms-openai_pre_process_feeds', function ( $feeds, $entry ) {
+	foreach ( $feeds as &$feed ) {
+		// Process shortcode on chat completion message prompt
+		if ( $feed['meta']['chat_completions_message'] ) {
+			$feed['meta']['chat_completions_message'] = do_shortcode( $feed['meta']['chat_completions_message'] );
+		}
+	}
+
+	return $feeds;
+}, 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2292239606/51747?folderId=7098280

## Summary

By default, shortcodes are not processed on the message prompts. This snippet gives the ability to customize this, and process the message prompts on Chat Completion Messages.

Example OpenAI feed setting:
<img width="535" alt="Screenshot 2023-07-18 at 7 01 17 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/8eed611f-8f5e-41ec-907e-70cd0f07ac17">

```php
function my_shortcode_test() { 
	return 'This is my shortcode.';
}
add_shortcode( 'my_shortcode', 'my_shortcode_test' );
```

How the message prompts are processed:
<img width="821" alt="Screenshot 2023-07-18 at 7 01 33 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/0e438adc-b883-4a68-a63d-5dbbd9946e8a">


