### PR TITLE
`gw-prevent-duplicate-drop-down-selections.js`: Fixed an issue where options disabled by GP Inventory could get re-enabled even if the choice inventory was at zero.

### DIFF
--- a/experimental/gw-prevent-duplicate-drop-down-selections.js
+++ b/experimental/gw-prevent-duplicate-drop-down-selections.js
@@ -23,6 +23,10 @@ jQuery(".gfield_ddselect").change(function () {
 	jQuery(".gfield_ddselect").each(function (a) {
 		var parent_el = jQuery(this);
 		jQuery("option", jQuery(this)).each(function (b) {
+			// With GP Inventory, any Inventory Exhausted choice should remain disabled.
+			if ($(this).attr('class') != 'gpi-disabled') {
+				jQuery(this).prop("disabled", false);
+			}
 			if (b != 0) {
 				for (c = 0; c < select_num; c++) {
 					if (a != c) {

--- a/experimental/gw-prevent-duplicate-drop-down-selections.js
+++ b/experimental/gw-prevent-duplicate-drop-down-selections.js
@@ -24,7 +24,7 @@ jQuery(".gfield_ddselect").change(function () {
 		var parent_el = jQuery(this);
 		jQuery("option", jQuery(this)).each(function (b) {
 			// With GP Inventory, any Inventory Exhausted choice should remain disabled.
-			if ($(this).attr('class') != 'gpi-disabled') {
+			if (! $(this).hasClass('gpi-disabled')) {
 				jQuery(this).prop("disabled", false);
 			}
 			if (b != 0) {

--- a/experimental/gw-prevent-duplicate-drop-down-selections.js
+++ b/experimental/gw-prevent-duplicate-drop-down-selections.js
@@ -23,7 +23,6 @@ jQuery(".gfield_ddselect").change(function () {
 	jQuery(".gfield_ddselect").each(function (a) {
 		var parent_el = jQuery(this);
 		jQuery("option", jQuery(this)).each(function (b) {
-			jQuery(this).prop("disabled", false);
 			if (b != 0) {
 				for (c = 0; c < select_num; c++) {
 					if (a != c) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2292978921/51848?folderId=3808239

## Summary

When using [this snippet](https://github.com/gravitywiz/snippet-library/blob/master/experimental/gw-prevent-duplicate-drop-down-selections.js) on fields that have inventory set by GP Inventory, the snippet 're-enables' options that have been disabled by GP Inventory because they are out of stock, allowing a user to select options that they shouldn't be able to.

Here is quick loom of resolving this issue (~100 seconds):
https://www.loom.com/share/b83b90597ba2461bb244b5e140f69663