### PR TITLE
`gpasc-add-spinner-during-autosave`: Added new snippet to show/hide a snipper during a GPASC auto save request.

### DIFF
--- a/gp-advanced-save-and-continue/gpasc-add-spinner-during-auto-save.js
+++ b/gp-advanced-save-and-continue/gpasc-add-spinner-during-auto-save.js
@@ -1,0 +1,25 @@
+/**
+ * Gravity Perks // Advanced Save and Continue // Add Spinner During Autosave
+ * https://gravitywiz.com/documentation/gravity-forms-advanced-save-continue/
+ *
+ * This snippet allows you to add a spinner during an auto save request and then remove it
+ * once the request is complete.
+ * 
+ * Instructions:
+ *  1. Add snippet to form using https://gravitywiz.com/gravity-forms-custom-javascript/
+ *  2. Profit.
+ */
+
+gform.addAction( 'gpasc_auto_save_started', function( formId, gpasc ) {
+	var spinnerTarget = function() {
+		console.log( 'spinner target' );
+		return $( '.gform_save_link' );
+	}
+	gform.addFilter( 'gform_spinner_target_elem', spinnerTarget, 10, 'gpasc_spinner_target_elem' );
+	gformAddSpinner( formId );
+	gform.removeFilter( 'gform_spinner_target_elem', 10, 'gpasc_spinner_target_elem' );
+} );
+
+gform.addAction( 'gpasc_auto_save_finished', function( formId ) {
+	$( '#gform_ajax_spinner_' + formId ).remove();
+} );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2295536795/52038/

💻 Github: https://github.com/gravitywiz/gp-advanced-save-and-continue/pull/34 

## Summary

Adds a new snippet leveraging the [gpasc_auto_save_started-js](https://gravitywiz.com/documentation/gpasc_auto_save_started-js/) and [gpasc_auto_save_started-js](https://gravitywiz.com/documentation/gpasc_auto_save_started-js/) action hooks to show/hide a spinner during autosave requests.

