### PR TITLE
`gpecf-set-discount-amount-by-field-value.php`: Fixed an issue with the snippet no t using negative value for discount.

### DIFF
--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -112,6 +112,8 @@ class GPECF_Discount_Amounts_By_Field_Value {
 							var currency = new window.Currency(
 								window.gf_global.gf_currency_config
 							);
+							amount = amount > 0 ? -1 * amount : amount;
+
 
 							var formattedAmount = currency.toMoney(amount);
 							$( '.ginput_discount_' + self.formId + '_' + self.discountFieldId ).html( formattedAmount );

--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -102,6 +102,11 @@ class GPECF_Discount_Amounts_By_Field_Value {
 
 					};
 
+					// Function to convert the formatted amount to a number
+					function convertToNumber(amount) {
+						return parseFloat( amount.replace( /[^\d.-]/g, '' ) );
+					}
+
 					self.setDiscountAmount = function( value ) {
 						if ( value.indexOf( '|' ) !== -1 ) {
 							value = value.split( '|' )[0];
@@ -117,6 +122,12 @@ class GPECF_Discount_Amounts_By_Field_Value {
 
 							var formattedAmount = currency.toMoney(amount);
 							$( '.ginput_discount_' + self.formId + '_' + self.discountFieldId ).html( formattedAmount );
+
+							var total = $( '.ginput_total_' + self.formId ).val();
+							total = convertToNumber(total) +convertToNumber(formattedAmount);
+							total = total < 0 ? 0 : total;
+							var formattedTotal = currency.toMoney(total);
+							$( '.ginput_total_' + self.formId ).val(formattedTotal);
 						}
 					}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2299585841/52198?folderId=3808239

## Summary

Discount value does not get displayed as a positive value.

**BEFORE:**
<img width="312" alt="Screenshot 2023-07-23 at 8 43 02 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/9b6df063-eebc-4820-b7e9-a0319e19e4ba">

**AFTER:**
<img width="367" alt="Screenshot 2023-07-23 at 8 42 34 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/edbc0798-07af-4fa5-a608-3b366228c5d8">
