### PR TITLE
`gw-advanced-conditional-shortcodes.php`: Fixed an issue with missing break on the conditional shortcodes snippet.

### DIFF
--- a/gravity-forms/gw-advanced-conditional-shortcodes.php
+++ b/gravity-forms/gw-advanced-conditional-shortcodes.php
@@ -48,6 +48,7 @@ add_filter( 'gform_shortcode_conditional', function( $result, $atts, $content ) 
 			break;
 		} elseif ( $relation == 'all' && ! $is_match ) {
 			$conditional_met = false;
+			break;
 		}
 	}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2327129106/53384?folderId=3808239

## Summary

A code logic update to the snippet.

The loop logic is :

```
	foreach ( $conditions as $condition ) {
		$is_match = GFFormsModel::matches_operation( $condition['value'], $condition['compare'], $condition['operator'] );
		if ( $relation == 'any' && $is_match ) {
			$conditional_met = true;
			break;
		} elseif ( $relation == 'all' && ! $is_match ) {
			$conditional_met = false;
		}
	}

```

Just like for `any` relation and match found, we can set `$conditional_met` to true and just break from the loop, we should do the same break from the loop when for `all` relation we get even one not matching.
