### PR TITLE
`gw-cache-buster.php`: Fixed issue where GP Advanced Save and Continue "Start New Draft" `form_path` would be incorrect due to the AJAX request which loads the form.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -212,6 +212,12 @@ class GW_Cache_Buster {
 			$form_id = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 		}
 
+		add_filter( 'gpasc_new_draft_form_path', function( $form_path, $form ) {
+			return rgget( 'form_request_origin' )
+				? remove_query_arg( 'gf_token', rgget( 'form_request_origin' ) )
+				: $form_path;
+		}, 10, 2 );
+
 		/**
 		 * Init scripts are output to the footer by default so they are not needed in the AJAX response. Some plugins
 		 * deliberately output inline scripts alongside the form (see Nested Forms' `gpnf_preload_form` filter) but I

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -140,8 +140,9 @@ class GW_Cache_Buster {
 		$ajax_url       = remove_query_arg( $exclude_params, add_query_arg( $_GET, admin_url( 'admin-ajax.php' ) ) );
 		$ajax_url       = add_query_arg(
 			array(
-				'action'  => 'gfcb_get_form',
-				'form_id' => $form_id,
+				'action'              => 'gfcb_get_form',
+				'form_id'             => $form_id,
+				'form_request_origin' => rawurlencode( $_SERVER['REQUEST_URI'] ),
 			),
 			$ajax_url
 		);
@@ -175,7 +176,7 @@ class GW_Cache_Buster {
 					gform.initializeOnLoaded( function() {
 						// Form has been rendered. Trigger post render to initialize scripts.
 						jQuery( document ).trigger( 'gform_post_render', [ formId, 1 ] );
-						gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: formId, currentPage: 1 } });} );
+						gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: formId, currentPage: 1 } });
 					} );
 				} );
 			} )( jQuery );


### PR DESCRIPTION
## Context


⛑️ Ticket(s): https://secure.helpscout.net/conversation/2318327951/52962?folderId=6987275

## Summary

Because this snippet loads the form contents via AJAX, the GPASC `$form_path` would be wrong when this is enabled due to the fact that request for the form markup is an admin AJAX URL and not the URL where the form lives.

This implements a new filter within GPASC which allows `$form_path` to be modified.

Note, this relies on this change to Advanced Save and Continue: https://github.com/gravitywiz/gp-advanced-save-and-continue/pull/35

