### PR TITLE
`gppa-encrypt-fileupload-field-links.php`: Added a snippet that encrypts file upload field links with GPPA.

### DIFF
--- a/gp-populate-anything/gppa-encrypt-fileupload-field-links.php
+++ b/gp-populate-anything/gppa-encrypt-fileupload-field-links.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Encrypt File Upload Field Links
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ *
+ * Encrypt File Upload Links when populated with GP Populate Anything.
+ *
+ * Note: This will disable the default behavior of file upload field encryption on Gravity Forms.
+ * Instead, it will manually encrypt the file upload links directly on the Gravity Forms Entry.
+ */
+add_filter( 'gform_secure_file_download_location', '__return_false' );
+
+// Update 729 and 1 to the Form ID and Field ID of the dynamically populated field loading File Upload field links.
+add_filter( 'gform_save_field_value_729_1', 'encrypt_links', 10, 4 );
+function encrypt_links( $value, $lead, $field, $form ) {
+	$upload_root = GFFormsModel::get_upload_url( $form['id'] );
+	$upload_root = trailingslashit( $upload_root );
+
+	if ( strpos( $value, $upload_root ) !== false ) {
+		$value        = str_replace( $upload_root, '', $value );
+		$download_url = site_url( 'index.php' );
+		$args         = array(
+			'gf-download' => urlencode( $value ),
+			'form-id' => $form['id'],
+			'field-id' => $field['id'],
+			'hash' => GFCommon::generate_download_hash( $form['id'], $field['id'], $value ),
+		);
+		$download_url = add_query_arg( $args, $download_url );
+
+		return $download_url;
+	}
+	return $value;
+}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2326751274/53373?folderId=3808239

## Summary

When using GPPA to get the URL of uploaded files in another form entry. GPPA returns the direct link to the file. This update adds the ability to get encrypted links with GPPA.

Snippet in action (~150 seconds) with **Before** and **After**:
https://www.loom.com/share/699da443af204e93b886c2d72e93d702
