### PR TITLE
`gw-zip-files.php`: Updated snippet to add support for merge tags in zip files.

### DIFF
--- a/gravity-forms/gw-zip-files.php
+++ b/gravity-forms/gw-zip-files.php
@@ -305,7 +305,7 @@ class GW_Zip_Files {
 
 	public function get_zip_paths( $entry, $type = false ) {
 
-		$filename = $this->get_zip_filename( $entry['id'] );
+		$filename = $this->get_zip_filename( $entry );
 		$paths    = GFFormsModel::get_file_upload_path( $entry['form_id'], $filename );
 
 		foreach ( $paths as &$path ) {
@@ -315,8 +315,12 @@ class GW_Zip_Files {
 		return $type ? rgar( $paths, $type ) : $paths;
 	}
 
-	public function get_zip_filename( $entry_id ) {
-		return $this->get_slug( $this->_args['zip_name'], $entry_id, $this->_args['field_ids'] ) . '.zip';
+	public function get_zip_filename( $entry ) {
+		$form_id  = $entry['form_id'];
+		$form     = GFAPI::get_form( $form_id );
+		// replace merge tags in the zip file name
+		$zip_name = GFCommon::replace_variables( $this->_args['zip_name'], $form, $entry, false, false, false, 'text' );
+		return $this->get_slug( $zip_name, false, $this->_args['field_ids'] ) . '.zip';
 	}
 
 	public function get_meta_key( $entry_id = false ) {
@@ -475,7 +479,7 @@ class GW_Zip_Files {
 new GW_Zip_Files(
 	array(
 		'form_id'       => 123,
-		'zip_name'      => 'my-sweet-archive',
+		'zip_name'      => 'my-sweet-archive', // supports merge tags
 		'notifications' => array( '5f4668ec2afbb' ),
 	)
 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2331036263/53520/

## Summary

The  [Zip Files](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-zip-files.php) snippet to generate a zip of all uploaded files from the submitted entry does not support merge tags. This update adds support for it.

Update in action (~30 seconds):
https://www.loom.com/share/63ad5a18b0d74c52a101edd91f75f976
