### PR TITLE
`gpfr-global-filename-template.php`: Fixed issue where `{i}` merge tag would increment twice as fast as it should.

### DIFF
--- a/gp-file-renamer/gpfr-global-filename-template.php
+++ b/gp-file-renamer/gpfr-global-filename-template.php
@@ -7,7 +7,6 @@
  *
  * Requires GP File Renamer v1.0.5+.
  */
-add_filter( 'gpfr_filename', function( $renamed_file, $file, $entry, $form, $field ) {
-	$renamed_file = gp_file_renamer()->get_template_value( '{entry:id}/{filename}-{i}', $file, $entry, $form, $field );
-	return $renamed_file;
+add_filter( 'gpfr_filename_template', function ( $template, $filename, $form, $field, $entry ) {
+	return '{entry:id}/{filename}-{i}';
 }, 10, 5 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2330760345/53504?folderId=6987275 

## Summary

Calling `get_template_value()` more than once per file can be problematic as it can cause the `{i}` merge tag to be incremented twice as fast as it should be.

This change leverages a new filter, `gpfr_filename_template`, that allows the filename template to be modified before `get_template_value()` is called internally within GPFR.

🚨 Relies on the changes in this GPNF pull request: https://github.com/gravitywiz/gp-file-renamer/pull/13

