### PR TITLE
`gpfr-apply-rename-to-every-field.php`: Added snippet to apply GPFR to every field, no matter if there is an existing template value or not.

### DIFF
--- a/gp-file-renamer/gpfr-apply-rename-to-every-field.php
+++ b/gp-file-renamer/gpfr-apply-rename-to-every-field.php
@@ -13,3 +13,20 @@
 add_filter( 'gpfr_is_applicable_field', function ( $should_apply_gpfr, $form, $field ) {
 	return true;
 }, 10, 3 );
+
+
+/**
+ * It is recommended to also register a filter callback for `gpfr_filename_template` to ensure that
+ * any file upload fields without a template set in the form settings will still get a valid template.
+ *
+ * Without inlcuding this, any file upload fields without a template set will automatically assume that the
+ * intended file name is an empty string which will likely cause unintended behavior.
+ */
+add_filter( 'gpfr_filename_template', function( $template, $file, $form, $field, $entry ) {
+	// if no template is set for this field, default to storing each file in a directory name by the entry id.
+	if ( empty( $template ) ) {
+		return '{entry_id}/{filename}';
+	}
+
+	return $template;
+}, 10, 5 );

--- a/gp-file-renamer/gpfr-apply-rename-to-every-field.php
+++ b/gp-file-renamer/gpfr-apply-rename-to-every-field.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Gravity Perks // File Renamer // Apply Rename to Every Field
+ * https://gravitywiz.com/documentation/gravity-forms-file-renamer/
+ *
+ * This applies GPFR to every single field, no matter if there is a "template value" set for the field or not.
+ *
+ * This is useful when combined with "gpfr_filename_template" filter to automatically apply the filtered template
+ * to all fields.
+ *
+ * Requires GP File Renamer v1.0.6+
+ */
+add_filter( 'gpfr_is_applicable_field', function ( $should_apply_gpfr, $form, $field ) {
+	return true;
+}, 10, 3 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2330760345/53504?folderId=6987275 

## Summary

If using the `gpfr_filename_template` to automatically set a filename template for every field, it can become quite laborious to go through every single field and add a "dummy" template. This allows you to automatically apply GPFR to any field you want to on the fly.

🚨 Relies on the changes in this GPNF pull request: https://github.com/gravitywiz/gp-file-renamer/pull/13
