### PR TITLE
`gw-cache-buster.php`: Fixed issue where default `gform_post_render` event suppression was not working after a string change in GF's init script.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -174,6 +174,7 @@ class GW_Cache_Buster {
 					gform.initializeOnLoaded( function() {
 						// Form has been rendered. Trigger post render to initialize scripts.
 						jQuery( document ).trigger( 'gform_post_render', [ formId, 1 ] );
+						gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: formId, currentPage: 1 } });} );
 					} );
 				} );
 			} ( jQuery ) );
@@ -190,10 +191,15 @@ class GW_Cache_Buster {
 
 	public function suppress_default_post_render_event( $form_string, $form, $current_page ) {
 
-		$footer_script_body = "gform.initializeOnLoaded( function() { jQuery(document).trigger('gform_post_render', [{$form['id']}, {$current_page}]) } );";
-		$search             = GFCommon::get_inline_script_tag( $footer_script_body );
+		$searches = array(
+			"gform.initializeOnLoaded( function() { jQuery(document).trigger('gform_post_render', [{$form['id']}, {$current_page}]) } );",
+			"gform.initializeOnLoaded( function() {jQuery(document).trigger('gform_post_render', [{$form['id']}, {$current_page}]);gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: {$form['id']}, currentPage: {$current_page} } });} );",
+		);
 
-		$form_string = str_replace( $search, '', $form_string );
+		foreach ( $searches as $search ) {
+			$search      = GFCommon::get_inline_script_tag( $search );
+			$form_string = str_replace( $search, '', $form_string );
+		}
 
 		return $form_string;
 	}


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

💬 Slack: https://gravitywiz.slack.com/archives/C03T0CNL8AV/p1693304528635109?thread_ts=1692977024.600819&cid=C03T0CNL8AV

🆘 HelpScout: https://secure.helpscout.net/conversation/2318327951/52962/

## Summary

https://www.loom.com/share/12e8a695e16f43be9f8720553ec7712b?sid=a561a02a-00c7-4c46-bb92-9ec8fa69e6e4
