### PR TITLE
Fixes for count and currency parsing

### DIFF
--- a/gp-populate-anything/gppa-aggregate-functions.php
+++ b/gp-populate-anything/gppa-aggregate-functions.php
@@ -22,7 +22,6 @@
  */
 class GPPA_Aggregate_Functions {
 
-	public static $default_count_regex = '/{count}/';
 	public static $sum_regex = '/{sum:(.+)}/';
 	public static $avg_regex = '/{avg:(.+)}/';
 	public static $min_regex = '/{min:(.+)}/';
@@ -57,15 +56,14 @@ class GPPA_Aggregate_Functions {
 
 	}
 
-	public function enable_query_all_value_objects( $query_all_value_objects, $field, $field_values, $object_type_instance, $filter_groups, $primary_property, $templates ) {
-		return $this->matches_any_merge_tag( rgar( $templates, 'value' ) );
+	public function enable_query_all_value_objects( $should_query_all, $field, $field_values, $object_type_instance, $filter_groups, $primary_property, $templates ) {
+		return $should_query_all || $this->matches_any_merge_tag( rgar( $templates, 'value' ) );
 	}
 
 	// The count function normally has "query all value objects" enabled, but this function overrides that.
 	// We need to specify that count has to have "query all value objects" enabled to avoid breaking it.
 	public function matches_any_merge_tag( $template_value ) {
-		return preg_match( self::$default_count_regex, $template_value ) ||
-			preg_match( self::$sum_regex, $template_value ) ||
+		return preg_match( self::$sum_regex, $template_value ) ||
 			preg_match( self::$avg_regex, $template_value ) ||
 			preg_match( self::$min_regex, $template_value ) ||
 			preg_match( self::$max_regex, $template_value );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

This is a proposed fix for the aggregate functions snippet.  By default, the {count} merge tag requires that the gppa_query_all_value_objects filter return "true."  Because this snippet overrides that filter, it breaks the {count}
merge tag.  This fix resolves that issue.

This fix also resolves an issue with parsing currency values from fields that aren't "product" fields.  For instance, if we have a group of checkboxes with currency values in them, values with dollar signs or thousands separators won't be parsed properly.  Feel free to modify this portion of the fix to improve currency parsing.
