### PR TITLE
`gw-dynamic-range.php`: Added support for dynamically populated min-max fields to work with dynamic range logic.

### DIFF
--- a/gravity-forms/gw-dynamic-range.php
+++ b/gravity-forms/gw-dynamic-range.php
@@ -241,6 +241,18 @@ class GW_Dynamic_Range {
 
 					}
 
+					// For dynamically populated Min-Max Fields
+					$( document ).on( 'gppa_updated_batch_fields', function( e, formId, updatedFieldIDs ) {
+						if ( parseInt( formId ) !== self.formId ) {
+							return;
+						}
+
+						// Re-init if min or max fields are updated via GP Populate Anything
+						if ( $.inArray( String( self.minFieldId ), updatedFieldIDs ) !== -1 || $.inArray( String( self.maxFieldId ), updatedFieldIDs ) !== -1 ) {
+							self.init();
+						}
+					} );
+
 					self.init();
 
 				}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2367056173/54949?folderId=3808239

## Summary

The snippet doesn't work if the field used to set the min and max attributes are dynamically populated.

BEFORE:
https://www.loom.com/share/6410c8dfeb4b4ea8bf7b2295ca820659

AFTER:
https://www.loom.com/share/2f66ffff239446a089981a271cbab5f7
