### PR TITLE
`gw-prioritize-next-over-save-and-continue.js`: Added a snippet to prevent the Save & Continue button from taking priority over Next buttons when pressing enter.

### DIFF
--- a/gravity-forms/gw-prioritize-next-over-save-and-continue.js
+++ b/gravity-forms/gw-prioritize-next-over-save-and-continue.js
@@ -1,0 +1,11 @@
+/**
+ * Gravity Wiz // Gravity Forms // Prioritize Next Button Over Save and Continue When Pressing Enter
+ * https://gravitywiz.com/
+ *
+ * Instructions:
+ *    Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-custom-javascript/
+ */
+$("#gform_GFFORMID")
+	.find(".gform_save_link")
+	.attr("type", "button");


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2371358392/55130?folderId=3808239

## Summary

In GPASC, there's an issue where pressing the Enter or Return key activates the "Save" action instead of the "Next" action. This is because the "Save and Continue" link is implemented using <input type="submit">, while the "Next page" button is implemented using <input type="button">. Overall this does seem the right approach.

To customize the user experience, this JavaScript snippet can be integrated to modify the behavior. This snippet enables users to effectively "skip" the default Enter key behavior associated with "Save and Continue" and instead allows them to progress through the form and navigate to the "Next" pages when they press Enter.

BEFORE:
https://www.loom.com/share/9e4bbabe16e346a28d70b96025d42306

AFTER:
https://www.loom.com/share/5922cba6fa5d43afa9d392e36301f725
