### PR TITLE
`gpep-edit-entry.php`: Added support for workflow restarting when an entry is edited on the frontend with GPEPEE.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -106,8 +106,8 @@ class GPEP_Edit_Entry {
 				$session[ gp_easy_passthrough()->get_slug() . '_' . $form['id'] ] = null;
 				remove_action( 'gform_after_submission', array( gp_easy_passthrough(), 'store_entry_id' ) );
 			}
+			// If restart workflow is enabled.
 			if ( $this->restart_workflow ) {
-				// If updating the entry, make sure to restart the Gravity Flow Workflow.
 				$api = new Gravity_Flow_API( $form['id'] );
 				$api->restart_workflow( GFAPI::get_entry( $update_entry_id ) );
 			}
@@ -189,8 +189,8 @@ class GPEP_Edit_Entry {
 
 // Configurations
 new GPEP_Edit_Entry( array(
-	'form_id'        => 123,   // Set this to the form ID.
-	'delete_partial' => false, // Set this to false if you wish to preserve partial entries after an edit is submitted.
-	'refresh_token'  => true,  // Set this to true to generate a fresh Easy Passthrough token after updating an entry.
-	'restart_workflow' => true, // Set this to true to restart the workflow
+	'form_id'          => 123,   // Set this to the form ID.
+	'delete_partial'   => false, // Set this to false if you wish to preserve partial entries after an edit is submitted.
+	'refresh_token'    => true,  // Set this to true to generate a fresh Easy Passthrough token after updating an entry.
+	'restart_workflow' => true,  // Set this to true to restart the workflow.
 ) );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -106,9 +106,11 @@ class GPEP_Edit_Entry {
 				$session[ gp_easy_passthrough()->get_slug() . '_' . $form['id'] ] = null;
 				remove_action( 'gform_after_submission', array( gp_easy_passthrough(), 'store_entry_id' ) );
 			}
-			// If updating the entry, make sure to restart the Gravity Flow Workflow.
-			$api = new Gravity_Flow_API( $form['id'] );
-			$api->restart_workflow( GFAPI::get_entry( $update_entry_id ) );
+			if ( $this->restart_workflow ) {
+				// If updating the entry, make sure to restart the Gravity Flow Workflow.
+				$api = new Gravity_Flow_API( $form['id'] );
+				$api->restart_workflow( GFAPI::get_entry( $update_entry_id ) );
+			}
 			return $update_entry_id;
 		}
 
@@ -190,4 +192,5 @@ new GPEP_Edit_Entry( array(
 	'form_id'        => 123,   // Set this to the form ID.
 	'delete_partial' => false, // Set this to false if you wish to preserve partial entries after an edit is submitted.
 	'refresh_token'  => true,  // Set this to true to generate a fresh Easy Passthrough token after updating an entry.
+	'restart_workflow' => true, // Set this to true to restart the workflow
 ) );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -106,6 +106,9 @@ class GPEP_Edit_Entry {
 				$session[ gp_easy_passthrough()->get_slug() . '_' . $form['id'] ] = null;
 				remove_action( 'gform_after_submission', array( gp_easy_passthrough(), 'store_entry_id' ) );
 			}
+			// If updating the entry, make sure to restart the Gravity Flow Workflow.
+			$api = new Gravity_Flow_API( $form['id'] );
+			$api->restart_workflow( GFAPI::get_entry( $update_entry_id ) );
 			return $update_entry_id;
 		}
 

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -193,5 +193,5 @@ new GPEP_Edit_Entry( array(
 	'form_id'          => 123,   // Set this to the form ID.
 	'delete_partial'   => false, // Set this to false if you wish to preserve partial entries after an edit is submitted.
 	'refresh_token'    => true,  // Set this to true to generate a fresh Easy Passthrough token after updating an entry.
-	'restart_workflow' => true,  // Set this to true to restart the workflow.
+	'restart_workflow' => true,  // Set this to true to restart the Gravity Flow workflow.
 ) );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -193,5 +193,5 @@ new GPEP_Edit_Entry( array(
 	'form_id'          => 123,   // Set this to the form ID.
 	'delete_partial'   => false, // Set this to false if you wish to preserve partial entries after an edit is submitted.
 	'refresh_token'    => true,  // Set this to true to generate a fresh Easy Passthrough token after updating an entry.
-	'restart_workflow' => true,  // Set this to true to restart the Gravity Flow workflow.
+	'restart_workflow' => false,  // Set this to true to restart the Gravity Flow workflow.
 ) );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -24,9 +24,10 @@ class GPEP_Edit_Entry {
 			return;
 		}
 
-		$this->form_id        = rgar( $options, 'form_id' );
-		$this->delete_partial = rgar( $options, 'delete_partial', true );
-		$this->refresh_token  = rgar( $options, 'refresh_token', false );
+		$this->form_id           = rgar( $options, 'form_id' );
+		$this->delete_partial    = rgar( $options, 'delete_partial', true );
+		$this->refresh_token     = rgar( $options, 'refresh_token', false );
+		$this->restart_workflow  = rgar( $options, 'restart_workflow', false );
 
 		add_filter( "gpep_form_{$this->form_id}", array( $this, 'capture_passed_through_entry_ids' ), 10, 3 );
 		add_filter( "gform_entry_id_pre_save_lead_{$this->form_id}", array( $this, 'update_entry_id' ), 10, 2 );

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -108,7 +108,7 @@ class GPEP_Edit_Entry {
 				remove_action( 'gform_after_submission', array( gp_easy_passthrough(), 'store_entry_id' ) );
 			}
 			// If restart workflow is enabled.
-			if ( $this->restart_workflow ) {
+			if ( $this->restart_workflow && class_exists( 'Gravity_Flow_API' ) ) {
 				$api = new Gravity_Flow_API( $form['id'] );
 				$api->restart_workflow( GFAPI::get_entry( $update_entry_id ) );
 			}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2359338748/54671?folderId=3808239

## Summary

With the snippet [Edit Entries via Easy Passthrough](https://gravitywiz.com/edit-gravity-forms-entries-on-the-front-end/) snippet, Gravity Flow Workflow is not restarted. This update adds an option for that functionality.

BEFORE (Without the update):
https://www.loom.com/share/db89455486434d9db3fc49ed241814bd

AFTER (With the update):
https://www.loom.com/share/a921f937b45145c597b1877523365d18
