### PR TITLE
Fixed an issue with GPPA GV Edit on GPPA 2.0.

### DIFF
--- a/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
+++ b/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
@@ -14,7 +14,7 @@ add_filter( 'gravityview/edit_entry/field_value', function( $field_value, $field
 	}
 
 	// Update "123" to your form ID and "4" to your field ID.
-	if ( $field->formId == 268 && $field->id == 1 ) {
+	if ( $field->formId == 123 && $field->id == 4 ) {
 		if ( isset( $GLOBALS['gppa-field-values'] ) ) {
 			// Based on GPPA version, we will need a different method call.
 			$hydrated_field = version_compare( $gppa_version, '2.0', '>=' ) ?

--- a/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
+++ b/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
@@ -7,19 +7,10 @@
  * https://github.com/gravitywiz/snippet-library/blob/master/gp-populate-anything/gppa-gpnf-force-dyn-pop-on-gv-edit.php
  */
 add_filter( 'gravityview/edit_entry/field_value', function( $field_value, $field ) {
-	$gppa_version = defined( 'GPPA_VERSION' ) ? GPPA_VERSION : 'NA';
-	// If GPPA is not active, return.
-	if ( $gppa_version === 'NA' ) {
-		return $field_value;
-	}
-
 	// Update "123" to your form ID and "4" to your field ID.
 	if ( $field->formId == 123 && $field->id == 4 ) {
 		if ( isset( $GLOBALS['gppa-field-values'] ) ) {
-			// Based on GPPA version, we will need a different method call.
-			$hydrated_field = version_compare( $gppa_version, '2.0', '>=' ) ?
-				gp_populate_anything()->populate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false ) :
-				gp_populate_anything()->hydrate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false );
+			$hydrated_field = gp_populate_anything()->populate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false );
 			$field_value    = $hydrated_field['field_value'];
 		}
 	}

--- a/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
+++ b/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
@@ -7,10 +7,19 @@
  * https://github.com/gravitywiz/snippet-library/blob/master/gp-populate-anything/gppa-gpnf-force-dyn-pop-on-gv-edit.php
  */
 add_filter( 'gravityview/edit_entry/field_value', function( $field_value, $field ) {
+	$gppa_version = defined( 'GPPA_VERSION' ) ? GPPA_VERSION : 'NA';
+	// If GPPA is not active, return.
+	if ( $gppa_version === 'NA' ) {
+		return $field_value;
+	}
+
 	// Update "123" to your form ID and "4" to your field ID.
-	if ( $field->formId == 123 && $field->id == 4 ) {
+	if ( $field->formId == 268 && $field->id == 1 ) {
 		if ( isset( $GLOBALS['gppa-field-values'] ) ) {
-			$hydrated_field = gp_populate_anything()->hydrate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false );
+			// Based on GPPA version, we will need a different method call.
+			$hydrated_field = version_compare( $gppa_version, '2.0', '>=' ) ?
+				gp_populate_anything()->populate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false ) :
+				gp_populate_anything()->hydrate_field( $field, GFAPI::get_form( $field->formId ), array(), null, false );
 			$field_value    = $hydrated_field['field_value'];
 		}
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2372100022/55166?folderId=3808239

## Summary

`gppa-force-dyn-pop-on-gv-edit.php` snippet does not work with GPPA 2.0. We need to update the method call.

Here is an example form below. The 'Single Line Text A' should populate the current user role. It does not work with GPPA 2.0 as of now (BEFORE). However, with the update (AFTER), it works fine whether we use GPPA 2.0.x or GPPA 1.2.x.

BEFORE:
https://www.loom.com/share/0aa5ebc17c2d48faabee2b6adc0186a1

AFTER:
https://www.loom.com/share/f5c39b748df04ced81e2cd431b8b56d1
