### PR TITLE
`gw-prevent-duplicate-selections.js`: Fixed an issue with placeholder value getting disabled.

### DIFF
--- a/gravity-forms/gw-prevent-duplicate-selections.js
+++ b/gravity-forms/gw-prevent-duplicate-selections.js
@@ -47,7 +47,7 @@ function gwDisableDuplicates( $elem, $group, selected ) {
 	}
 
 	let value     = $elem.val();
-	let $targets  = $group.not( $elem ).not( '.gplc-disabled' ).not( '.gpi-disabled' );
+	let $targets  = $group.not( $elem ).not( '.gplc-disabled' ).not( '.gpi-disabled' ).not( '.gf_placeholder' );
 	let isChecked = $elem.is( ':checked' );
 
 	// We use this to instruct Gravity Forms not to re-enable disabled duplicate options when


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2377401092/55467?folderId=3808239

## Summary

[This snippet](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-prevent-duplicate-selections.js) applies to Placeholder values, but it shouldn't.

Placeholder values should not be disabled.

**Both forms have the same placeholder values.**
<img width="410" alt="Screenshot 2023-10-03 at 7 12 32 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/aa75178f-a12d-4a5f-a289-0aaefdb990ce">

**Before update** (on form load, second dropdown's Placeholder isn't selectable)
<img width="279" alt="Screenshot 2023-10-03 at 7 16 56 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c87003c8-b5e1-463b-acfc-d50656acff56">

**After update** (on form load):
<img width="236" alt="Screenshot 2023-10-03 at 7 12 57 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/5df23edd-2b25-4f6c-9b02-d06779ad133b">
