### PR TITLE
`gpcc-copy-label.js`: Fixed an issue with copying labels from checkbox selections.

### DIFF
--- a/gp-copy-cat/gpcc-copy-label.js
+++ b/gp-copy-cat/gpcc-copy-label.js
@@ -19,7 +19,7 @@ gform.addFilter( 'gppc_copied_value', function( value, $elem, data ) {
 	} else if( $source.is( '.gfield_radio' ) ) {
 		value = $( '.gfield-choice-input:checked + label' ).text();
 	} else if ( $source.is( '.gfield_checkbox') ) {
-		$inputs= $source.find( 'input:checked' );
+		$inputs = $source.find( 'input:checked' );
 		var checkedLabels = [];
 		$inputs.each( function () {
 			var label = $(this).next('label').text();

--- a/gp-copy-cat/gpcc-copy-label.js
+++ b/gp-copy-cat/gpcc-copy-label.js
@@ -13,21 +13,19 @@
 * 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
 */
 gform.addFilter( 'gppc_copied_value', function( value, $elem, data ) {
-    $source = jQuery( '#input_' + data.sourceFormId + '_' + data.source );
-    if( $source.is( 'select' ) ) {
-        value = $source.find( 'option:selected' ).text();
-    } else if( $source.is( '.gfield_radio' ) ) {
-        value = $( '.gfield-choice-input:checked + label' ).text();
+	$source = jQuery( '#input_' + data.sourceFormId + '_' + data.source );
+	if( $source.is( 'select' ) ) {
+		value = $source.find( 'option:selected' ).text();
+	} else if( $source.is( '.gfield_radio' ) ) {
+		value = $( '.gfield-choice-input:checked + label' ).text();
 	} else if ( $source.is( '.gfield_checkbox') ) {
-		// Since multiple checkboxes maybe selected, make sure individual checkbox values do not have whitespaces.
-		values = value.split( ' ' );
-		var labelArray = [];
-		values.forEach( function ( value ) {
-			$input = $( 'input[value="' + value + '"]' );
-			var labelElement = $( 'label[for="' + $input.attr( 'id' ) + '"]' );
-			labelArray.push( labelElement.text() );
+		$inputs= $source.find( 'input:checked' );
+		var checkedLabels = [];
+		$inputs.each( function () {
+			var label = $(this).next('label').text();
+			checkedLabels.push( label );
 		});
-		value = labelArray.join( ' ' );
+		value = checkedLabels.join(' ');
 	}
-    return value;
+	return value;
 } );

--- a/gp-copy-cat/gpcc-copy-label.js
+++ b/gp-copy-cat/gpcc-copy-label.js
@@ -8,7 +8,7 @@
 * Use this snippet to copy the label instead of the value.
 *
 * Instructions:
-* 1. Install our free Custom Javascript for Gravity Forms plugin. 
+* 1. Install our free Custom Javascript for Gravity Forms plugin.
 *    Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
 * 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
 */
@@ -16,8 +16,18 @@ gform.addFilter( 'gppc_copied_value', function( value, $elem, data ) {
     $source = jQuery( '#input_' + data.sourceFormId + '_' + data.source );
     if( $source.is( 'select' ) ) {
         value = $source.find( 'option:selected' ).text();
-    }  else if( $source.is( '.gfield_radio' ) ) {
+    } else if( $source.is( '.gfield_radio' ) ) {
         value = $( '.gfield-choice-input:checked + label' ).text();
+	} else if ( $source.is( '.gfield_checkbox') ) {
+		// Since multiple checkboxes maybe selected, make sure individual checkbox values do not have whitespaces.
+		values = value.split( ' ' );
+		var labelArray = [];
+		values.forEach( function ( value ) {
+			$input = $( 'input[value="' + value + '"]' );
+			var labelElement = $( 'label[for="' + $input.attr( 'id' ) + '"]' );
+			labelArray.push( labelElement.text() );
+		});
+		value = labelArray.join( ' ' );
 	}
     return value;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2377837725/55492

## Summary

The snippet to copy the label of a choice-based field, when using Copy Cat, doesn't work on a Checkbox field. It only supports Dropdown and radio button fields. This update adds support for the checkbox field.

![Screenshot 2023-10-04 at 8 32 10 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/2aa6206e-491b-4c60-a7c3-8669f7cac743)

BEFORE:
https://www.loom.com/share/255f3dbe2e234d9694bf29ce3114a662

AFTER:
https://www.loom.com/share/731daa5781c1404489a290d83336c6ec
