### PR TITLE
Fixed issue where fields using the JSON API object without filters returned no results.

### DIFF
--- a/experimental/gppa-object-type-json-api.php
+++ b/experimental/gppa-object-type-json-api.php
@@ -143,9 +143,9 @@ class GPPA_Object_Type_JSON_API extends GPPA_Object_Type {
 	 */
 	public function search( $var, $search_params ) {
 		foreach ( $search_params as $search_group ) {
-			// For GPPA 2.0+, search_group may also read the numeric "limit" value, so skip for non-array values.
+			// For GPPA 2.0+, $search_group may also read the numeric "limit" value, so indicate match if it's not an array.
 			if ( ! is_array( $search_group ) ) {
-				continue;
+				return true;
 			}
 
 			$matches_group = true;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2377701857/55479/

## Summary

This PR addresses an issue introduced in https://github.com/gravitywiz/snippet-library/pull/677 where fields populating from the JSON API object without filters return no results. The issue was that we skipped that filter rather than indicating that all results matched that filter.

Worth noting this PR does not address the fact that the default limit of `501` is not honored by this snippet.
