### PR TITLE
`gw-quantity-as-decimal.php`: Fixed an issue with Calculation Product field not editable with decimal values.

### DIFF
--- a/gravity-forms/gw-quantity-as-decimal.php
+++ b/gravity-forms/gw-quantity-as-decimal.php
@@ -48,6 +48,7 @@ class GW_Quantity_Decimal {
 			add_filter( 'gform_field_input', array( $this, 'modify_quantity_input_tag' ), 10, 5 );
 		}
 
+		add_filter( 'gform_field_content', array( $this, 'fix_content' ), 10, 5 );
 	}
 
 	function allow_quantity_float( $result, $value, $form, $field ) {
@@ -85,6 +86,11 @@ class GW_Quantity_Decimal {
 		$markup  = str_replace( $search, $replace, $markup );
 
 		return $markup;
+	}
+
+	function fix_content( $content, $field, $value, $lead_id, $form_id ) {
+		// ensure the quantity min attribute.
+		return preg_replace( '/\smin=["\']0["\']/', 'min="0" step="any"', $content );
 	}
 
 	function get_field_input( $field, $value, $form ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2386150351/55864?folderId=3808239

## Summary

https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-quantity-as-decimal.php
The snippet doesn't work when editing the quantity of a calculated product field on the backend. This happens when the "Output HTML5" setting is enabled on Gravity Forms. On the Calculation field, Gravity Forms runs this logic:

`$qty_min_attr   = GFFormsModel::is_html5_enabled() ? "min='0'" : '';`

This adds the `"min='0'"` to the input field (For example, `<input type="number" name="input_3.3" value="5.2" id="ginput_quantity_305_3" class="ginput_quantity" size="10" min="0">`. This field would not be editable with decimal values now.

<img width="791" alt="Screenshot 2023-10-12 at 8 12 43 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/012258ae-edad-4081-9780-44a81e04f8db">

To fix this, we can add the [`step` attribute ](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)



