### PR TITLE
`gw-modify-thousand-separator.php`: Added new snippet to modify or remove the thousands separator in a currency field.

### DIFF
--- a/gravity-forms/gw-modify-thousand-separator.php
+++ b/gravity-forms/gw-modify-thousand-separator.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Modify Thousandths Separator
+ * https://gravitywiz.com/
+ *
+ * Usage:
+ *
+ * 1. Modify `$separator` to your desired thousandths separator. This example _removes_ the thousandths separator.
+ * 2. Thats it.
+ */
+
+add_filter( 'gform_currencies', function( $currencies ) {
+	$separator                               = '';
+	$currencies['EUR']['thousand_separator'] = $separator;
+	return $currencies;
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2382639486/55734?folderId=6987275 


## Summary

Adds a snippet to remove the `thousand_separator` from a currency field.


