### PR TITLE
`gw-none-of-the-above-checkbox.js`: Fixed an issue with the snippet not working.

### DIFF
--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -26,7 +26,7 @@ $( '.gw-none-of-the-above' ).each( function() {
 	var $others = $field.find( 'input' ).not( $last );
 
 	// If "None of the Above" choice is checked by default.
-	if ( $( $last ).prop( 'checked' ) ) {
+	if ( $last.prop( 'checked' ) ) {
 		var $checkboxes = $field.find( 'input' ).not( $last )
 		$checkboxes
 			.prop( 'checked', false )

--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -26,7 +26,7 @@ $( '.gw-none-of-the-above' ).each( function() {
 	var $others = $field.find( 'input' ).not( $last );
 
 	// If "None of the Above" choice is checked by default.
-	if ( $( last ).prop( 'checked' ) ) {
+	if ( $( $last ).prop( 'checked' ) ) {
 		var $checkboxes = $field.find( 'input' ).not( $last )
 		$checkboxes
 			.prop( 'checked', false )


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2398204713/56361/

## Summary

[This snippet](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-none-of-the-above-checkbox.js) is not working. A JS error is output into the console on page load.

**BEFORE:**
<img width="996" alt="Screenshot 2023-10-24 at 5 04 25 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c1fcc3bb-1be6-4ae7-87e1-7064b35ee14d">


**AFTER:**
<img width="141" alt="Screenshot 2023-10-24 at 5 02 47 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/0ae1d38c-d8e5-4335-9c64-52c14a7d142d">
<img width="103" alt="Screenshot 2023-10-24 at 5 02 52 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/583468b8-fe61-4616-bede-cb88fa42ba28">
