### PR TITLE
`gw-gravity-forms-rename-uploaded-files.php`: Fixed an issue where filename merge tag did not work.

### DIFF
--- a/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
+++ b/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
@@ -249,7 +249,7 @@ class GW_Rename_Uploaded_Files {
 
 		// replace merge tags
 		$form     = GFAPI::get_form( $entry['form_id'] );
-		$filename = GFCommon::replace_variables( $template, $form, $entry, false, true, false, 'text' );
+		$filename = GFCommon::replace_variables( $filename, $form, $entry, false, true, false, 'text' );
 		// make sure filename is "clean". This includes removing any user inputted items such as "../", "/usr/bin" etc
 		$filename = $this->clean( $filename );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2401416833/56482?folderId=3808239

## Summary

The {filename} merge tag doesn't work when using the Rename uploaded files snippet. Inadvertently, we were processing `GFCommon::replace_variables` on the initial `$template` after having replaced the `{filename}` value from it (if present). This update fixes that issue.

**_THE FORM:_**
<img width="323" alt="Screenshot 2023-10-28 at 9 20 45 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/fa67c3ac-c096-41a6-b57c-cd31f372bca0">

_**THE SNIPPET SETUP:**_
<img width="488" alt="Screenshot 2023-10-28 at 9 21 05 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/0faeb77d-1453-44ee-9196-b31eb6f04cd4">

**_THE TEST CASE:_**
<img width="237" alt="Screenshot 2023-10-28 at 9 21 47 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/4f22fa31-8eed-4608-a016-a48dd4a25ca4">

**_BEFORE:_**
<img width="219" alt="Screenshot 2023-10-28 at 9 23 24 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/7e9d543e-6649-49fc-a024-cc3fca4ac4e1">

**_AFTER:_**
<img width="211" alt="Screenshot 2023-10-28 at 9 22 30 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/a504bbcd-259d-427d-9674-b605a1c4556b">
