### PR TITLE
`gpep-edit-entry.php`: Added support for deleting values for conditionally hidden fields on edit.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -134,7 +134,7 @@ class GPEP_Edit_Entry {
 		$has_change = false;
 
 		// The passed entry does not reflect what is actually in the database.
-		$db_entry   = null;
+		$db_entry = null;
 
 		/**
 		 * @var \GF_Field $field
@@ -154,7 +154,7 @@ class GPEP_Edit_Entry {
 				$inputs = array(
 					array(
 						'id' => $field->id,
-					)
+					),
 				);
 			}
 
@@ -164,7 +164,6 @@ class GPEP_Edit_Entry {
 					break 2;
 				}
 			}
-
 		}
 
 		if ( $has_change ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2398744738/56383/

## Summary

**Video Overview**: https://www.loom.com/share/152186005083436d860d43362ea4609c

If you edit an entry with existing values, and during the edit, an existing value's field is hidden via conditional logic, one would expect that this value would be deleted, but it is not.

This PR resolves that issue by using `GFAPI::update_entry()` with the entry that has been generated based on the current submission. The current submission entry may differ from the entry stored in the database as GF's default form submission process does not delete values for conditionally hidden fields, only saves/updates new field values.

**Note:** We'll probably want to implement this for Entry Blocks at some point.
