### PR TITLE
`gw-update-posts.php`: Fixed an issue with confirmation message not displaying.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -166,6 +166,7 @@ class GW_Update_Posts {
 
 		}
 
+		// ensure the fires after hooks is set to false, so that doesn't override some of the normal rendering - GF confirmation for instance.
 		wp_update_post( $post, false, false );
 
 	}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -166,7 +166,7 @@ class GW_Update_Posts {
 
 		}
 
-		wp_update_post( $post );
+		wp_update_post( $post, false, false );
 
 	}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2402316918/56523?folderId=3808239

## Summary

When the Update Posts snippet is active on this user's form, the confirmation message doesn't display after submitting the form.

We disable `wp_update_post` param `$fire_after_hooks` to ensure we do see the confirmation.

**Confirmation message setting on form:**
![Screenshot 2023-10-31 at 2 10 06 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/9c2a7386-cce1-428d-a364-28917ffa127e)

**BEFORE:**
![Screenshot 2023-10-31 at 2 09 23 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/160de120-7f04-4369-83e3-e90d3f0ff48a)

**AFTER:**
![Screenshot 2023-10-31 at 2 09 35 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/78ce82d3-dce9-438e-9a96-15b66ffeb018)
