### PR TITLE
`gpro-readonly-on-edit.php`: Added a snippet to provide disable editing functionality on GPEB, GravityView and Gravity Flow User Input.

### DIFF
--- a/gp-entry-blocks/gpeb-readonly-on-edit.php
+++ b/gp-entry-blocks/gpeb-readonly-on-edit.php
@@ -1,30 +1,6 @@
 <?php
 /**
- * Gravity Perks // Entry Blocks // Set Fields as Readonly On Edit
- * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
- *
- * Configure fields to be readonly when editing via Entry Blocks by adding the "gpeb-readonly-on-edit" class to the
- * field's CSS Class Name field setting.
+ * This snippet has evolved! 🦄
+ * Find the new version of this snippet here:
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-read-only/gpro-readonly-on-edit
  */
-add_filter( 'gform_pre_render', 'gpeb_set_readonly_on_edit' );
-add_filter( 'gform_pre_process', 'gpeb_set_readonly_on_edit' );
-
-function gpeb_set_readonly_on_edit( $form ) {
-
-	$is_block = (bool) rgpost( 'gpeb_entry_id' );
-	if ( ! $is_block ) {
-		$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
-	}
-
-	if ( ! $is_block ) {
-		return $form;
-	}
-
-	foreach ( $form['fields'] as &$field ) {
-		if ( strpos( $field->cssClass, 'gpeb-readonly-on-edit' ) !== false ) {
-			$field->gwreadonly_enable = true;
-		}
-	}
-
-	return $form;
-}

--- a/gp-entry-blocks/gpeb-readonly-on-edit.php
+++ b/gp-entry-blocks/gpeb-readonly-on-edit.php
@@ -2,5 +2,5 @@
 /**
  * This snippet has evolved! 🦄
  * Find the new version of this snippet here:
- * https://github.com/gravitywiz/snippet-library/blob/master/gp-read-only/gpro-readonly-on-edit
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-read-only/gpro-readonly-on-edit.php
  */

--- a/gp-read-only/gpro-readonly-on-edit.php
+++ b/gp-read-only/gpro-readonly-on-edit.php
@@ -8,7 +8,7 @@
  * Usage:
  *
  * 1. Install this code as a plugin or as a snippet.
- * 2. Add the `gpeb-readonly-on-edit` CSS Class Name to field's Custom CSS Class setting.
+ * 2. Add the `gpro-readonly-on-edit` CSS Class Name to field's Custom CSS Class setting.
  *
  * Plugin Name:  GP Read Only —  Set Fields as Readonly On Edit
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-read-only/
@@ -23,22 +23,22 @@ add_filter( 'gform_pre_process', 'gpeb_set_readonly_on_edit' );
 
 function gpeb_set_readonly_on_edit( $form ) {
 
-$is_block = (bool) rgpost( 'gpeb_entry_id' );
-if ( ! $is_block ) {
-	$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
-}
+	$is_block = (bool) rgpost( 'gpeb_entry_id' );
+	if ( ! $is_block ) {
+		$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
+	}
 
-$is_gravityview  = function_exists( 'gravityview' ) && gravityview()->request->is_edit_entry();
-$is_gravity_flow = rgget( 'lid' ) && rgget( 'page' ) == 'gravityflow-inbox';
+	$is_gravityview  = function_exists( 'gravityview' ) && gravityview()->request->is_edit_entry();
+	$is_gravity_flow = rgget( 'lid' ) && rgget( 'page' ) == 'gravityflow-inbox';
 
-// disable the target field for GPEB, GravityView and Gravity Flow User Input step.
-if ( $is_block || $is_gravityview || $is_gravity_flow ) {
-	foreach ( $form['fields'] as &$field ) {
-		if ( strpos( $field->cssClass, 'gpeb-readonly-on-edit' ) !== false ) {
-			$field->gwreadonly_enable = true;
+	// disable the target field for GPEB, GravityView and Gravity Flow User Input step.
+	if ( $is_block || $is_gravityview || $is_gravity_flow ) {
+		foreach ( $form['fields'] as &$field ) {
+			if ( strpos( $field->cssClass, 'gpro-readonly-on-edit' ) !== false ) {
+				$field->gwreadonly_enable = true;
+			}
 		}
 	}
-}
 
-return $form;
+	return $form;
 }

--- a/gp-read-only/gpro-readonly-on-edit.php
+++ b/gp-read-only/gpro-readonly-on-edit.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Gravity Perks // GP Read Only // Set Fields as Readonly On Edit
+ * https://gravitywiz.com/documentation/gravity-forms-read-only/
+ *
+ * Configure fields to be readonly when editing via Entry Blocks or GravityView or Gravity Flow User Input Step.
+ *
+ * Usage:
+ *
+ * 1. Install this code as a plugin or as a snippet.
+ * 2. Add the `gpeb-readonly-on-edit` CSS Class Name to field's Custom CSS Class setting.
+ *
+ * Plugin Name:  GP Read Only —  Set Fields as Readonly On Edit
+ * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-read-only/
+ * Description:  This snippet allows you to set read only for fields when editing.
+ * Author:       Gravity Wiz
+ * Version:      0.1
+ * Author URI:   https://gravitywiz.com/
+ */
+
+add_filter( 'gform_pre_render', 'gpeb_set_readonly_on_edit' );
+add_filter( 'gform_pre_process', 'gpeb_set_readonly_on_edit' );
+
+function gpeb_set_readonly_on_edit( $form ) {
+
+$is_block = (bool) rgpost( 'gpeb_entry_id' );
+if ( ! $is_block ) {
+	$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
+}
+
+// disable the target field for GPEB, GravityView and Gravity Flow User Input step.
+if ( $is_block || ( function_exists( 'gravityview' ) && gravityview()->request->is_edit_entry() ) || ( rgget( 'lid' ) && rgget( 'page' ) == 'gravityflow-inbox' ) ) {
+	foreach ( $form['fields'] as &$field ) {
+		if ( strpos( $field->cssClass, 'gpeb-readonly-on-edit' ) !== false ) {
+			$field->gwreadonly_enable = true;
+		}
+	}
+}
+
+return $form;
+}

--- a/gp-read-only/gpro-readonly-on-edit.php
+++ b/gp-read-only/gpro-readonly-on-edit.php
@@ -28,8 +28,11 @@ if ( ! $is_block ) {
 	$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
 }
 
+$is_gravityview  = function_exists( 'gravityview' ) && gravityview()->request->is_edit_entry();
+$is_gravity_flow = rgget( 'lid' ) && rgget( 'page' ) == 'gravityflow-inbox';
+
 // disable the target field for GPEB, GravityView and Gravity Flow User Input step.
-if ( $is_block || ( function_exists( 'gravityview' ) && gravityview()->request->is_edit_entry() ) || ( rgget( 'lid' ) && rgget( 'page' ) == 'gravityflow-inbox' ) ) {
+if ( $is_block || $is_gravityview || $is_gravity_flow ) {
 	foreach ( $form['fields'] as &$field ) {
 		if ( strpos( $field->cssClass, 'gpeb-readonly-on-edit' ) !== false ) {
 			$field->gwreadonly_enable = true;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2402596321/56535?folderId=3808239

## Summary

Snippet updated to add field disabled functionality to GravityView and Gravity Flow User Input steps, along with GP Entry Blocks.

**GPEB (text disabled to edit)**
<img width="395" alt="Screenshot 2023-11-02 at 8 32 30 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/a4101459-f472-4090-9c7a-da9eeeb69391">

**GravityView (text disabled to edit)**
<img width="362" alt="Screenshot 2023-11-02 at 8 32 07 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/a9f7ef32-103f-44c0-a22c-77b7a64edf15">

**Gravity Flow (text disabled to edit)**
<img width="453" alt="Screenshot 2023-11-02 at 8 32 43 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/762951e0-82d7-44c9-9d7f-345e5e37136a">
