### PR TITLE
`gw-conditional-logic-enable-current-field.php`: Fixed an issue with conditional logic on current field snippet running on pages other than Form Editor.

### DIFF
--- a/gravity-forms/gw-conditional-logic-enable-current-field.php
+++ b/gravity-forms/gw-conditional-logic-enable-current-field.php
@@ -23,7 +23,7 @@ add_action( 'admin_footer', function() {
 		<script>
 			gform.addFilter( 'gform_is_conditional_logic_field', function( isSupported, field ) {
 				// Only apply our logic in the form editor when the current field is selected and its visibility is not set to "administrative".
-				if ( GetSelectedField() && GetSelectedField().id == field.id && field.visibility !== 'administrative' ) {
+				if ( typeof GetSelectedField === "function" && GetSelectedField() && GetSelectedField().id == field.id && field.visibility !== 'administrative' ) {
 					var inputType = GetInputType( field );
 					isSupported = jQuery.inArray( inputType, GetConditionalLogicFields() ) !== -1;
 				}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2415455946/57066/

## Summary

Snippet breaking Conditional Logic on Notifications. The snippet taps the JavaScript hook `gform_is_conditional_logic_field` which runs on Notification page, but since that isn't a Form Editor page we need to add a logic to prevent it from firing on non form editor pages.

**BEFORE:**
![Screenshot 2023-11-09 at 9 45 01 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/7b2d1742-638b-4b49-8fad-3531bdeb3f6a)

**AFTER:**
![Screenshot 2023-11-09 at 9 44 05 PM](https://github.com/gravitywiz/snippet-library/assets/26293394/f407db9e-9564-4722-8ef6-a99e5a2b764c)

