### PR TITLE
`gpaa-use-full-street-address.js`: Added snippet to use full street address for countries like Poland.

### DIFF
--- a/gp-address-autocomplete/gpaa-use-full-street-address.js
+++ b/gp-address-autocomplete/gpaa-use-full-street-address.js
@@ -1,0 +1,19 @@
+/**
+ * Gravity Perks // GP Address Autocomplete // Use Full Street Address
+ *
+ * For some countries like Poland, when entering an address with a street number,
+ * the place result may sometimes truncate it. This snippet will prepend the street number if it is not
+ * included in the result.
+ *
+ * http://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install our free Custom Javascript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-custom-javascript/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+window.gform.addFilter('gpaa_values', function(values, place, instance) {
+	var fullAddress = instance.inputs.address1.value;
+	values.address1 = fullAddress.split(',')[0].trim();
+	return values;
+});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2416758649/57134?folderId=3808239

## Summary

If the address includes a /XX number at the end of the first address line, you can select the address from the GPAA returned results, but the /XX number is removed.

**BEFORE:**
<img width="877" alt="Screenshot 2023-11-13 at 7 26 08 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/664ab172-9f15-4cd8-9fde-1416803d5ac0">

<img width="875" alt="Screenshot 2023-11-13 at 7 26 25 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/9a4ac73d-d2cf-493c-b12c-c5f852a91f6a">


**AFTER:**
<img width="878" alt="Screenshot 2023-11-13 at 7 25 47 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/6dadf765-c69f-4f96-9573-47be817c29aa">

<img width="887" alt="Screenshot 2023-11-13 at 7 25 24 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/f4095dc3-ca3d-4df9-b656-047ac2ea3c90">
