### PR TITLE
Fixed issue where zero-dollar products that had none-zero-dollar options were removed.

### DIFF
--- a/gravity-forms/gw-gravity-forms-filter-out-zero-dollar-products.php
+++ b/gravity-forms/gw-gravity-forms-filter-out-zero-dollar-products.php
@@ -9,18 +9,24 @@
  * Gravity Forms Drop Down Products which resulted in the placeholder choice being added to the
  * order as a zero-cost line item. We are not aware of a current need for this snippet.
  */
-add_filter( 'gform_product_info', 'gw_remove_empty_products', 10, 3 );
-function gw_remove_empty_products( $product_info, $form, $lead ) {
+add_filter( 'gform_product_info', function ( $product_info, $form, $lead ) {
 
 	$products = array();
 
 	foreach ( $product_info['products'] as $field_id => $product ) {
 		if ( GFCommon::to_number( $product['price'] ) != 0 ) {
 			$products[ $field_id ] = $product;
+		} else if ( isset( $product['options'] ) && is_array( $product['options'] ) ) {
+			foreach ( $product['options'] as $option ) {
+				if ( GFCommon::to_number( $option['price'] ) !== 0 ) {
+					$products[ $field_id ] = $product;
+					break;
+				}
+			}
 		}
 	}
 
 	$product_info['products'] = $products;
 
 	return $product_info;
-}
+}, 10, 3 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2408973399/56781/

## Summary

Updated snippet to prevent the removal of $0 products that contained non-$0 options.

### No Snippet
![CleanShot 2023-11-17 at 17 13 57@2x](https://github.com/gravitywiz/snippet-library/assets/550549/838a6f9d-2f33-4038-b829-fe2a1eb9ff38)

### Old Snippet
All products removed. 😆

### New Snippet
![CleanShot 2023-11-17 at 17 12 38@2x](https://github.com/gravitywiz/snippet-library/assets/550549/fa51f0dc-179f-4f72-a398-a67d9591582e)
