### PR TITLE
`gw-all-fields-template.php`: Fixed an issue with the email field not processed as a text but a link.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -440,6 +440,7 @@ class GW_All_Fields_Template {
 					}
 
 					$raw_field_value = RGFormsModel::get_lead_field_value( $lead, $field );
+					$format          = $field->type === 'email' ? 'text' : $format;
 					$field_value     = GFCommon::get_lead_field_display( $field, $raw_field_value, rgar( $lead, 'currency' ), $use_text, $format, 'email' );
 
 					$display_field = true;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2429986137/57820?folderId=3808239

## Summary

All Fields Template. Email fields are getting output as links. It should be getting output as an email text.

BEFORE:
<img width="421" alt="Screenshot 2023-11-24 at 3 55 51 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/536cc166-6539-41f5-b8a5-5307e7428009">

AFTER:
<img width="217" alt="Screenshot 2023-11-24 at 3 55 33 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/98cd068d-dc7a-481c-9c10-23229cb41ccc">
