### PR TITLE
`gravity-forms/gw-prevent-duplicate-selections.js`: Added support for GPADVS enabled multi-select fields.

### DIFF
--- a/gravity-forms/gw-prevent-duplicate-selections.js
+++ b/gravity-forms/gw-prevent-duplicate-selections.js
@@ -74,7 +74,7 @@ function getChangedOptionElFromSelect( $select, selected ) {
         const prevVal = gpadvsPreviousValues[selectId] || null;
 
         // Cache the current value so that we can compare against it on
-        // on the next change event to determine whih option was changed.
+        // on the next change event to determine which option was changed.
         gpadvsPreviousValues[selectId] = val;
 
         let changedOptVal;


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/GPADVS-1-1-Disabled-Choices-d910084a1ed24bd8947fdd6df242a2a9?pvs=4 

## Summary

This enabled support for this snippet on GPADVS enabled multi-select fields.

