### PR TITLE
`gw-include-post-permalink.php`: Fixed an issue with Post ID not fetching with merge tags with APC addon updates.

### DIFF
--- a/gravity-forms/gw-include-post-permalink.php
+++ b/gravity-forms/gw-include-post-permalink.php
@@ -18,10 +18,17 @@
 class GWPostPermalink {
 
 	function __construct() {
-
+		add_filter( 'gform_is_feed_asynchronous', array( $this, 'disable_async' ), 10, 4 );
 		add_filter( 'gform_custom_merge_tags', array( $this, 'add_custom_merge_tag' ), 10, 4 );
 		add_filter( 'gform_replace_merge_tags', array( $this, 'replace_merge_tag' ), 10, 3 );
 
+	}
+
+	function disable_async ( $is_async, $feed, $entry, $form ) {
+		if ( rgar( $feed, 'addon_slug' ) === 'gravityformsadvancedpostcreation' ) {
+			return false;
+		}
+		return $is_async;
 	}
 
 	function add_custom_merge_tag( $merge_tags, $form_id, $fields, $element_id ) {
@@ -62,21 +69,6 @@ class GWPostPermalink {
 	}
 
 	function get_post_id_by_entry( $entry ) {
-		// retry logic to fetch the post_id
-		$retry_limit = 3;
-		$retry_count = 0;
-		$post_id     = 0;
-		while ( $post_id === 0 && $retry_count < $retry_limit ) {
-			// refresh entry and try to get post
-			$entry   = GFAPI::get_entry( $entry['id'] ) ;
-			$post_id = absint( rgar( $entry, 'post_id' ) );
-		
-			if ( $post_id === 0 ) {
-				sleep(1); // Wait for 1 second before retrying
-				$retry_count++;
-			}
-		}
-
 		$post_id = rgar( $entry, 'post_id' );
 		if ( ! $post_id && function_exists( 'gf_advancedpostcreation' ) ) {
 			$entry_post_ids = gform_get_meta( $entry['id'], gf_advancedpostcreation()->get_slug() . '_post_id' );

--- a/gravity-forms/gw-include-post-permalink.php
+++ b/gravity-forms/gw-include-post-permalink.php
@@ -62,6 +62,21 @@ class GWPostPermalink {
 	}
 
 	function get_post_id_by_entry( $entry ) {
+		// retry logic to fetch the post_id
+		$retry_limit = 3;
+		$retry_count = 0;
+		$post_id     = 0;
+		while ( $post_id === 0 && $retry_count < $retry_limit ) {
+			// refresh entry and try to get post
+			$entry   = GFAPI::get_entry( $entry['id'] ) ;
+			$post_id = absint( rgar( $entry, 'post_id' ) );
+		
+			if ( $post_id === 0 ) {
+				sleep(1); // Wait for 1 second before retrying
+				$retry_count++;
+			}
+		}
+
 		$post_id = rgar( $entry, 'post_id' );
 		if ( ! $post_id && function_exists( 'gf_advancedpostcreation' ) ) {
 			$entry_post_ids = gform_get_meta( $entry['id'], gf_advancedpostcreation()->get_slug() . '_post_id' );

--- a/gravity-forms/gw-include-post-permalink.php
+++ b/gravity-forms/gw-include-post-permalink.php
@@ -18,6 +18,7 @@
 class GWPostPermalink {
 
 	function __construct() {
+		// we have to disable asynchronous feed to ensure post permalink merge tags are not rendered before post is actually created
 		add_filter( 'gform_is_feed_asynchronous', array( $this, 'disable_async' ), 10, 4 );
 		add_filter( 'gform_custom_merge_tags', array( $this, 'add_custom_merge_tag' ), 10, 4 );
 		add_filter( 'gform_replace_merge_tags', array( $this, 'replace_merge_tag' ), 10, 3 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2438396771/58350?folderId=3808239


## Summary

The Post permalink snippet doesn't work with the latest version of Gravity Forms Advanced Post Creation Add-On.

As a fix, this update adds a 'retry logic' to ensure we do fetch the post id. Changing the priority of the hooks `add_filter( 'gform_replace_merge_tags', array( $this, 'replace_merge_tag' ), 10, 3 );` wasn't giving a consistent resolution. The retry logic gave 100% results on my testing.


Video demo of the issue (Credits @sbassah):
 https://www.loom.com/share/dfc79bc1eda6424ab8bc7c4d457a6982?sid=7cf4436b-f7fe-434c-9a7b-07f3b4dbfa9a
 
 After this update, the merge tag always works.