### PR TITLE
`gpnf-export-child-field-header.php`: Updated to add support for handling input-specific column headers.

### DIFF
--- a/gp-nested-forms/gpnf-export-child-field-header.php
+++ b/gp-nested-forms/gpnf-export-child-field-header.php
@@ -3,15 +3,20 @@
  * Gravity Perks // Nested Forms // Only show child field labels when Nested Form field has no label
  * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
  */
-add_filter( 'gpnf_export_child_field_header', function( $header, $form, $field, $child_field ) {
+add_filter( 'gpnf_export_child_field_header', function( $header, $form, $field, $child_field, $input ) {
 
 	$parent_label = $field->get_field_label( false, null );
+	if ( ! empty( $parent_label ) ) {
+		return $header;
+	}
 
-	if ( empty( $parent_label ) ) {
-		$header = $child_field->get_field_label( false, null );
+	$child_field_label = $child_field->get_field_label( false, null );
+
+	if ( rgar( $input, 'label' ) ) {
+		$header = sprintf( '%s (%s)', $child_field_label, $input['label'] );
 	} else {
-		$header = sprintf( '%s / %s', $parent_label, $child_field->get_field_label( false, null ) );
+		$header = $child_field_label;
 	}
 
 	return $header;
-}, 10, 4 );
+}, 10, 5 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2429207246/57777

## Summary

With the introduction of input-specific export columns in https://github.com/gravitywiz/gp-nested-forms/pull/57, this snippet must be updated to account for this new scenario.
