### PR TITLE
`gw-gravity-forms-custom-js.php`: Fixed an issue with Custom JS not rendering in some scenarios.

### DIFF
--- a/gravity-forms/gw-gravity-forms-custom-js.php
+++ b/gravity-forms/gw-gravity-forms-custom-js.php
@@ -94,9 +94,11 @@ class GF_Custom_JS {
 	}
 
 	public function add_custom_js_setting( $form_settings, $form ) {
-		if ( rgget( 'subview' ) !== 'settings' ) {
+		// If we are on the 'settings' subview OR when subview is not set, then by default it will open the 'settings' subview
+		if ( rgget( 'subview' ) !== 'settings' && !( rgget ( 'view' ) === 'settings' && ! isset( $_GET['subview'] ) ) ) {
 			return $form_settings;
 		}
+
 		$form_settings['Custom Code'] = array(
 			'title'  => esc_html__( 'Custom Code' ),
 			'fields' => array(
@@ -111,6 +113,7 @@ class GF_Custom_JS {
 				),
 			),
 		);
+
 		return $form_settings;
 	}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2451951378/58904?folderId=3808239

## Summary

The Custom JS settings do not show when navigating to form settings via the form selector in the top left corner of Gravity Forms.

The initial logic is just to check the `subview` on the `$_GET`, but when we are loaded to the form settings via the form selector on the top left, the `subview` is blank. Even though the default view does still render the main Form Settings page. For this, we can add a case check - when `view` does confirm `settings` but `subview` is empty / not set.

**BEFORE:**
https://www.loom.com/share/840f0632eebe4f19906827cf99eb4fc0

**AFTER:**
https://www.loom.com/share/1d46572075df42028c833fcafcc33d5a
