### PR TITLE
`gw-cache-buster.php`: Fixed issue where default `gform_post_render` event suppression incorrectly applied to all forms.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -9,7 +9,7 @@
  * Plugin URI:  https://gravitywiz.com/cache-busting-with-gravity-forms/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
- * Version:     0.3
+ * Version:     0.4
  * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
@@ -57,8 +57,6 @@ class GW_Cache_Buster {
 
 		$form_id = $atts['id'];
 
-		add_filter( "gform_footer_init_scripts_filter_{$form_id}", array( $this, 'suppress_default_post_render_event' ), 10, 3 );
-
 		if ( ! $this->is_cache_busting_applicable() ) {
 			return $markup;
 		}
@@ -67,6 +65,8 @@ class GW_Cache_Buster {
 		if ( ! $is_enabled ) {
 			return $markup;
 		}
+
+		add_filter( "gform_footer_init_scripts_filter_{$form_id}", array( $this, 'suppress_default_post_render_event' ), 10, 3 );
 
 		ob_start();
 		?>


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2438335097/58348

## Summary

Cache Buster incorrectly suppresses the default `gform_post_render` event for _all_ forms regardless of whether Cache Buster was enabled for that form or if that form was being rendered in a context that is applicable for Cache Buster.

Hilariously, I already tried to fix this once here (https://github.com/gravitywiz/snippet-library/commit/651990849fa8da6f9b5eacb3e0ad2945001aeeec) but I was clearly smoking crack at the time as it seems painfully obvious that was not the right place to move the filter. 😆
