### PR TITLE
`gw-update-posts.php`: Fixed an issue with Update Posts updating post date time even when value was not set.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -97,9 +97,13 @@ class GW_Update_Posts {
 		}
 
 		if ( $this->_args['post_date'] ) {
-			$new_date_time       = $this->get_post_date( $entry, $form );
-			$post->post_date     = $new_date_time;
-			$post->post_date_gmt = get_gmt_from_date( $new_date_time );
+			$new_date_time = $this->get_post_date( $entry, $form );
+			if ( $this->_args['post_date']['date'] ) {
+				$post->post_date = $new_date_time;
+			}
+			if ( $this->_args['post_date']['time'] ) {
+				$post->post_date_gmt = get_gmt_from_date( $new_date_time );
+			}
 		}
 
 		if ( $this->_args['featured_image'] && is_callable( 'gp_media_library' ) ) {

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -11,6 +11,8 @@
  */
 class GW_Update_Posts {
 
+	protected $_args;
+
 	public function __construct( $args = array() ) {
 
 		// Set our default arguments, parse against the provided arguments, and store for use throughout the class.
@@ -96,12 +98,13 @@ class GW_Update_Posts {
 			$post->post_name = rgar( $entry, $this->_args['slug'] );
 		}
 
-		if ( $this->_args['post_date'] ) {
-			$new_date_time = $this->get_post_date( $entry, $form );
-			if ( $this->_args['post_date']['date'] ) {
-				$post->post_date = $new_date_time;
-			}
-			if ( $this->_args['post_date']['time'] ) {
+		if (
+			( ! is_array( $this->_args['post_date'] ) && ! empty( $this->_args['post_date'] ) ) ||
+				rgars( $this->_args, 'post_date/date' )
+		) {
+			$new_date_time       = $this->get_post_date( $entry, $form );
+			if ( $new_date_time ) {
+				$post->post_date     = $new_date_time;
 				$post->post_date_gmt = get_gmt_from_date( $new_date_time );
 			}
 		}
@@ -227,7 +230,7 @@ class GW_Update_Posts {
 			}
 		} else {
 			$post_date['date'] = $this->_args['post_date']['date'];
-			$post_date['time'] = $this->_args['post_date']['time'];
+			$post_date['time'] = rgar( $this->_args['post_date'], 'time' );
 		}
 
 		$date = rgar( $entry, $post_date['date'], gmdate( 'm/d/Y' ) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2461660694/59260?folderId=3808239

## Summary

The update post snippet also updates the Post Date to the current date even when the post date parameter is not set. This fix makes sure we check for the presence of the values provided in the argument before setting them, i.e. `$this->_args['post_date']['date']` and `$this->_args['post_date']['time']`.
