### PR TITLE
`gw-advanced-merge-tags.php`: Fixed an compatibility issue with `order_summary` merge tag modifiers.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -78,7 +78,7 @@ class GW_Advanced_Merge_Tags {
 		add_action( 'gform_pre_render', array( $this, 'support_dynamic_population_merge_tags' ) );
 
 		add_action( 'gform_merge_tag_filter', array( $this, 'support_html_field_merge_tags' ), 10, 4 );
-		add_action( 'gform_replace_merge_tags', array( $this, 'replace_merge_tags' ), 10, 3 );
+		add_action( 'gform_replace_merge_tags', array( $this, 'replace_merge_tags' ), 12, 3 );
 		add_action( 'gform_pre_replace_merge_tags', array( $this, 'replace_get_variables' ), 10, 5 );
 		add_action( 'gform_merge_tag_filter', array( $this, 'handle_field_modifiers' ), 10, 6 );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2463972101/59316?folderId=3808239

## Summary

The `order_summary:my_custom_template` doesn't work when the snippet `GW_Advanced_Merge_Tags` is activated.

The `GW_Advanced_Merge_Tags` snippet just needs to ensure its `gform_replace_merge_tags` logic doesn't happen too soon. The `gform_replace_merge_tags` happens at '10' (order summary and others), we make sure the advanced merge tags merge tag replacement happens later - say '12'.

**BEFORE:**
<img width="795" alt="Screenshot 2024-01-02 at 8 43 58 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/bc355921-fb3d-4387-a484-3a2d4fe97020">

**AFTER:**
<img width="804" alt="Screenshot 2024-01-02 at 8 43 42 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/0a172c34-78bd-4101-82e3-7d8bf1fc741c">

