### PR TITLE
`gpnf-limit-entry-min-max-from-field.php`: Fixed a possible error with the GPNF Min Max Entry Snippet.

### DIFF
--- a/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
+++ b/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
@@ -131,7 +131,7 @@ class GP_Nested_Forms_Dynamic_Entry_Min_Max {
 
 					self.init = function () {
 
-						var attrReadyMaxFieldId = self.maxFieldId.replace( '.', '_' );
+						var attrReadyMaxFieldId = typeof self.maxFieldId === 'string' ? self.maxFieldId.replace('.', '_') : self.maxFieldId;
 						var maxFieldId = 'input_' + self.parentFormId + '_' + attrReadyMaxFieldId;
 
 						// GF uses "1" for the input index in the HTML id attribute for Single Product fields. Weird.


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2465600705/59366?folderId=7098280

## Summary

The `attrReadyMaxFieldId` assigned to `self.maxFieldId.replace('.', '_')` can only be applicable if the maxFieldId is of data type string (having a value like '1.4', '2.2, etc). This would be because it is accessing a sub-field (like lists). For a simple text or number field, we just need `self.maxFieldId`. Also, calling `.replace` on a numeric value would trigger a console error.

Thus, this assignment must be updated with a check to ensure we are only applying it where necessary. Rest of the code compilation and processing is fine.
