### PR TITLE
`gpnf-map-child-entries-to-acf-repeater-field.php`: Fixed an issue with nested form field data not displaying on ACF field.

### DIFF
--- a/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
+++ b/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
@@ -5,7 +5,10 @@
  */
 
 class GPNF_Map_Child_Entries_To_ACF_Repeater {
-	function __construct( $args ) {
+
+	private $args;
+
+	public function __construct( $args ) {
 		$this->_args = wp_parse_args( $args, array(
 			'form_id'                 => false,
 			'nested_form_field_id'   => false,

--- a/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
+++ b/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
@@ -47,7 +47,7 @@ class GPNF_Map_Child_Entries_To_ACF_Repeater {
 	'form_id'                  => 7, // Set this to the parent form ID
 	'nested_form_field_id'     => 18, // Update to the ID of the Nested Form field.
 	'field_map'                => array(
-		'nom_comedien'         => 1,
+		'num_comedien'         => 1,
 		'role_comedien'        => 3,
 	), // The field map contains "field_name" => "child_entry_field_id" pairs. The field name is the name of the fields in
 	// the ACF Repeater field. The child entry field ID is the field ID from the child form.

--- a/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
+++ b/gp-nested-forms/gpnf-map-child-entries-to-acf-repeater-field.php
@@ -3,36 +3,50 @@
  * Gravity Perks // GP Nested Forms // Pass Nested Form Entries to ACF Repeater Field when using GF APC Add-on
  * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
  */
-// Update "123" to the ID of the Parent form.
-add_action( 'gform_after_submission_123', 'gw_child_entries_to_repeater', 10, 2 );
-function gw_child_entries_to_repeater( $entry, $form ) {
 
-	// Update "4" to the ID of the Nested Form field.
-	$nested_form_field_id = 4;
-	// The field map contains "field_name" => "child_entry_field_id" pairs. The field name is the name of the fields in
-	// the ACF Repeater field. The child entry field ID is the field ID from the child form.
-	$field_map = array(
-		'custom_field_one' => 5,
-		'custom_field_two' => 6,
-	);
-	// Update test_repeat to the field name of the ACF repeater field.
-	$acf_repeater_field_name = 'test_repeat';
-	/* STOP! You don't need to edit below this line. */
+class GPNF_Map_Child_Entries_To_ACF_Repeater {
+	function __construct( $args ) {
+		$this->_args = wp_parse_args( $args, array(
+			'form_id'                 => false,
+			'nested_form_field_id'   => false,
+			'field_map'               => array(),
+			'acf_repeater_field_name' => false,
+		) );
 
-	$parent_entry  = new GPNF_Entry( $entry );
-	$child_entries = $parent_entry->get_child_entries( $nested_form_field_id );
-	$repeat_value  = array();
-	$created_posts = gform_get_meta( $entry['id'], 'gravityformsadvancedpostcreation_post_id' );
-	foreach ( $created_posts as $post ) {
-		$post_id = $post['post_id'];
-		foreach ( $child_entries as $child_entry ) {
-			$value = array();
-			foreach ( $field_map as $acf_field_name => $child_entry_field_id ) {
-				$value[ $acf_field_name ] = rgar( $child_entry, $child_entry_field_id );
-			}
-			array_push( $repeat_value, $value );
-		}
-		update_field( $acf_repeater_field_name, $repeat_value, $post_id );
+		add_action( 'gform_advancedpostcreation_post_after_creation', array( $this, 'gw_child_entries_to_repeater' ), 10, 2 );
 	}
 
-}
+	function gw_child_entries_to_repeater( $post_id, $feed, $entry, $form ) {
+
+		if ( $form['id'] !== $this->_args['form_id'] ) {
+			return;
+		}
+	
+		$parent_entry  = new GPNF_Entry( $entry );
+		$child_entries = $parent_entry->get_child_entries( $this->_args['nested_form_field_id'] );
+		$repeat_value  = array();
+		$created_posts = gform_get_meta( $entry['id'], 'gravityformsadvancedpostcreation_post_id' );
+		foreach ( $created_posts as $post ) {
+			$post_id = $post['post_id'];
+			foreach ( $child_entries as $child_entry ) {
+				$value = array();
+				foreach ( $this->_args['field_map'] as $acf_field_name => $child_entry_field_id ) {
+					$value[ $acf_field_name ] = rgar( $child_entry, $child_entry_field_id );
+				}
+				array_push( $repeat_value, $value );
+			}
+			update_field( $this->_args['acf_repeater_field_name'], $repeat_value, $post_id );
+		}
+	}
+ }
+
+ new GPNF_Map_Child_Entries_To_ACF_Repeater( array(
+	'form_id'                  => 7, // Set this to the parent form ID
+	'nested_form_field_id'     => 18, // Update to the ID of the Nested Form field.
+	'field_map'                => array(
+		'nom_comedien'         => 1,
+		'role_comedien'        => 3,
+	), // The field map contains "field_name" => "child_entry_field_id" pairs. The field name is the name of the fields in
+	// the ACF Repeater field. The child entry field ID is the field ID from the child form.
+	'acf_repeater_field_name'  => 'comediens', // Update o the field name of the ACF repeater field.
+) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2438225719/58343?folderId=7098280

## Summary

When the parent form is submitted, a post is created with the Advanced Post Creation add-on. The Nested Form entries should be linked to the targetted repeater field in the created post, but they don't work. This is down to the asynchronous behavior of Gravity Forms Advanced Post Creation Add-on v1.4.0 ([changelog](https://docs.gravityforms.com/advanced-post-creation-change-log/)). Disabling async does resolve the issue.

Also, the snippet is converted to a class-based snippet for easy management by the end user.