### PR TITLE
`gw-all-fields-template.php`: Fixed a fatal error with the snippet and Nested Forms.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -8,7 +8,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-all-fields-template/
  * Description:  Modify the {all_fields} merge tag output via a template file.
  * Author:       Gravity Wiz
- * Version:      0.10
+ * Version:      0.11
  * Author URI:   http://gravitywiz.com
  *
  * Usage:

--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -175,6 +175,7 @@ class GW_All_Fields_Template {
 			 */
 			if ( $context == 'nested' ) {
 
+				$input_ids = array();
 				$nested_form_field_id = rgar( $modifiers, 'parent', false );
 				if ( ! $nested_form_field_id ) {
 					break;
@@ -198,7 +199,7 @@ class GW_All_Fields_Template {
 				case 'filter':
 					if ( in_array( $field->id, $field_ids ) ) {
 						// Check for input-specific filters.
-						if ( is_array( $raw_value ) && ! in_array( $field->id, $input_ids ) ) {
+						if ( is_array( $raw_value ) && ! empty( $input_ids ) && ! in_array( $field->id, $input_ids ) ) {
 							$filtered_values = array();
 
 							foreach ( $input_ids as $input_id ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2460908266/59240?folderId=3808239

## Summary

The All Fields Template is causing a fatal error:
`Warning: Undefined variable $input_ids in /.../gw-all-fields-template/gw-all-fields-template.php on line 201`

The issue is down to the `$input_ids` only getting initialized in the preceding else block (and not the if). This leads to potential scenarios of tapping in on that value/variable even though it does not exist.

**BEFORE:**
<img width="400" alt="Screenshot 2024-01-09 at 9 27 11 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/2ce0227b-2e0e-4af0-a682-763e01936187">

**AFTER:**
<img width="400" alt="Screenshot 2024-01-09 at 9 26 38 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/0af02e18-e719-4ba2-be65-ff583553e572">
