### PR TITLE
`gw-cache-buster.php`: Fixed PHP 8.2 warnings.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -14,6 +14,8 @@
  */
 class GW_Cache_Buster {
 
+	private $args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2460911417/59241?folderId=3808239

## Summary

`PHP Deprecated: Creation of dynamic property GW_Cache_Buster::$_args is deprecated in /.../gw-cache-buster/gw-cache-buster.php on line 20`

With PHP 8.2 the use of dynamic properties in a Class is deprecated. We need to have it explicitly declared.
