### PR TITLE
`gw-first-error-focus.php`: Removed behavior to scroll to the top of the form if there is no error unless it's a multi-page form.

### DIFF
--- a/gravity-forms/gw-first-error-focus.php
+++ b/gravity-forms/gw-first-error-focus.php
@@ -35,7 +35,7 @@ function gw_first_error_focus_script() {
 
 					if (!hasError) {
 						requestAnimationFrame(function() {
-							window.scrollTo(0, $('.gform_wrapper').offset().top);
+							window.scrollTo(0, 0);
 						});
 					}
 				});

--- a/gravity-forms/gw-first-error-focus.php
+++ b/gravity-forms/gw-first-error-focus.php
@@ -31,11 +31,16 @@ function gw_first_error_focus_script() {
 					// We need to reset our flag so that we can still do our focus action when the form conditional logic
 					// has been re-evaluated.
 					window['gwfef'] = false;
+					var y = 0;
+					// For a multiple page form after page 1, we need to render on the gform wrapper
+					if ($('.gf_step_current_page') && $('.gf_step_current_page').text() > 1) {
+						y = $('.gform_wrapper').offset().top;
+					}
 					var hasError = gwFirstErrorFocus().length;
 
 					if (!hasError) {
 						requestAnimationFrame(function() {
-							window.scrollTo(0, 0);
+							window.scrollTo(0, y);
 						});
 					}
 				});

--- a/gravity-forms/gw-first-error-focus.php
+++ b/gravity-forms/gw-first-error-focus.php
@@ -31,16 +31,11 @@ function gw_first_error_focus_script() {
 					// We need to reset our flag so that we can still do our focus action when the form conditional logic
 					// has been re-evaluated.
 					window['gwfef'] = false;
-					var y = 0;
-					// For a multiple page form after page 1, we need to render on the gform wrapper
-					if ($('.gf_step_current_page') && $('.gf_step_current_page').text() > 1) {
-						y = $('.gform_wrapper').offset().top;
-					}
 					var hasError = gwFirstErrorFocus().length;
-
-					if (!hasError) {
+					var onSubsequentPage = $('.gf_step_current_page') && $('.gf_step_current_page').text() > 1;
+					if (!hasError && onSubsequentPage) {
 						requestAnimationFrame(function() {
-							window.scrollTo(0, y);
+							window.scrollTo(0, $('.gform_wrapper').offset().top);
 						});
 					}
 				});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2479112475/59893?folderId=3808239
https://secure.helpscout.net/conversation/2482109891/60004?folderId=3808239

## Summary

The snippet takes the page to the `gform_wrapper` div on page load (i.e. when there are no rendered errors). The logic to scroll to `gform_wrapper` when there are no errors is the one that is causing the issues: `window.scrollTo(0, $('.gform_wrapper').offset().top);`

**Part - 1:**
https://www.loom.com/share/2a52775855d9413190f361d133a5e504
**Part - 2:**
https://www.loom.com/share/0aae06dc58374e3f86e6ff3cecbdbdd5
