### PR TITLE
`gw-export-multi-input-fields-single-colum.php`: Fixed a compatibility issue with GP Google Sheets.

### DIFF
--- a/gravity-forms/gw-export-multi-input-fields-single-colum.php
+++ b/gravity-forms/gw-export-multi-input-fields-single-colum.php
@@ -10,15 +10,10 @@
  * Plugin URI: http://gravitywiz.com/how-do-i-export-multi-input-fields-in-a-single-column-with-gravity-forms/
  * Description: Export multi-input Gravity Forms fields as a single column.
  * Author: David Smith
- * Version: 1.2
+ * Version: 1.3
  * Author URI: http://gravitywiz.com
  */
-add_filter( 'gform_export_fields', function( $form ) {
-
-	// only modify the form object when the form is loaded for field selection; not when actually exporting
-	if ( rgpost( 'export_lead' ) || rgpost( 'action' ) == 'gf_process_export' ) {
-		return $form;
-	}
+add_filter( 'gform_form_export_page', function( $form ) {
 
 	$fields = array();
 


### PR DESCRIPTION
## Context
⛑️ Ticket(s): https://secure.helpscout.net/conversation/2471019694/59531?folderId=3808239

## Summary

Checkbox fields are not sent to Google Sheets when Gravity Forms - Export Multi-input Fields in Single Column plugin is active.

The proposed solution in this PR is to skip the `gform_export_fields` hook's processing when the trigger is `GP Google Sheets`, by checking on the `$_POST` object.
