### PR TITLE
`gppa-acf-repeater-mapper.php`: Fixed an issue with regular expression.

### DIFF
--- a/gp-populate-anything/gppa-acf-repeater-mapper.php
+++ b/gp-populate-anything/gppa-acf-repeater-mapper.php
@@ -36,7 +36,7 @@ add_filter( 'gppa_input_choices', function( $choices, $field, $objects ) {
 
 	foreach ( $field->{'gppa-choices-templates'} as $template => $key ) {
 		// Look for ACF repeater meta: repeater_name_0_subfield_name
-		if ( preg_match( '/meta_([^0-9]+)_([0-9]+)_(.+)/', $key, $matches ) ) {
+		if ( preg_match( '/^meta_(.*?)_([^_]+)_([^_]+)$/', $key, $matches ) ) {
 			list( , $repeater, $index, $subfield ) = $matches;
 			$map[ $template ]                      = $subfield;
 		}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2470092230/59496?folderId=3808239

## Summary

A limitation with the [ACF Repeater Mapper snippet](https://github.com/gravitywiz/snippet-library/blob/master/gp-populate-anything/gppa-acf-repeater-mapper.php) if the repeater field has a number attached to the name.

So, if we processed for `$key` as `meta_test_repeater_1_0_name`. This will give us:

`$repeater` as `test_repeater`
`$index` as `1`
`$subfield` as `0_name`

This is because of the additional 1 attached to the name. The `$repeater` is actually `test_repeater_1`, `$index` is `0`, and `$subfield` is `name`.