### PR TITLE
`gw-field-to-field-conditional-logic.php`: Fixed an issue with number formatting.

### DIFF
--- a/gravity-forms/gw-field-to-field-conditional-logic.php
+++ b/gravity-forms/gw-field-to-field-conditional-logic.php
@@ -138,9 +138,22 @@ class GF_Field_To_Field_Conditional_Logic {
 							}
 
 							rule.value = GFMergeTag.getMergeTagValue( formId, mergeTags[0][1], mergeTags[0][3] );
+							rule.value = convertIfNumberWithCommas( rule.value );
 
 							return rule;
 						} );
+
+						function convertIfNumberWithCommas( str ) {
+							// Regex to check if the string is a number with commas.
+							var regex = /^\d{1,3}(,\d{3})*$/;
+
+							// If it's a number with commas, remove them.
+							if ( regex.test( str ) ) {
+								str = str.replace( /,/g, '' );
+							}
+
+							return str;
+						}
 
 					};
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2477359501/59822?folderId=3808239

## Summary

The snippet above doesn't work if the result of a calculation field used for the conditional logic check is in the thousands.

The issue is with comparing numeric values that are comma formatted.

**BEFORE:** ('Show This' did not hide even if the values 1000 and 1,000 are numerically equal.)
<img width="278" alt="Screenshot 2024-01-18 at 12 32 12 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/43fc7062-e94a-4b57-b191-b9f1c365b65f">

**AFTER:**
<img width="290" alt="Screenshot 2024-01-18 at 12 31 49 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c396e8eb-0d37-4da9-aa23-d78b62f67c4a">
