### PR TITLE
`gpnf-auto-attach-child-files.php`: Added support for Image Hopper Files.

### DIFF
--- a/gp-nested-forms/gpnf-auto-attach-child-files.php
+++ b/gp-nested-forms/gpnf-auto-attach-child-files.php
@@ -71,7 +71,7 @@ class GPNF_Auto_Attach_Child_Files {
 			return $notification;
 		}
 
-		$upload_fields = GFCommon::get_fields_by_type( $form, array( 'fileupload' ) );
+		$upload_fields = GFCommon::get_fields_by_type( $form, array( 'fileupload', 'image_hopper', 'image_hopper_post' ) );
 
 		if ( ! $this->is_applicable_notification( $notification ) ) {
 			return $notification;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2481484636/59962?folderId=3808239

## Summary

This snippet is supposed to auto-attach child files to the notification of the parent form. It works for the GF File upload fields, it doesn't work when an Image Hopper file upload field. This update adds support for that. We need to be specifying what upload files we need from the child entries:

`$upload_fields = GFCommon::get_fields_by_type( $child_form, array( 'fileupload', 'image_hopper', 'image_hopper_post' ) );`


