### PR TITLE
`gw-populate-date.php`: Fixed PHP 8.2 warnings on many snippets.

### DIFF
--- a/gp-ecommerce-fields/gpecf-deduct-deposit.php
+++ b/gp-ecommerce-fields/gpecf-deduct-deposit.php
@@ -17,6 +17,8 @@
  */
 class GW_Deduct_Deposit {
 
+	private $args = array();
+
 	public function __construct( $args ) {
 
 		$this->_args = wp_parse_args( $args, array(

--- a/gp-nested-forms/gpnf-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gpnf-delay-child-notifications-for-parent-payment.php
@@ -14,6 +14,8 @@
  */
 class GW_GPNF_Delay_Child_Notifications {
 
+	private $args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class

--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -16,6 +16,8 @@ class GW_Choice_Count {
 
 	private static $is_script_output;
 
+	private $args = array();
+
 	function __construct( $args ) {
 
 		$this->_args = wp_parse_args( $args, array(

--- a/gravity-forms/gw-min-and-max-character-limit.php
+++ b/gravity-forms/gw-min-and-max-character-limit.php
@@ -14,6 +14,8 @@
  */
 class GW_Minimum_Characters {
 
+	private $args = array();
+
 	public function __construct( $args = array() ) {
 
 		// make sure we're running the required minimum version of Gravity Forms

--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -13,6 +13,9 @@ class GW_Populate_Date {
 
 	protected static $is_script_output = false;
 
+	private $args          = array();
+	private $_field_values = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class

--- a/gravity-forms/gw-quantity-as-decimal.php
+++ b/gravity-forms/gw-quantity-as-decimal.php
@@ -15,6 +15,9 @@
 class GW_Quantity_Decimal {
 
 	private static $_current_form;
+	private $form_id;
+	private $global    = false;
+	private $field_ids = array();
 
 	function __construct( $form_id, $field_ids = array(), $global = false ) {
 

--- a/gravity-forms/gw-require-list-columns.php
+++ b/gravity-forms/gw-require-list-columns.php
@@ -5,7 +5,8 @@
  */
 class GWRequireListColumns {
 
-	private $field_ids;
+	private $field_ids     = array();
+	private $required_cols = array();
 
 	public static $fields_with_req_cols = array();
 

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -16,6 +16,8 @@
  */
 class GW_Require_Unique_Values {
 
+	private $args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2460911417/59241?folderId=3808239

## Summary

```
PHP Deprecated:Creation of dynamic property GW_Populate_Date::$_args is deprecated in ... code on line 18
PHP Deprecated:Creation of dynamic property GW_Populate_Date::$_field_values is deprecated in ... code on line 30
PHP Deprecated:Creation of dynamic property GW_GPNF_Delay_Child_Notifications::$_args is deprecated in ... code on line 19
PHP Deprecated:Creation of dynamic property GW_Require_Unique_Values::$_args is deprecated in ... code on line 21
PHP Deprecated:Creation of dynamic property GW_Quantity_Decimal::$form_id is deprecated in ... code on line 24
PHP Deprecated:Creation of dynamic property GW_Quantity_Decimal::$field_ids is deprecated in ... code on line 25
PHP Deprecated:Creation of dynamic property GW_Quantity_Decimal::$global is deprecated in ... code on line 26
PHP Deprecated:Creation of dynamic property GW_Minimum_Characters::$_args is deprecated in ... code on line 24
PHP Deprecated:Creation of dynamic property GW_Choice_Count::$_args is deprecated in ... code on line 20
PHP Deprecated:Creation of dynamic property GWRequireListColumns::$required_cols is deprecated in ... code on line 14
PHP Deprecated:Creation of dynamic property GW_Deduct_Deposit::$_args is deprecated in ... code on line 21
```

With PHP 8.2 the use of dynamic properties in a Class is deprecated. We need to have it explicitly declared.
