### PR TITLE
`gppa-acf-repeater-mapper.php`: Fixed an issue with regular expression.

### DIFF
--- a/gp-populate-anything/gppa-acf-repeater-mapper.php
+++ b/gp-populate-anything/gppa-acf-repeater-mapper.php
@@ -36,7 +36,8 @@ add_filter( 'gppa_input_choices', function( $choices, $field, $objects ) {
 
 	foreach ( $field->{'gppa-choices-templates'} as $template => $key ) {
 		// Look for ACF repeater meta: repeater_name_0_subfield_name
-		if ( preg_match( '/^meta_(.*?)_([^_]+)_([^_]+)$/', $key, $matches ) ) {
+		// Known Limitation: We cannot have a number on the repeater field name.
+		if ( preg_match( '/meta_([^0-9]+)_([0-9]+)_(.+)/', $key, $matches ) ) {
 			list( , $repeater, $index, $subfield ) = $matches;
 			$map[ $template ]                      = $subfield;
 		}

--- a/gp-populate-anything/gppa-acf-repeater-mapper.php
+++ b/gp-populate-anything/gppa-acf-repeater-mapper.php
@@ -35,8 +35,12 @@ add_filter( 'gppa_input_choices', function( $choices, $field, $objects ) {
 	$map = array();
 
 	foreach ( $field->{'gppa-choices-templates'} as $template => $key ) {
-		// Look for ACF repeater meta: repeater_name_0_subfield_name
-		// Known Limitation: We cannot have a number on the repeater field name.
+		/**
+		 * Look for ACF repeater meta: repeater_name_0_subfield_name
+		 * 
+		 * Known limitation: This cannot have a number on the repeater field name. For an enumerator, it is
+		 * recommended to use alphabets like, repeater_name_a_0_name, repeater_name_b_1_name,etc.
+		 */ 
 		if ( preg_match( '/meta_([^0-9]+)_([0-9]+)_(.+)/', $key, $matches ) ) {
 			list( , $repeater, $index, $subfield ) = $matches;
 			$map[ $template ]                      = $subfield;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2454263207/58976/

## Summary

Follow up to this previous update https://github.com/gravitywiz/snippet-library/pull/757 for the issue reported [here](https://secure.helpscout.net/conversation/2470092230/59496?folderId=3808239). We are rolling back to the previous state, adding a comment that we cannot use numbers in repeater names as a known limitation.
