### PR TITLE
`gpnf-auto-attach-child-files.php`: Added support for Image Hopper Files on Child Forms.

### DIFF
--- a/gp-nested-forms/gpnf-auto-attach-child-files.php
+++ b/gp-nested-forms/gpnf-auto-attach-child-files.php
@@ -95,7 +95,7 @@ class GPNF_Auto_Attach_Child_Files {
 			}
 
 			$child_form    = GFAPI::get_form( $field->gpnfForm );
-			$upload_fields = GFCommon::get_fields_by_type( $child_form, array( 'fileupload' ) );
+			$upload_fields = GFCommon::get_fields_by_type( $child_form, array( 'fileupload', 'image_hopper', 'image_hopper_post' ) );
 			$child_entries = $parent_entry->get_child_entries( $field->id );
 			$upload_root   = GFFormsModel::get_upload_root();
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2481484636/59962?folderId=7098280

## Summary

This does what the previous PR https://github.com/gravitywiz/snippet-library/pull/760 was supposed to do, but didn't because of a wrong commit.

This snippet is supposed to auto-attach child files to the notification of the parent form. It works for the GF File upload fields, it doesn't work when an Image Hopper file upload field. This update adds support for that. We need to be specifying what upload files we need from the child entries:

`$upload_fields = GFCommon::get_fields_by_type( $child_form, array( 'fileupload', 'image_hopper', 'image_hopper_post' ) );`