### PR TITLE
`gw-prevent-duplicate-selections.php`: Fixed an issue with duplicate selections logic did not work with some dynamically populated data.

### DIFF
--- a/gravity-forms/gw-prevent-duplicate-selections.php
+++ b/gravity-forms/gw-prevent-duplicate-selections.php
@@ -47,7 +47,7 @@ class GW_Prevent_Duplicate_Selections {
 
 		<script type="text/javascript" defer>
 
-			jQuery( function( $ ) {
+			function process_duplicate_selections($) {
 				window.gform.addFilter( 'gplc_excluded_input_selectors', function( selectors ) {
 					selectors.push( '.gw-disable-duplicates-disabled' );
 					return selectors;
@@ -203,7 +203,14 @@ class GW_Prevent_Duplicate_Selections {
 					}
 
 				}
-			} );
+			}
+
+			// Loading at the time of form loading.
+			jQuery( process_duplicate_selections );
+			// Loading when selections are updated via GP Populate Anything.
+			jQuery( document ).on( 'gppa_updated_batch_fields', function( event, formId, fieldIds ) {
+				jQuery( process_duplicate_selections );
+			})
 		</script>
 
 		<?php


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2493953931/60560?folderId=3808239

## Summary

The snippet doesn't work when the dropdown field choices are not set when the form renders. If choices are populated later based on another field selection, it doesn't work. We need to ensure to re-render the logic with `gppa_updated_batch_fields` for updated fields.

A quick summary screencast of testing this update:
https://www.loom.com/share/a668853d694b4575b0132a077eeeb00d