### PR TITLE
`gw-update-posts.php`: Added support for specifying an `append` parameter for meta values. 

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -4,7 +4,7 @@
  *
  * Update existing post title, content, author and custom fields with values from Gravity Forms.
  *
- * @version 0.5
+ * @version 0.6
  * @author  Scott Ryer <scott@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com


### PR DESCRIPTION
When set, snippet will append images for ACF Gallery fields instead of replacing. This is currently limited to ACF Gallery fields but could be readily expanded to other field types.

## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2476493794/59790

## Summary

Customer is using our Update Posts snippet to update an ACF gallery field attached to a post. Instead of replacing the images, he wants to append them.

This PR introduces the concept of passing custom parameters per meta value. Instead of setting the key and value, like so:

```php
'my_gallery' => 3
```

...you would instead pass an array as the value with any desired parameters:

```php
'my_gallery' => array(
    'field_id' => 3,
    'append' => true,
)
```

The previous format still works, of course.