### PR TITLE
Don't Process File Upload merge tag if it contains a modifier other than `index`

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -155,6 +155,9 @@ class GW_Multi_File_Merge_Tag {
 
 					$files = array_slice( $files, $offset, $length );
 
+				} elseif ( count( $modifiers ) > 0 ) {
+					/* Skip fields with a modifier other than "index" */
+					continue;
 				}
 
 				$value = '';


### PR DESCRIPTION
This update ensures any modifiers – [such as the native `:download` option](https://docs.gravityforms.com/file-upload/#h-modifiers) or any custom modifiers – outputs the expected value. 

To give you an example, let's say we are using the default settings, and our form has a Multi File Upload field (ID1) and two images uploaded.

**Before Change**
`{File Upload:1}` -> `<img src="{url1}" width="33%" /><img src="{url2}" width="33%" />` 
`{File Upload:1:index[1]}` -> `<img src="{url2}" width="33%" />` 
`{File Upload:1:download}` -> `<img src="{url1}" width="33%" /><img src="{url2}" width="33%" />` 
`{File Upload:1:count}` -> `<img src="{url1}" width="33%" /><img src="{url2}" width="33%" />`

**After Change**
`{File Upload:1}` -> `<img src="{url1}" width="33%" /><img src="{url2}" width="33%" />` 
`{File Upload:1:index[1]}` -> `<img src="{url2}" width="33%" />` 
`{File Upload:1:download}` -> `{url1}?dl=1<br>{url2}?dl=1` 
`{File Upload:1:count}` -> `2`