### PR TITLE
`gw-coupons-exclude-products.php`: Fixed console error when a coupon is applied

### DIFF
--- a/gravity-forms/gw-coupons-exclude-products.php
+++ b/gravity-forms/gw-coupons-exclude-products.php
@@ -69,17 +69,9 @@ class GW_Coupons_Exclude_Products {
 
 				if( window.gform ) {
 
-					gform.addFilter( 'gform_coupons_discount_amount', function( discount, couponType, couponAmount, price, totalDiscount ) {
+					gform.addFilter( 'gform_coupons_discount_amount', function( discount, couponType, couponAmount, price, totalDiscount, formId ) {
 
-						// pretty hacky... work our way up the chain to see if the 4th func up is the expected func
-						var caller = arguments.callee.caller.caller.caller.caller;
-
-						if( caller.name != 'PopulateDiscountInfo' ) {
-							return discount;
-						}
-
-						var formId = caller.arguments[1],
-							price  = price - getExcludedAmount( formId );
+						var price  = price - getExcludedAmount( formId );
 
 						if( couponType == 'percentage' ) {
 							discount = price * Number( ( couponAmount / 100 ) );


### PR DESCRIPTION
⛑️ https://secure.helpscout.net/conversation/2512235919/61615

## Summary
Fixed a console error `Uncaught TypeError: Cannot read properties of null (reading 'caller') ...` when a coupon code is applied on a form when using the `gw-coupons-exclude-products.php` Snippet.
