### PR TITLE
`gpnf-sync-parent-child-entry-payment-status.php`: Fixed a fatal error when the sync parent child entry payment snippet was activated.

### DIFF
--- a/gp-nested-forms/gpnf-sync-parent-child-entry-payment-status.php
+++ b/gp-nested-forms/gpnf-sync-parent-child-entry-payment-status.php
@@ -22,7 +22,10 @@ add_action( 'gform_post_update_entry', function( $entry, $original_entry ) {
 	gpnf_sync_child_entries_payment_details( $entry );
 }, 10, 2 );
 
-add_action( 'gform_after_update_entry', 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' );
+add_action( 'gform_after_update_entry', function( $form, $entry_id, $original_entry ) {
+	gpnf_get_parent_entry_and_sync_child_entries_payment_details( $entry_id );
+}, 10, 3 );
+
 add_action( 'gform_update_payment_status', 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' );
 add_action( 'gform_update_payment_date', 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' );
 add_action( 'gform_update_transaction_id', 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' );
@@ -92,9 +95,6 @@ if ( ! function_exists( 'gpnf_has_product_field' ) ) {
 
 if ( ! function_exists( 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' ) ) {
 	function gpnf_get_parent_entry_and_sync_child_entries_payment_details( $entry_id ) {
-		if ( ! is_scalar( $entry_id ) ) {
-			return;
-		}
 		$entry = GFAPI::get_entry( $entry_id );
 		gpnf_sync_child_entries_payment_details( $entry );
 	}

--- a/gp-nested-forms/gpnf-sync-parent-child-entry-payment-status.php
+++ b/gp-nested-forms/gpnf-sync-parent-child-entry-payment-status.php
@@ -92,6 +92,9 @@ if ( ! function_exists( 'gpnf_has_product_field' ) ) {
 
 if ( ! function_exists( 'gpnf_get_parent_entry_and_sync_child_entries_payment_details' ) ) {
 	function gpnf_get_parent_entry_and_sync_child_entries_payment_details( $entry_id ) {
+		if ( ! is_scalar( $entry_id ) ) {
+			return;
+		}
 		$entry = GFAPI::get_entry( $entry_id );
 		gpnf_sync_child_entries_payment_details( $entry );
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2518151181/61994?folderId=7098280

## Summary

The gpnf-sync-parent-child-entry-payment-status snippet is causing a fatal error when updating any entry: https://github.com/gravitywiz/snippet-library/blob/master/gp-nested-forms/gpnf-sync-parent-child-entry-payment-status.php

```
PHP Fatal error:  Uncaught TypeError: Illegal offset type in isset or empty in \..\gravityforms\includes\query\class-gf-query.php:
Stack trace:
#0 \..\gravityforms\includes\query\class-gf-query.php(1436): GF_Query->get_entries(Array)
#1 \..\gravityforms\includes\api.php(701): GF_Query->get_entry(Array)
#2 \..\code-snippets\php\snippet-ops.php(582) : eval()'d code(94): GFAPI::get_entry(Array)
#3 \..\public\wp-includes\class-wp-hook.php(326): gpnf_get_parent_entry_and_sync_child_entries_payment_details(Array)
....
```