### PR TITLE
`gw-prevent-duplicate-selections.php`: Fixed issue where variable was not initialized soon enough and broke functionality when GPADVS was enabled.

### DIFF
--- a/gravity-forms/gw-prevent-duplicate-selections.php
+++ b/gravity-forms/gw-prevent-duplicate-selections.php
@@ -62,6 +62,12 @@ class GW_Prevent_Duplicate_Selections {
 		<script type="text/javascript">
 			window.<?php echo __CLASS__; ?> = function() {
 				var $ = jQuery;
+				/**
+				 * Cache for storing previous values of GP Advanced Select enabled multi-select
+				 * fields. We use this to check against in order to determine which option was
+				 * changed on a change event.
+				 */
+				const gpadvsPreviousValues = {};
 
 				window.gform.addFilter( 'gplc_excluded_input_selectors', function( selectors ) {
 					selectors.push( '.gw-disable-duplicates-disabled' );
@@ -79,13 +85,6 @@ class GW_Prevent_Duplicate_Selections {
 				$inputs.each( function( event ) {
 					gwDisableDuplicates( $( this ), $inputs.not('.gw-disable-duplicates-disabled') );
 				} );
-
-				/**
-				 * Cache for storing previous values of GP Advanced Select enabled multi-select
-				 * fields. We use this to check against in order to determine which option was
-				 * changed on a change event.
-				 */
-				const gpadvsPreviousValues = {};
 
 				/**
 				 * Given a select element, determines which option was changed.


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2512621772/61659?folderId=6987275 

## Summary

`gpadvsPreviousValues` was not initialized before it was used which broke functionality when GPADVS was enabled.


