### PR TITLE
`gw-cache-buster.php`: Added new `post_render_script` override for GravityForms change.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -213,7 +213,7 @@ class GW_Cache_Buster {
 		if ( is_callable( 'GFFormDisplay::post_render_script' ) ) {
 			$post_render_script = GFFormDisplay::post_render_script( $form['id'], $current_page );
 			$post_render_script = preg_quote( $post_render_script, '/' ); // Escape special characters
-			$pattern            = '/gform\.initializeOnLoaded\(\s*function\(\)\s*\{\s*(' . $post_render_script . ')\s*\}\s*\);/';
+			$pattern            = '/<script>\s*gform\.initializeOnLoaded\(\s*function\(\)\s*\{\s*(' . $post_render_script . ')\s*\}\s*\);\s*<\/script>/';
 			$form_string        = preg_replace( $pattern, '', $form_string );
 		}
 

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -177,8 +177,13 @@ class GW_Cache_Buster {
 					// GF is using it as their standard for triggering the `gform_post_render` event, I figured we should follow suit.
 					gform.initializeOnLoaded( function() {
 						// Form has been rendered. Trigger post render to initialize scripts.
-						jQuery( document ).trigger( 'gform_post_render', [ formId, 1 ] );
-						gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: formId, currentPage: 1 } });
+						<?php
+							echo 'gform.initializeOnLoaded( function() {' . GFFormDisplay::post_render_script(
+								$form_id,
+								GFFormDisplay::get_current_page( $form_id )
+								) .
+								'} );';
+						?>
 					} );
 				} );
 			} )( jQuery );
@@ -194,7 +199,6 @@ class GW_Cache_Buster {
 	}
 
 	public function suppress_default_post_render_event( $form_string, $form, $current_page ) {
-
 		$searches = array(
 			"gform.initializeOnLoaded( function() { jQuery(document).trigger('gform_post_render', [{$form['id']}, {$current_page}]) } );",
 			"gform.initializeOnLoaded( function() {jQuery(document).trigger('gform_post_render', [{$form['id']}, {$current_page}]);gform.utils.trigger({ event: 'gform/postRender', native: false, data: { formId: {$form['id']}, currentPage: {$current_page} } });} );",
@@ -203,6 +207,13 @@ class GW_Cache_Buster {
 		foreach ( $searches as $search ) {
 			$search      = GFCommon::get_inline_script_tag( $search );
 			$form_string = str_replace( $search, '', $form_string );
+		}
+
+		if ( is_callable( 'GFFormDisplay::post_render_script' ) ) {
+			$post_render_script = GFFormDisplay::post_render_script( $form['id'], $current_page );
+			$post_render_script = preg_quote( $post_render_script, '/' ); // Escape special characters
+			$pattern            = '/gform\.initializeOnLoaded\(\s*function\(\)\s*\{\s*(' . $post_render_script . ')\s*\}\s*\);/';
+			$form_string        = preg_replace( $pattern, '', $form_string );
 		}
 
 		return $form_string;

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -178,11 +178,12 @@ class GW_Cache_Buster {
 					gform.initializeOnLoaded( function() {
 						// Form has been rendered. Trigger post render to initialize scripts.
 						<?php
-							echo 'gform.initializeOnLoaded( function() {' . GFFormDisplay::post_render_script(
-								$form_id,
-								GFFormDisplay::get_current_page( $form_id )
-								) .
-								'} );';
+							echo sprintf(
+								'gform.initializeOnLoaded(function() {%s});',
+								GFFormDisplay::post_render_script(
+									$form_id,
+									GFFormDisplay::get_current_page( $form_id )
+							) );
 						?>
 					} );
 				} );


### PR DESCRIPTION
## Context


💬 Slack: https://gravitywiz.slack.com/archives/C03T0CNL8AV/p1709131136355889 

## Summary

Gravity Forms rolled out this change which we now need to account for here.

https://github.com/gravityforms/gravityforms/pull/2762

