### PR TITLE
`gw-all-fields-template.php`: Fixed an issue with `nopricingfields` not hiding Product fields from the final result.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -220,8 +220,10 @@ class GW_All_Fields_Template {
 						$value = $this->get_all_fields_field_value( $field, $value );
 					}
 					break;
+				case 'nopricingfields':
 				case 'exclude':
-					if ( in_array( (int) $field->id, $field_ids, true ) ) {
+					// exclude the fields marked to be excluded, or exclude all pricing fields if 'nopricingfields' merge tag is used.
+					if ( in_array( (int) $field->id, $field_ids, true ) || ( $modifier == 'nopricingfields' && GFCommon::is_product_field( $field->type ) ) ) {
 
 						$exclude_full_value = true;
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2517551316/61937?viewId=8134459

## Summary

With All Fields Template. `:nopricingfields` modifier shows Pricing Fields.

**BEFORE:**
<img width="504" alt="Screenshot 2024-03-07 at 10 08 34 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/28751f17-b5e1-48b6-8f62-1eb7b7aaa37a">

**AFTER:**
<img width="117" alt="Screenshot 2024-03-07 at 10 08 47 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/e2eaa414-ba56-48c6-830b-e807c734e797">
