### PR TITLE
`gw-round-robin.php`: Added support for GP Inventory Choices with Round Robin functionality.

### DIFF
--- a/gravity-forms/gw-round-robin.php
+++ b/gravity-forms/gw-round-robin.php
@@ -154,6 +154,11 @@ class GW_Round_Robin {
 			$field->choices = gp_limit_choices()->apply_choice_limits( $field->choices, $field, $form );
 		}
 
+		// Add support for GP Inventory Choices.
+		if ( is_callable( 'gp_inventory_type_choices' ) ) {
+			$field->choices = gp_inventory_type_choices()->apply_choice_limits( $field->choices, $field, $form );
+		}
+
 		$rotation = array_filter( wp_list_pluck( $field->choices, 'value' ) );
 
 		return $rotation;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2523586865/62278?folderId=3808239

## Summary

Added support for GP Inventory Choice Limits to Round Robin snippet's functionality. If an inventory is exhausted, round robin entry value will not be processed for that option.
