### PR TITLE
`gpeb-disable-copy-cat-edit.php`: Added snippet to disable Copy Cat when editing using Entry Blocks.

### DIFF
--- a/gp-entry-blocks/gpeb-disable-copy-cat-edit.php
+++ b/gp-entry-blocks/gpeb-disable-copy-cat-edit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Perks // Entry Blocks // Remove Copy Cat on Edit.
+ * Gravity Perks // Entry Blocks // Disable Copy Cat When Editing.
  * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
  *
  * Removes copy cat functionality on Entry Blocks' Edit Page.

--- a/gp-entry-blocks/gpeb-remove-copy-cat-edit.php
+++ b/gp-entry-blocks/gpeb-remove-copy-cat-edit.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Gravity Perks // Entry Blocks // Remove Copy Cat on Edit.
+ * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
+ *
+ * Removes copy cat functionality on Entry Blocks' Edit Page.
+ */
+add_filter( 'gform_pre_render', 'gpeb_remove_gpcc_on_edit' );
+add_filter( 'gform_pre_process', 'gpeb_remove_gpcc_on_edit' );
+
+function gpeb_remove_gpcc_on_edit( $form ) {
+
+	$is_block = (bool) rgpost( 'gpeb_entry_id' );
+	if ( ! $is_block ) {
+		$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
+		if ( ! $is_block ) {
+			return $form;
+		}
+	}
+
+	foreach ( $form['fields'] as &$field ) {
+		// remove any of the copy cat classes from the field.
+		preg_match_all( '/copy-([0-9]+(?:.[0-9]+)*)-to-([0-9]+(?:.[0-9]+)*)(?:-if-([0-9]+(?:.[0-9]+)*))?/', $field['cssClass'], $matches, PREG_SET_ORDER );
+		if ( empty( $matches ) ) {
+			continue;
+		}
+		$field['cssClass'] = str_replace( $matches[0], '', $field['cssClass'] );
+	}
+
+	return $form;
+}

--- a/gp-entry-blocks/gpeb-remove-copy-cat-edit.php
+++ b/gp-entry-blocks/gpeb-remove-copy-cat-edit.php
@@ -5,19 +5,7 @@
  *
  * Removes copy cat functionality on Entry Blocks' Edit Page.
  */
-add_filter( 'gform_pre_render', 'gpeb_remove_gpcc_on_edit' );
-add_filter( 'gform_pre_process', 'gpeb_remove_gpcc_on_edit' );
-
-function gpeb_remove_gpcc_on_edit( $form ) {
-
-	$is_block = (bool) rgpost( 'gpeb_entry_id' );
-	if ( ! $is_block ) {
-		$is_block = class_exists( 'WP_Block_Supports' ) && rgar( WP_Block_Supports::$block_to_render, 'blockName' ) === 'gp-entry-blocks/edit-form';
-		if ( ! $is_block ) {
-			return $form;
-		}
-	}
-
+add_filter( 'gpeb_edit_form', function ( $form ) {
 	foreach ( $form['fields'] as &$field ) {
 		// remove any of the copy cat classes from the field.
 		preg_match_all( '/copy-([0-9]+(?:.[0-9]+)*)-to-([0-9]+(?:.[0-9]+)*)(?:-if-([0-9]+(?:.[0-9]+)*))?/', $field['cssClass'], $matches, PREG_SET_ORDER );
@@ -28,4 +16,4 @@ function gpeb_remove_gpcc_on_edit( $form ) {
 	}
 
 	return $form;
-}
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2530369085/62727?folderId=7098280

## Summary

Snippet to prevent GPCC from copying values when editing the entry via Entry Blocks.
