### PR TITLE
Fix the inability to remove decimal quantity from the cart

### DIFF
--- a/wc-gf-product-addons/wcgfpa-remove-qty-from-cart-description.php
+++ b/wc-gf-product-addons/wcgfpa-remove-qty-from-cart-description.php
@@ -16,7 +16,7 @@
  */
 add_filter( 'woocommerce_gforms_field_display_text', function( $display_text, $display_value, $field ) {
 	if ( strpos( $field->cssClass, 'wcgfpa-remove-qty' ) !== false ) {
-		preg_match_all( '/Qty: [0-9]+, /', $display_text, $matches, PREG_SET_ORDER );
+		preg_match_all( '/Qty: [0-9]*[.,]?[0-9]+, /', $display_text, $matches, PREG_SET_ORDER );
 		$match        = array_pop( $matches );
 		$display_text = str_replace( $match[0], '', $display_text );
 	}


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary
The current snippet can only remove integer quantities from the cart. It is however possible to have decimal quantity especially with the use of the `gravity-forms/gw-quantity-as-decimal.php` snippet.

<!-- Briefly explain what's new in this pull request. -->
