### PR TITLE
Fix character count with the better mb_strlen

### DIFF
--- a/gravity-forms/gw-min-and-max-character-limit.php
+++ b/gravity-forms/gw-min-and-max-character-limit.php
@@ -85,7 +85,7 @@ class GW_Minimum_Characters {
 			}
 		}
 
-		$char_count      = strlen( $value );
+		$char_count      = mb_strlen( $value );
 		$is_min_reached  = $this->_args['min_chars'] !== false && $char_count >= $this->_args['min_chars'];
 		$is_max_exceeded = $this->_args['max_chars'] !== false && $char_count > $this->_args['max_chars'];
 

--- a/gravity-forms/gw-round-robin.php
+++ b/gravity-forms/gw-round-robin.php
@@ -154,6 +154,11 @@ class GW_Round_Robin {
 			$field->choices = gp_limit_choices()->apply_choice_limits( $field->choices, $field, $form );
 		}
 
+		// Add support for GP Inventory Choices.
+		if ( is_callable( 'gp_inventory_type_choices' ) ) {
+			$field->choices = gp_inventory_type_choices()->apply_choice_limits( $field->choices, $field, $form );
+		}
+
 		$rotation = array_filter( wp_list_pluck( $field->choices, 'value' ) );
 
 		return $rotation;


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary
i18n is crucial when developing WP plugins :). This fix provides a better character count. As simple as it is, a form submission could be prevented because of incorrect validation, which might lead to e.g. loss of sale or lead.

<!-- Briefly explain what's new in this pull request. -->
