### PR TITLE
`gpadvs-preserve-choice-order.php`: Added support to preserve choice order with Multi Select fields using GP Advanced Select.

### DIFF
--- a/gp-advanced-select/gpadvs-preserve-choice-order.php
+++ b/gp-advanced-select/gpadvs-preserve-choice-order.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Gravity Perks // Advanced Select // Preserve Choice Order
+ * https://gravitywiz.com/documentation/gravity-forms-advanced-select/
+ *
+ * Preserve Choice Order with Multi Select Fields using GP Advanced Select.
+ * 
+ * Instruction Video: https://www.loom.com/share/d2ad3fea02234f02871ac9b1efe20b53
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet by following the instructions here:
+ *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ */
+add_filter( 'gform_save_field_value', 'preserve_choice_order_with_advanced_select', 10, 4 );
+function preserve_choice_order_with_advanced_select( $value, $lead, $field, $form ) {
+	// For non GPAS values, return.
+	if ( $field->type != 'multiselect' || ! gp_advanced_select()->is_advanced_select_field( $field ) ) {
+		return $value;
+	}
+
+	// Decode JSON "value" string to an array.
+	$value_array = json_decode($value, true);
+
+	// Create a map of choice values to their respective index, and sort with that.
+	$value_indices = array_flip( array_column( $field->choices, 'value' ) );
+	usort( $value_array, function ( $a, $b ) use ( $value_indices ) {
+		return $value_indices[$a] - $value_indices[$b];
+	});
+
+	// Encode back to JSON string.
+	$value = json_encode( $value_array );
+
+	return $value;
+}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2522300498/62231?folderId=3808239

## Summary

With a Multi-Select field, using GP Advanced Select, selected choices are stored in the entry in the order that they are selected. This snippet helps override that behaviour to preserve the order choice.

Screencast:
https://www.loom.com/share/d2ad3fea02234f02871ac9b1efe20b53