### PR TITLE
`gw-advanced-merge-tags.php`: Added support for Live Merge Tags in HTML field to work on GP Post Content Merge Tags.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -432,6 +432,17 @@ class GW_Advanced_Merge_Tags {
 	public function support_html_field_merge_tags( $value, $tag, $modifiers, $field ) {
 		if ( $field->type == 'html' && ( $tag != 'all_fields' || in_array( 'allowHtmlFields', explode( ',', $modifiers ) ) ) ) {
 			$value = $field->content;
+
+			// Support for LMTs with GP Post Content Merge Tags
+			if ( class_exists( 'GP_Populate_Anything_Live_Merge_Tags' ) && is_callable( 'gp_post_content_merge_tags' ) && rgget( 'eid' ) ) {
+				$gppa_lmt = GP_Populate_Anything_Live_Merge_Tags::get_instance();
+				if ( $gppa_lmt->has_live_merge_tag( $value ) ) {
+					$form  = GFAPI::get_form( $field->formId );
+					$entry = gp_post_content_merge_tags()->get_entry();
+					$gppa_lmt->populate_lmt_whitelist( $form );
+					$value = $gppa_lmt->replace_live_merge_tags_static( $value, $form, $entry );
+				}
+			}
 		}
 
 		return $value;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2535995803/63104?folderId=7098280

## Summary

The live merge tag in an HTML field isn't processed when the HTML field content is displayed on the confirmation page using the GPPCMT

BEFORE (Samuel):
https://www.loom.com/share/9f41bc1e25e9448fa083597ba363e203?sid=14eb078b-48cd-4425-a4d9-fa706a0826ba

AFTER:
https://www.loom.com/share/3480a1c24fc34897b0b211663d5f4137
