### PR TITLE
`gpadvs-preserve-choice-order.php`: Fixed PHP warnings.

### DIFF
--- a/gp-advanced-select/gpadvs-preserve-choice-order.php
+++ b/gp-advanced-select/gpadvs-preserve-choice-order.php
@@ -23,15 +23,11 @@ add_filter( 'gform_save_field_value', function ( $value, $lead, $field, $form ) 
 
 	// Create a map of choice values to their respective index, and sort with that.
 	if ( is_array( $field->choices ) && ! empty( $field->choices ) && $value_array ) {
-		$valid_values = array_filter( array_column( $field->choices, 'value' ), function ( $value ) {
-			return is_string( $value ) || is_int( $value );
-		});
-		$value_indices = array_flip( $valid_values );
-		if ( is_array( $value_indices ) ) {
-			usort( $value_array, function ( $x, $y ) use ( $value_indices ) {
-				return $value_indices[ $x ] - $value_indices[ $y ];
-			});
-		}
+		// Avoid PHP notices for non-string, non-integer values with `array_flip()` by casting everything to a string and ensuring the result is an array.
+		$value_indices = (array) array_flip( array_map( 'strval', array_column( $field->choices, 'value' ) ) );
+		usort( $value_array, function ( $x, $y ) use ( $value_indices ) {
+			return $value_indices[ $x ] - $value_indices[ $y ];
+		} );
 	}
 
 	// Encode back to JSON string.

--- a/gp-advanced-select/gpadvs-preserve-choice-order.php
+++ b/gp-advanced-select/gpadvs-preserve-choice-order.php
@@ -22,10 +22,17 @@ add_filter( 'gform_save_field_value', function ( $value, $lead, $field, $form ) 
 	$value_array = json_decode( $value, true );
 
 	// Create a map of choice values to their respective index, and sort with that.
-	$value_indices = array_flip( array_column( $field->choices, 'value' ) );
-	usort( $value_array, function ( $x, $y ) use ( $value_indices ) {
-		return $value_indices[ $x ] - $value_indices[ $y ];
-	});
+	if ( is_array( $field->choices ) && ! empty( $field->choices ) && $value_array ) {
+		$valid_values = array_filter( array_column( $field->choices, 'value' ), function ( $value ) {
+			return is_string( $value ) || is_int( $value );
+		});
+		$value_indices = array_flip( $valid_values );
+		if ( is_array( $value_indices ) ) {
+			usort( $value_array, function ( $x, $y ) use ( $value_indices ) {
+				return $value_indices[ $x ] - $value_indices[ $y ];
+			});
+		}
+	}
 
 	// Encode back to JSON string.
 	$value = json_encode( $value_array );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2522300498/62231?folderId=7098280

## Summary

Fix PHP warnings with the snippet.

```
Warning: array_flip(): Can only flip STRING and INTEGER values!
Warning: usort() expects parameter 1 to be array, null given
```
