### PR TITLE
Fix validation error for the decimal quantity field

### DIFF
--- a/gravity-forms/gw-quantity-as-decimal.php
+++ b/gravity-forms/gw-quantity-as-decimal.php
@@ -58,9 +58,16 @@ class GW_Quantity_Decimal {
 			$this->is_enabled_field( $field ) &&
 			in_array( $field->type, array( 'product', 'quantity' ) ) &&
 			in_array( $field->validation_message, array( __( 'Please enter a valid quantity. Quantity cannot contain decimals.', 'gravityforms' ), __( 'Please enter a valid quantity', 'gravityforms' ) ) ) ) {
-			$is_numeric_decimal_dot   = $field->type == 'product' ? GFCommon::is_numeric( rgpost( "input_{$field['id']}_3" ), 'decimal_dot' ) : GFCommon::is_numeric( rgpost( "input_{$field['id']}" ), 'decimal_dot' );
-			$is_numeric_decimal_comma = $field->type == 'product' ? GFCommon::is_numeric( rgpost( "input_{$field['id']}_3" ), 'decimal_comma' ) : GFCommon::is_numeric( rgpost( "input_{$field['id']}" ), 'decimal_comma' );
-			if ( $is_numeric_decimal_dot || $is_numeric_decimal_comma ) {
+
+			$posted_value = $field->type == 'product' ? rgpost( "input_{$field['id']}_3" ) : rgpost( "input_{$field['id']}" );
+			// We trim in case HTML5 is turned off, else type="number" doesn't allow space
+			$posted_value = trim( $posted_value );
+
+			$is_numeric_decimal_dot   = GFCommon::is_numeric( $posted_value, 'decimal_dot' );
+			$is_numeric_decimal_comma = GFCommon::is_numeric( $posted_value, 'decimal_comma' );
+			$is_valid_float           = preg_match( '/^[0-9]*[.,]?[0-9]+$/', $posted_value );
+
+			if ( $is_numeric_decimal_dot || $is_numeric_decimal_comma || $is_valid_float ) {
 				$result['is_valid'] = true;
 			}
 		}


### PR DESCRIPTION
Fix validation error for the decimal quantity field when the value starts with the decimal sign (dot/comma).

As can be seen in the screenshot below, form validation fails for a value like `.2` - which is a valid value - even when the total is correctly calculated. This is quite inconsistent.

Code formatting/refactoring was also done for some parts of the existing code in order to provide clarity and reduce repetitions e.g. the `GFCommon::is_numeric` method was used 4 times in the old code but just twice in the new code.

<img width="614" alt="Screenshot 2024-03-15 at 15 20 57" src="https://github.com/gravitywiz/snippet-library/assets/26330390/59ffcbcd-e912-41a6-8fad-a03e2307c6ae">


## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

<!-- Briefly explain what's new in this pull request. -->
