### PR TITLE
`gpcc-copy-label.js`: Fixed an issue with copying labels from multiple radio buttons targeted to a single field.

### DIFF
--- a/gp-copy-cat/gpcc-copy-label.js
+++ b/gp-copy-cat/gpcc-copy-label.js
@@ -17,7 +17,7 @@ gform.addFilter( 'gppc_copied_value', function( value, $elem, data ) {
 	if( $source.is( 'select' ) ) {
 		value = $source.find( 'option:selected' ).text();
 	} else if( $source.is( '.gfield_radio' ) ) {
-		value = $( '.gfield-choice-input:checked + label' ).text();
+		value = $source.find( '.gfield-choice-input:checked:first + label' ).text();
 	} else if ( $source.is( '.gfield_checkbox') ) {
 		$inputs = $source.find( 'input:checked' );
 		var checkedLabels = [];

--- a/gp-copy-cat/gpcc-copy-label.js
+++ b/gp-copy-cat/gpcc-copy-label.js
@@ -17,7 +17,7 @@ gform.addFilter( 'gppc_copied_value', function( value, $elem, data ) {
 	if( $source.is( 'select' ) ) {
 		value = $source.find( 'option:selected' ).text();
 	} else if( $source.is( '.gfield_radio' ) ) {
-		value = $source.find( '.gfield-choice-input:checked:first + label' ).text();
+		value = $source.find( '.gfield-choice-input:checked + label' ).text();
 	} else if ( $source.is( '.gfield_checkbox') ) {
 		$inputs = $source.find( 'input:checked' );
 		var checkedLabels = [];


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2521383136/62172?folderId=7098280

## Summary

GPCC Copy labels snippet copies only from the first radio button when multiple radio buttons are targeting to the same target field.

**BEFORE:** (Issue explained)
https://www.loom.com/share/6e3c06c5c4c04c178c8fe311363eb33b

**AFTER:**
 https://www.loom.com/share/119205a37f3f4ecaa66616235bbb33d1

