### PR TITLE
`gw-populate-date.php`: Fixed an issue with Populate Date Time Snippet and Read Only Time Field.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1733,7 +1733,7 @@ class GW_Populate_Date {
 							case 'time':
 								var hours   = isNaN( date.getHours() ) ? '' : date.getHours(),
 									minutes = isNaN( date.getMinutes() )  ? '' : date.getMinutes(),
-									hasAMPM = $inputs.length === 3,
+									hasAMPM = $inputs.filter( 'select' ).length === 1,
 									isPM    = false;
 
 								if ( hasAMPM ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2544365356/63530?folderId=7098280

## Summary

The original logic to check for AMPM is to see `$inputs.length === 3`. There are 3 visible fields, one for the HOURS, one for the MINUTES, and third for the AM/PM (select-dropdown). The third is rendered only when the 12hour format is enabled (i.e. AMPM enabled). It is obviously not rendered with the 24hour format.

When we are also using the GP Read Only on the Time field, it adds a hidden input. This makes the number for `$inputs.length` to be 3 when 24hour format is enabled. Also, it makes the value as 4 when the 12hour format is enabled. So the calculation with the 24hour format is as if AMPM is enabled
See Read Only Time is trying to display 1:00 (instead of 13:00) with the **24hour** format
<img width="182" alt="Screenshot 2024-03-21 at 4 25 38 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/d2cfebd7-c7af-4260-ba54-05ce85093f61">

and for the **12hour format** it is as if AMPM is not enabled.
See Read Only Time is trying to display 13:00 (intead of 1:00) on the 12hour format!
<img width="245" alt="Screenshot 2024-03-21 at 4 26 25 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/f12cc0f0-5db2-46fe-b705-7994411519e1">



Instead of checking for the length, we can update to actually check if there is a `select` (dropdown) on the `$inputs`. This would be : `$inputs.filter( 'select' ).length === 1`. Regardless of read only or not, this will exactly tell us if there is the AM-PM dropdown or not.
Update with **24 hour** format:
<img width="199" alt="Screenshot 2024-03-21 at 4 27 31 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/408dceb9-8a7b-4f0d-a508-37fd31ec2613">

Update with **12 hour** format:
<img width="262" alt="Screenshot 2024-03-21 at 4 27 41 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/f8d2e56b-d9f2-4686-929e-46f276b06a8a">
