### PR TITLE
`gw-limit-multi-selects.php`: Fixed issue where setting the `min` to `1` did not work.

### DIFF
--- a/gravity-forms/gw-limit-multi-selects.php
+++ b/gravity-forms/gw-limit-multi-selects.php
@@ -197,14 +197,15 @@ class GW_Limit_Multi_Select {
 
 	public function validate( $result, $value, $form, $field ) {
 
-		if ( ! $this->is_applicable_field( $field ) || ! is_array( $value ) ) {
+		if ( ! $this->is_applicable_field( $field ) ) {
 			return $result;
 		}
 
 		$min = $this->get_min();
 		$max = $this->get_max();
 
-		$count = count( $value );
+		// if nothing is selected, $value will be an empty string so $count must be "0".
+		$count = empty( $value ) ? 0 : count( $value );
 
 		if ( $count < $min ) {
 			$result['is_valid'] = false;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2499159955/60820/ 

## Summary

If no options are selected for a configured multi-select, the `$value` arg in `validate()` will be an empty string and the function will return early without setting a validation error.

The fix is to explicity set `$count` to `1` if an empty string is detected so that the remainder of the logic will work as expected.

