### PR TITLE
`gw-update-posts.php`: Fixed issue where an empty post ID would result in the current post getting updated.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -68,8 +68,13 @@ class GW_Update_Posts {
 
 	public function update_post_by_entry( $entry, $form ) {
 
+		$post_id = rgar( $entry, $this->_args['post_id'] );
+		// If post not selected or post not available, return.
+		if ( empty( $post_id ) ) {
+			return;
+		}
 		// Get the post and, if the current user has capabilities, update post with new content.
-		$post = get_post( rgar( $entry, $this->_args['post_id'] ) );
+		$post = get_post( $post_id );
 		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 			return;
 		}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -4,7 +4,7 @@
  *
  * Update existing post title, content, author and custom fields with values from Gravity Forms.
  *
- * @version 0.5
+ * @version 0.6
  * @author  Scott Ryer <scott@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2545475210/63599/

## Summary

When using the [Update Posts](https://gravitywiz.com/how-to-update-posts-with-gravity-forms/) snippet, if the "Post ID" field is blank when the form is submitted, then the snippet will update the post that the form is embedded on, instead of just bailing.

**BEFORE**:
https://www.loom.com/share/185dd99a886c4194b0e59f677e2e8cd0

**AFTER**:
https://www.loom.com/share/2f655d3746a14659ba24ed6388c1bcb4
