### PR TITLE
`gppa-form-editor-increase-max-string-length.php`: Added snippet examples for JavaScript filter.

### DIFF
--- a/gp-populate-anything/gppa-form-editor-increase-max-string-length.php
+++ b/gp-populate-anything/gppa-form-editor-increase-max-string-length.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Increase Max String Length of the Form Editor.
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ */
+add_filter( 'gform_admin_pre_render', function ( $form ) {
+	?>
+	<script type="text/javascript">
+		gform.addFilter('gppa_form_editor_max_string_length', function(form) {
+			// Increase the length from default 50 to your choice.
+			return 1000;
+	});
+
+	</script>
+	<?php
+	return $form;
+} );

--- a/gp-populate-anything/gppa-form-editor-skip-max-string-length.php
+++ b/gp-populate-anything/gppa-form-editor-skip-max-string-length.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Increase Max String Length of the Form Editor.
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ */
+add_filter( 'gform_admin_pre_render', function ( $form ) {
+	?>
+	<script type="text/javascript">
+		gform.addFilter('gppa_form_editor_max_string_length', function(form) {
+			// Skip max string length check by returning false.
+			return false;
+	});
+
+	</script>
+	<?php
+	return $form;
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2546023537/63636?folderId=7098280

## Summary

This is dependent on the GP Populate Anything Updates pushed with the GPPA PR https://github.com/gravitywiz/gp-populate-anything/pull/524

Example links added here: https://gravitywiz.com/documentation/gppa_form_editor_max_string_length/

