### PR TITLE
`gravity-forms/gw-choice-counter.php`:Fixed form submission timing.

### DIFF
--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -121,6 +121,8 @@ class GW_Choice_Count {
 							for ( var i = 0; i < choiceFieldIds.length; i++ ) {
 
 								var $choiceField = $( '#input_' + formId + '_' + choiceFieldIds[ i ] );
+								if ( !$choiceField.is( ':visible' ) ) { continue; }
+
 								if ( ! values ) {
 									// If no values provided in the config, just get the number of checkboxes checked.
 									if ( self.isCheckableField( $choiceField ) ) {


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2543030933/63466

## Summary
When the `GW_Choice_Count` snippet is active on the customer's site, it takes some time for the form to submit. The issue was narrowed down to this [Line](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-choice-counter.php#L127), Weird.