### PR TITLE
`gppa-aggregate-functions.php`: Fixed an issue with Aggregate Functions running infinitely.

### DIFF
--- a/gp-populate-anything/gppa-aggregate-functions.php
+++ b/gp-populate-anything/gppa-aggregate-functions.php
@@ -65,6 +65,10 @@ class GPPA_Aggregate_Functions {
 	}
 
 	public function replace_template_sum_merge_tags( $template_value, $field, $template, $populate, $object, $object_type, $objects ) {
+		if ( ! is_string( $template_value ) ) {
+			return $template_value;
+		}
+
 		preg_match_all( self::$sum_regex, $template_value, $matches, PREG_SET_ORDER );
 		if ( $matches ) {
 			foreach ( $matches as $match ) {
@@ -80,11 +84,14 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $sum, $template_value );
 			}
 		}
-		remove_filter( 'gppa_process_template', array( $this, 'replace_template_sum_merge_tags' ), 2 );
 		return $template_value;
 	}
 
 	public function replace_template_avg_merge_tags( $template_value, $field, $template, $populate, $object, $object_type, $objects ) {
+		if ( ! is_string( $template_value ) ) {
+			return $template_value;
+		}
+
 		preg_match_all( self::$avg_regex, $template_value, $matches, PREG_SET_ORDER );
 		if ( $matches ) {
 			foreach ( $matches as $match ) {
@@ -102,11 +109,14 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $avg, $template_value );
 			}
 		}
-		remove_filter( 'gppa_process_template', array( $this, 'replace_template_avg_merge_tags' ), 2 );
 		return $template_value;
 	}
 
 	public function replace_template_min_merge_tags( $template_value, $field, $template, $populate, $object, $object_type, $objects ) {
+		if ( ! is_string( $template_value ) ) {
+			return $template_value;
+		}
+
 		preg_match_all( self::$min_regex, $template_value, $matches, PREG_SET_ORDER );
 		if ( $matches ) {
 			foreach ( $matches as $match ) {
@@ -128,11 +138,14 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $min, $template_value );
 			}
 		}
-		remove_filter( 'gppa_process_template', array( $this, 'replace_template_min_merge_tags' ), 2 );
 		return $template_value;
 	}
 
 	public function replace_template_max_merge_tags( $template_value, $field, $template, $populate, $object, $object_type, $objects ) {
+		if ( ! is_string( $template_value ) ) {
+			return $template_value;
+		}
+
 		preg_match_all( self::$max_regex, $template_value, $matches, PREG_SET_ORDER );
 		if ( $matches ) {
 			foreach ( $matches as $match ) {
@@ -154,7 +167,6 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $max, $template_value );
 			}
 		}
-		remove_filter( 'gppa_process_template', array( $this, 'replace_template_max_merge_tags' ), 2 );
 		return $template_value;
 	}
 

--- a/gp-populate-anything/gppa-aggregate-functions.php
+++ b/gp-populate-anything/gppa-aggregate-functions.php
@@ -80,6 +80,7 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $sum, $template_value );
 			}
 		}
+		remove_filter( 'gppa_process_template', array( $this, 'replace_template_sum_merge_tags' ), 2 );
 		return $template_value;
 	}
 
@@ -101,6 +102,7 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $avg, $template_value );
 			}
 		}
+		remove_filter( 'gppa_process_template', array( $this, 'replace_template_avg_merge_tags' ), 2 );
 		return $template_value;
 	}
 
@@ -126,6 +128,7 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $min, $template_value );
 			}
 		}
+		remove_filter( 'gppa_process_template', array( $this, 'replace_template_min_merge_tags' ), 2 );
 		return $template_value;
 	}
 
@@ -151,6 +154,7 @@ class GPPA_Aggregate_Functions {
 				$template_value = str_replace( $full_match, $max, $template_value );
 			}
 		}
+		remove_filter( 'gppa_process_template', array( $this, 'replace_template_max_merge_tags' ), 2 );
 		return $template_value;
 	}
 

--- a/gp-populate-anything/gppa-aggregate-functions.php
+++ b/gp-populate-anything/gppa-aggregate-functions.php
@@ -17,7 +17,7 @@
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-populate-anything/
  * Description:  Perform calculations on the values in a field/column and return a single value.
  * Author:       Gravity Wiz
- * Version:      0.1
+ * Version:      0.2
  * Author URI:   https://gravitywiz.com/
  */
 class GPPA_Aggregate_Functions {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2553813959/64057?folderId=3808239

## Summary

The snippet triggers an infinite traversal on each of the `gppa_process_template`, we can unhook it after having it processed once for a template value.
