### PR TITLE
`gw-format-date-merge-tags.php`: Fixed an issue with Captured Dates on Notifications and Confirmation.

### DIFF
--- a/gravity-forms/gw-format-date-merge-tags.php
+++ b/gravity-forms/gw-format-date-merge-tags.php
@@ -9,7 +9,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-date-merge-tags/
  * Description:  Adds merge tag modifiers for formatting date merge tags using PHP Date Formats.
  * Author:       Gravity Wiz
- * Version:      0.3
+ * Version:      0.4
  * Author URI:   https://gravitywiz.com
  */
 add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format ) {

--- a/gravity-forms/gw-format-date-merge-tags.php
+++ b/gravity-forms/gw-format-date-merge-tags.php
@@ -40,6 +40,9 @@ add_filter( 'gform_pre_replace_merge_tags', function( $text, $form, $entry, $url
 		$format      = $field->dateFormat ? $field->dateFormat : 'mdy';
 		$parsed_date = GFCommon::parse_date( $value, $format );
 
+		// On the Notifications/Confirmation side, & gets encoded to &amp;. Decode it back.
+		$modifier = htmlspecialchars_decode( $modifier );
+
 		// For whatever reason, Populate Anything's LMTs works better with `&comma` than `&#44;`. But... date() doesn't
 		// like it so let's replace it before we pass it to date().
 		$modifier = str_replace( '&comma;', ',', $modifier );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2559727114/64318?folderId=3808239
https://gravitywiz.com/gravity-forms-date-merge-tags/#comment-901673

## Summary

Adding a comma to the displayed date format returns an incorrect date. The format used for testing is `{:1:F j&amp;comma; Y}`. Here "1" is the field ID of the date field.

**BEFORE:**
<img width="613" alt="Screenshot 2024-04-06 at 10 20 58 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/71fb09f8-94e9-44de-b8d7-6dcdd8cab9f0">

**AFTER:**
<img width="231" alt="Screenshot 2024-04-06 at 10 21 16 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/d04b7667-ec2a-4a1a-9db6-319394c2f0ac">
