### PR TITLE
`gpeb-enable-hidden-field-filters.php`: Added snippet to enable Hidden Fields to be viewable as filters.

### DIFF
--- a/gp-entry-blocks/gpeb-enable-hidden-field-filters.php
+++ b/gp-entry-blocks/gpeb-enable-hidden-field-filters.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Gravity Perks // Entry Blocks // Enable Hidden Field Filters
+ * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
+ *
+ * Rather than displaying 50 checkboxes when using a Checkbox field in the Filter block, allow Entry Blocks
+ * to convert the Checkbox field to a Single Line Text field in the Filter block context. Users can then
+ * search for any checkbox value.
+ */
+add_filter( 'gpeb_filter_form', function ( $form ) {
+
+	foreach ( $form['fields'] as &$field ) {
+		// Update Hidden Field visibility.
+		$field->visibility = 'visible';
+
+		// Replace "Hidden" Field with Text Field to ensure it's rendered on the Filters
+		if ( $field->type === 'hidden' ) {
+			$field = new GF_Field_Text( $field );
+			$field->inputType = 'text';
+		}
+	}
+
+	return $form;
+}, 10, 1 );

--- a/gp-entry-blocks/gpeb-enable-hidden-field-filters.php
+++ b/gp-entry-blocks/gpeb-enable-hidden-field-filters.php
@@ -3,9 +3,7 @@
  * Gravity Perks // Entry Blocks // Enable Hidden Field Filters
  * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
  *
- * Rather than displaying 50 checkboxes when using a Checkbox field in the Filter block, allow Entry Blocks
- * to convert the Checkbox field to a Single Line Text field in the Filter block context. Users can then
- * search for any checkbox value.
+ * Hidden Fields are not displayed as Entry Blocks Filters by default. This snippet overrides that to enable Hidden Fields on Filters.
  */
 add_filter( 'gpeb_filter_form', function ( $form ) {
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2570532853/64931?folderId=7098280

## Summary

Adding a filter based on a Hidden field sets the fitler to hidden (it is not visible on the front end)

**Exanoke Filter Settings (Single Line Text B has been marked with Hidden Field Visibility):**
<img width="264" alt="Screenshot 2024-04-18 at 7 31 25 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/53195346-b65e-44fb-aae2-465878bfcb5c">

**BEFORE:**
<img width="730" alt="Screenshot 2024-04-18 at 7 29 56 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/ba970d4b-a528-4317-a709-fdbd74dea214">

**AFTER:**
<img width="768" alt="Screenshot 2024-04-18 at 7 30 06 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/d940a00d-caa8-436a-b070-73324e30513b">
