### PR TITLE
`gpaa-show-address-in-language.php`: Added snippet to show address in a specific language in the address fields.

### DIFF
--- a/gp-address-autocomplete/gpaa-show-address-in-language.php
+++ b/gp-address-autocomplete/gpaa-show-address-in-language.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Gravity Perks // GP Address Autocomplete // Show Address in a Specific Language
+ * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install snippet per https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *     2. Update $language with the ISO 639 two-letter lowercase abbreviation of the desired language e.g. 'en' for English (https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes).
+ */
+add_filter( 'script_loader_src', function( $src, $handle ) {
+	if ( 'gp-address-autocomplete-google' !== $handle ) {
+		return $src;
+	}
+
+	$language = '';
+
+	return add_query_arg( 'language', $language, $src );
+}, 10, 2 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2577549960/65279

## Summary

When users enter an address, it is populated from Google based on the browser's language. This PR provides a way to force Google to use a chosen language instead.