### PR TITLE
`gpnf-override-parent-merge-tag-on-submission.php`: Fixed issue with child entry's merge tag not getting replaced when used in combination with the `{Parent}` merge tag.

### DIFF
--- a/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
+++ b/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
@@ -95,7 +95,7 @@ class GPNF_Override_Parent_Merge_Tags {
 				}
 
 				foreach ( $inputs as $input ) {
-					$this->override_child_entry_input_value( $entry, $field, $input['id'], rgar( $input, 'defaultValue' ) );
+					$this->override_child_entry_input_value( $entry, $field, $child_form, $input['id'], rgar( $input, 'defaultValue' ) );
 				}
 			}
 		}
@@ -103,7 +103,7 @@ class GPNF_Override_Parent_Merge_Tags {
 		return $entry;
 	}
 
-	function override_child_entry_input_value( $entry, $field, $input_id, $default_value ) {
+	function override_child_entry_input_value( $entry, $field, $child_form, $input_id, $default_value ) {
 
 		preg_match_all( '/{Parent:(\d+(\.\d+)?)[^}]*}/i', $default_value, $matches, PREG_SET_ORDER );
 		if ( empty( $matches ) ) {
@@ -115,12 +115,12 @@ class GPNF_Override_Parent_Merge_Tags {
 			$value = str_replace( $match[0], rgar( $entry, $match[1] ), $value );
 		}
 
+		$default_value   = $value;
 		$child_entry_ids = explode( ',', rgar( $entry, $field->id ) );
 		foreach ( $child_entry_ids as $child_entry_id ) {
 			// If any child entry merge tag is present, replace it with the child entry value before replacing with the Parent merge tag values.
 			$child_entry = GFAPI::get_entry( $child_entry_id );
-			$child_form  = GFAPI::get_form( $child_entry['form_id'] );
-			$value       = GFCommon::replace_variables( $value, $child_form, $child_entry );
+			$value       = GFCommon::replace_variables( $default_value, $child_form, $child_entry );
 			GFAPI::update_entry_field( $child_entry_id, $input_id, $value );
 		}
 

--- a/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
+++ b/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
@@ -117,6 +117,10 @@ class GPNF_Override_Parent_Merge_Tags {
 
 		$child_entry_ids = explode( ',', rgar( $entry, $field->id ) );
 		foreach ( $child_entry_ids as $child_entry_id ) {
+			// If any child entry merge tag is present, replace it with the child entry value before replacing with the Parent merge tag values.
+			$child_entry = GFAPI::get_entry( $child_entry_id );
+			$child_form  = GFAPI::get_form( $child_entry['form_id'] );
+			$value       = GFCommon::replace_variables( $value, $child_form, $child_entry );
 			GFAPI::update_entry_field( $child_entry_id, $input_id, $value );
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2579271771/65352/

## Summary

If a parent merge tag is used along with the child merge tag, the child merge tag is not replaced only the parent merge tag is updated.

For instance, if we have the merge tag set as `{Parent:2}-@{:3}`. The value of Parent form's field ID is ABC, and the value of child entry's field ID 3 is 'XYZ'. This snippet will process the merge tag set on the field to result as `ABC-{:3}`

After the update, we do get the correct result: `ABC-XYZ`.

How this update works: https://www.loom.com/share/b8fd00cb40bc4fb3af69781b63523997