### PR TITLE
`gpaa-single-line-as-input.php`: Added full address capability to the Single Line as Input functionality.

### DIFF
--- a/gp-address-autocomplete/gpaa-single-line-as-input.php
+++ b/gp-address-autocomplete/gpaa-single-line-as-input.php
@@ -7,7 +7,7 @@
  *
  * Use a Single Line Text field as autocomplete input and populate the Single Line Text field with the full address.
  *
- * Note: This snippet will require the user to make a selection from the auto-suggested addresses. 
+ * Note: This snippet will require the user to make a selection from the auto-suggested addresses.
  *
  * Plugin Name:  GP Address Autocomplete - Use Single Line Text field as Autocomplete Input
  * Plugin URI:   https://gravitywiz.com/documentation/gravity-forms-address-autocomplete/
@@ -60,7 +60,14 @@ class GPAA_Single_Line_Input {
 
 					gform.addFilter('gpaa_values', function (values, place, gpaa, formId, fieldId) {
 						if ( args.formId == formId && args.addressFieldId == fieldId ) {
-							values.autocomplete = place.formatted_address;
+							if ( args.useFullAddress ) {
+								// Logic borrowed from https://github.com/gravitywiz/snippet-library/pull/730
+								var fullAddress     = gpaa.inputs.autocomplete.value;
+								values.autocomplete = fullAddress;
+								values.address1     = fullAddress.split(',')[0].trim();
+							} else {
+								values.autocomplete = place.formatted_address;
+							}
 							$input.data('gpaa-filled-value', place.formatted_address);
 						}
 
@@ -94,6 +101,7 @@ class GPAA_Single_Line_Input {
 			'formId'            => $this->_args['form_id'],
 			'addressFieldId'    => $this->_args['address_field_id'],
 			'singleLineFieldId' => $this->_args['single_line_field_id'],
+			'useFullAddress'    => $this->_args['use_full_address'],
 		);
 
 		$script = 'new GPAASingleLineInput( ' . json_encode( $args ) . ' );';
@@ -125,4 +133,5 @@ new GPAA_Single_Line_Input( array(
 	'form_id'              => 123,     // The ID of your form.
 	'address_field_id'     => 4,       // The ID of the Address field.
 	'single_line_field_id' => 5,        // The ID of the Single Line Text field.
+	// 'use_full_address'     => true,    // Uncomment to use the full street address if you don't want an abbreviated street address.
 ) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2580726019/65425?folderId=7098280

## Summary

Use [full street address](https://github.com/gravitywiz/snippet-library/blob/master/gp-address-autocomplete/gpaa-use-full-street-address.js) snippet cannot be directly used with the current Single Line as Input snippet. This update adds an extra argument to the Single Line as Input `use_full_address` and the internal logic with `gpaa_values` processes either functionality accordingly.

Quick Loom:
https://www.loom.com/share/b0633a46e44547189ca51954d524d5c4