### PR TITLE
`gpaa-always-use-subpremise.js`: Added option to show subpremise on Address Line 2.

### DIFF
--- a/gp-address-autocomplete/gpaa-always-use-subpremise.js
+++ b/gp-address-autocomplete/gpaa-always-use-subpremise.js
@@ -12,6 +12,9 @@
  *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
  *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
  */
+// Update to "true" to add subpremise to Address Line 2 instead of Street Address.
+let addSubpremiseToLine2 = false;
+
 window.gform.addFilter('gpaa_values', function(values, place, instance) {
     if (instance.inputs.address1.value.indexOf('/') === -1) {
         return values;
@@ -37,7 +40,11 @@ window.gform.addFilter('gpaa_values', function(values, place, instance) {
 		streetNumber = streetNumber.replace(/,$/, '');
 
         if (results && values.address1.indexOf(results[1]) === -1) {
-            values.address1 = (results[1].trim() + ' ' + values.address1.replace(streetNumber, '').trim()).trim().replace(/,$/, '');
+			if (!addSubpremiseToLine2) {
+            	values.address1 = (results[1].trim() + ' ' + values.address1.replace(streetNumber, '').trim()).trim().replace(/,$/, '');
+			} else {
+				values.address2 = results[1].trim().split('/')[0];
+			}
         }
     }
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2586015039/65683?folderId=3808239

## Summary

Added a variable that be can set in the snippet that will dictate where the subpremise is added.

`let addSubpremiseToLine2 = true;`

If `true` , it will add the subpremise to the Address Line 2 input. If false it will append it to the address Street Address input value. Make sure to update the snippet description to indicate this option.

**Sample Address: 5/50 Aaron St, Box Hill NSW, Australia**

With `let addSubpremiseToLine2 = false;`:
<img width="748" alt="Screenshot 2024-05-04 at 12 02 03 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/b5524424-6601-4287-8ba3-3d6f2447f573">

With `let addSubpremiseToLine2 = true;`:
<img width="746" alt="Screenshot 2024-05-04 at 12 01 30 AM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/502ab47a-6c70-473c-b068-d498a1dbd535">

