### PR TITLE
`gpnf-delete-child-entries-when-parent-value-changes.js`: Fixed issue with snippet not working with multiple Nested Forms.

### DIFF
--- a/gp-nested-forms/gpnf-delete-child-entries-when-parent-value-changes.js
+++ b/gp-nested-forms/gpnf-delete-child-entries-when-parent-value-changes.js
@@ -15,8 +15,9 @@
 // Update "4" to the ID of the field on the parent that when changed should delete the child entries.
 $( '#input_GFFORMID_4' ).on( 'change', function() {
 	// Update "5" to the ID of the Nested Form field on the parent form.
-	window.GPNestedForms_GFFORMID_5.viewModel.entries().forEach( function( item ) {
+	var gpnfA = window.GPNestedForms_GFFORMID_5;
+	gpnfA.viewModel.entries().forEach( function( item ) {
 		var $deleteButton = $( 'tr[data-entryid=' + item.id + ']' ).find( '.delete-button' );
-		GPNestedForms.deleteEntry( item, $deleteButton );
+		gpnfA.deleteEntry( item, $deleteButton );
 	} );
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2588340284/65814?folderId=7098280

## Summary

The snippet above doesn't work as expected when there are multiple nested form field on the page. it doesn't delete the nested forms entries when the parent value is changed.

**BEFORE:**
https://www.loom.com/share/c52aa6d524fa4af097b0aa8fe7ff8cde

**AFTER:**
https://www.loom.com/share/8cf6d2c6ec7d45ae958025a919459bcb
