### PR TITLE
`gw-multi-file-merge-tag.php`: Fixed `undefined array key` warning.

### DIFF
--- a/gravity-forms/gw-multi-file-merge-tag.php
+++ b/gravity-forms/gw-multi-file-merge-tag.php
@@ -173,8 +173,9 @@ class GW_Multi_File_Merge_Tag {
 
 			if ( $has_value ) {
 				$markup_settings = $this->get_markup_settings( $form['id'] );
-				if ( $markup_settings['container'] ) {
-					$value = sprintf( $markup_settings['container'], $value );
+				$container       = rgar( $markup_settings, 'container' );
+				if ( $container ) {
+					$value = sprintf( $container, $value );
 				}
 			}
 


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2585286901/65650

## Summary

<!-- Briefly explain what's new in this pull request. -->
Fix `Undefined array key "container" ` warning.