### PR TITLE
`gw-disable-submit-button-until-required-fields-are-filled-out.php`: Fixed multiple file upload compatibility with Disable Submit snippet.

### DIFF
--- a/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
+++ b/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
@@ -65,17 +65,23 @@ class GW_Disable_Submit {
 						} );
 
 						// Check for newly uploaded files
-						const fileUploadInput = document.querySelector( 'input[name="gform_uploaded_files"]' );
-						if ( fileUploadInput ) {
-							const observer = new MutationObserver( function( mutationsList, observer ) {
-								mutationsList.forEach( mutation => {
-									if ( mutation.type === 'attributes' && mutation.attributeName === 'value' ) {
+						args.inputHtmlIds.forEach(function (inputHtmlId){
+							let searchTerm = "#gform_preview";
+							let index	   = inputHtmlId.indexOf(searchTerm);
+							if ( index !== -1 ) {
+								let fieldId = inputHtmlId.substring(index + searchTerm.length).trim();
+								window.gfMultiFileUploader.uploaders['gform_multifile_upload' + fieldId].bind('StateChanged', function() {
+									if ( window.gfMultiFileUploader.uploaders['gform_multifile_upload' + fieldId].state == 1 ) {
 										self.runCheck();
 									}
 								});
-							});
-							observer.observe( fileUploadInput, { attributes: true });
-						}
+							}
+						});
+
+						// Check if field becomes empty on deleting file(s)
+						$(document).on( 'click', '.gform_delete_file', function() {
+							self.runCheck();
+						});
 
 						self.runCheck();
 
@@ -111,8 +117,8 @@ class GW_Disable_Submit {
 							}
 
 							if( $.trim( $( this ).val() ) ||
-								 $( this ).find( 'input:checked' ).length ||
-								 $( this ).find( '.ginput_preview' ).length
+								$( this ).find( 'input:checked' ).length ||
+								$( this ).find( '.ginput_preview' ).length
 								) {
 								fullCount += 1;
 							}
@@ -174,6 +180,7 @@ class GW_Disable_Submit {
 					break;
 
 				case 'fileupload':
+					// Only multiple files enabled File Upload field has to be handled differently.
 					if ( rgar( $field, 'multipleFiles' ) ) {
 						$html_ids[] = "#gform_preview_{$form['id']}_{$field['id']}";
 						break;

--- a/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
+++ b/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
@@ -4,7 +4,7 @@
 *
 * Disable submit buttones until all required fields have been filled out. Currently only supports single-page forms.
 *
-* @version   1.1
+* @version   1.2
 * @author    David Smith <david@gravitywiz.com>
 * @license   GPL-2.0+
 * @link      http://gravitywiz.com/...
@@ -64,6 +64,19 @@ class GW_Disable_Submit {
 							self.runCheck();
 						} );
 
+						// Check for newly uploaded files
+						const fileUploadInput = document.querySelector( 'input[name="gform_uploaded_files"]' );
+						if ( fileUploadInput ) {
+							const observer = new MutationObserver( function( mutationsList, observer ) {
+								mutationsList.forEach( mutation => {
+									if ( mutation.type === 'attributes' && mutation.attributeName === 'value' ) {
+										self.runCheck();
+									}
+								});
+							});
+							observer.observe( fileUploadInput, { attributes: true });
+						}
+
 						self.runCheck();
 
 					}
@@ -97,9 +110,10 @@ class GW_Disable_Submit {
 								return;
 							}
 
-							if( $.trim( $( this ).val() ) ) {
-								fullCount += 1;
-							} else if ( $( this ).find( 'input:checked' ).length ) {
+							if( $.trim( $( this ).val() ) ||
+								 $( this ).find( 'input:checked' ).length ||
+								 $( this ).find( '.ginput_preview' ).length
+								) {
 								fullCount += 1;
 							}
 
@@ -158,6 +172,12 @@ class GW_Disable_Submit {
 				case 'name':
 					$input_ids = array( 1, 2, 3, 4, 5, 6 );
 					break;
+
+				case 'fileupload':
+					if ( rgar( $field, 'multipleFiles' ) ) {
+						$html_ids[] = "#gform_preview_{$form['id']}_{$field['id']}";
+						break;
+					}
 
 				default:
 					$html_ids[] = "#input_{$form['id']}_{$field['id']}";


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2570453216/64916/

## Summary

The [Disable Submit snippet](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php) doesn't work with a required Upload field, with mutli-file enabled. This adds compatibility for that.
