### PR TITLE
`gpecf-deduct-deposit.php`: Fixed validation error with Deduct Deposit snippet.

### DIFF
--- a/gp-ecommerce-fields/gpecf-deduct-deposit.php
+++ b/gp-ecommerce-fields/gpecf-deduct-deposit.php
@@ -33,6 +33,84 @@ class GW_Deduct_Deposit {
 		remove_action( 'gform_product_info', array( gp_ecommerce_fields(), 'add_ecommerce_fields_to_order' ), 9 );
 
 		add_action( 'gform_product_info', array( $this, 'deduct_deposit' ), 9, 3 );
+		add_filter( 'gform_pre_render', array( $this, 'load_form_script' ) );
+		add_action( 'gform_register_init_scripts', array( $this, 'add_init_script' ) );
+
+	}
+
+	public function is_applicable_form( $form ) {
+
+		$form_id = isset( $form['id'] ) ? $form['id'] : $form;
+
+		return empty( $this->_args['form_id'] ) || (int) $form_id === (int) $this->_args['form_id'];
+	}
+
+	public function load_form_script( $form ) {
+
+		if ( $this->is_applicable_form( $form ) && ! has_action( 'wp_footer', array( $this, 'output_script' ) ) ) {
+			add_action( 'wp_footer', array( $this, 'output_script' ) );
+			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
+		}
+
+		return $form;
+	}
+
+	public function output_script() {
+		?>
+
+		<script type="text/javascript">
+
+			( function( $ ) {
+
+				window.<?php echo __CLASS__; ?> = function( args ) {
+
+					var self = this;
+
+					self.formId = args.formId;
+					self.depositFieldId = args.depositFieldId;
+
+					self.init = function() {
+						gform.addFilter( 'gform_product_total', function( total, formId ) {
+							if ( formId == self.formId ) {
+								var depositPrice    = $( 'input[name="input_' + self.depositFieldId + '.2"]' ).val();
+								var depositQuantity = $( 'input[name="input_' + self.depositFieldId + '.3"]' ).val();
+
+								depositValue = gformToNumber(depositPrice) * depositQuantity;
+
+								// since the depositValue (product field) would have been added to the total,
+								// it must first be removed to get base value and then discount applied (second substract).
+								total = total - depositValue - depositValue;
+							}
+							return total;
+						} );
+					};
+
+					self.init();
+
+				}
+
+			} )( jQuery );
+
+		</script>
+
+		<?php
+	}
+
+	public function add_init_script( $form ) {
+
+		if ( ! $this->is_applicable_form( $form ) ) {
+			return;
+		}
+
+		$args = array(
+			'formId' => $this->_args['form_id'],
+			'depositFieldId' => $this->_args['deposit_field_id'],
+		);
+
+		$script = 'new ' . __CLASS__ . '( ' . json_encode( $args ) . ' );';
+		$slug   = implode( '_', array( strtolower( __CLASS__ ), $this->_args['form_id'] ) );
+
+		GFFormDisplay::add_init_script( $form['id'], $slug, GFFormDisplay::ON_PAGE_RENDER, $script );
 
 	}
 

--- a/gp-ecommerce-fields/gpecf-deduct-deposit.php
+++ b/gp-ecommerce-fields/gpecf-deduct-deposit.php
@@ -103,7 +103,7 @@ class GW_Deduct_Deposit {
 		}
 
 		$args = array(
-			'formId' => $this->_args['form_id'],
+			'formId'         => $this->_args['form_id'],
 			'depositFieldId' => $this->_args['deposit_field_id'],
 		);
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2599694484/66359

## Summary

[Deduct Deposit from Order Summary snippet](https://gravitywiz.com/snippet-library/gpecf-deduct-deposit/) throws an error on submission: Submitted value ($xx) does not match expected value ($xx)

**How the error appears:**
<img width="400" alt="Screenshot 2024-05-17 at 8 10 25 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/b3692fa1-a771-4430-a741-2363f100f5a6">


Need to tap the [`gform_product_total`](https://docs.gravityforms.com/gform_product_total/) JS hook to actually update the total value, to prevent it from failing validation.

**BEFORE:** (front-end Deposit value appears as a normal product value getting added to Total)
<img width="645" alt="Screenshot 2024-05-17 at 8 08 39 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/c61617b3-a0df-41c4-949c-307faf189a7a">

**AFTER:** (front-end Deposit working as a discount value getting substracted from Total)
<img width="629" alt="Screenshot 2024-05-17 at 8 08 44 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/ab3190f6-59dc-4ea7-887f-94878d5621af">
