### PR TITLE
`gw-field-to-field-conditional-logic.php`: Added support for non-numeric rule field ID.

### DIFF
--- a/gravity-forms/gw-field-to-field-conditional-logic.php
+++ b/gravity-forms/gw-field-to-field-conditional-logic.php
@@ -182,10 +182,6 @@ class GF_Field_To_Field_Conditional_Logic {
 		foreach ( $object as $prop => $value ) {
 			if ( $prop === 'conditionalLogic' && ! empty( $value ) ) {
 				foreach ( $object[ $prop ]['rules'] as $rule ) {
-					// GF core only supports comparing fields to values but Gravity Perks supports other comparisons.
-					if ( ! is_numeric( $rule['fieldId'] ) ) {
-						continue;
-					}
 					$matches = $this->parse_merge_tags( $rule['value'] );
 					if ( ! empty( $matches ) ) {
 						$tag_field_id = $matches[0][1];


### PR DESCRIPTION

## Context
<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->
⛑️ Ticket(s): https://secure.helpscout.net/conversation/2600589764/66401


## Summary
The snippet isn't working with GP Inventory's "Available" conditional logic option. The issue is non-numeric ids are excluded from the dependencies array. This PR should fix the issue.