### PR TITLE
`gw-all-fields-template.php`: Added `format` modifier to have the value type choice of `text` or `html`.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -8,7 +8,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-all-fields-template/
  * Description:  Modify the {all_fields} merge tag output via a template file.
  * Author:       Gravity Wiz
- * Version:      0.10
+ * Version:      0.11
  * Author URI:   http://gravitywiz.com
  *
  * Usage:
@@ -111,7 +111,7 @@ class GW_All_Fields_Template {
 		}
 
 		$modifiers = $this->parse_modifiers( $modifiers );
-		$whitelist = array( 'filter', 'include', 'exclude', 'nopricingfields' );
+		$whitelist = array( 'filter', 'include', 'exclude', 'nopricingfields', 'format' );
 		$context   = rgar( $modifiers, 'context', false );
 
 		foreach ( $modifiers as $modifier => $mod_values ) {
@@ -259,6 +259,12 @@ class GW_All_Fields_Template {
 						if ( $exclude_full_value ) {
 							$value = false;
 						}
+					}
+					break;
+				case 'format':
+					// Use the raw_value for when text format is defined
+					if ( $mod_value == 'text' ) {
+						$value = $raw_value;
 					}
 					break;
 			}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2605590008/66639?folderId=7098280

## Summary

When using [All Fields Template](https://gravitywiz.com/gravity-forms-all-fields-template/), the email fields output as a link. 

<img width="350" alt="Screenshot 2024-05-24 at 4 42 11 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/b51cec93-d2cd-4407-a6be-029182bfa3b1">

This is good if we have it on an HTML Block, but not good if we are using it on an Email Field or Text Field.

To fix this, we are adding a `format` modifier which we can set to `text` to override the behaviour.

After the update, if we use `format[text]` with that merge tag `@{Nested Form:1:index[0],filter[3],format[text]}`, we will see:

<img width="350" alt="Screenshot 2024-05-24 at 4 44 07 PM" src="https://github.com/gravitywiz/snippet-library/assets/26293394/88f19e08-c373-41b2-87e0-cbd0cc8fa49b">

PS: We have only added the `format` explicitly for the Email field. For the HTML Block, we let it render the default HTML format.
