### PR TITLE
`gw-advanced-merge-tags.php`: Added support for `abbr` address field merge tag modifier.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -70,7 +70,7 @@ class GW_Advanced_Merge_Tags {
 			'save_source_post_id' => false,
 		) );
 
-		add_action( 'plugins_loaded', array( $this, 'add_hooks' ) );
+		add_action( 'init', array( $this, 'add_hooks' ) );
 	}
 
 	public function add_hooks() {
@@ -485,6 +485,11 @@ class GW_Advanced_Merge_Tags {
 						// Example: "hello my old friend" → "h*****************d".
 						return $this->mask_value( $value );
 					}
+				case 'abbr':
+					// When used on address field returns two letter code of the selected country.
+					// Example {My Address Field:1.6:abbr}
+					$default_countries = array_flip( GF_Fields::get( 'address' )->get_default_countries() );
+					return rgar( $default_countries, $value );
 			}
 		}
 


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2609518435/66829


## Summary

<!-- Briefly explain what's new in this pull request. -->
Add support for `abbr` merge tag modifier, when used on an address field returns the selected country two-letter code.
