### PR TITLE
`gw-limit-radio-button-selections-across-fields.js`: Added snippet to limit radio button selections across fields.

### DIFF
--- a/gravity-forms/gw-limit-radio-button-selections-across-fields.js
+++ b/gravity-forms/gw-limit-radio-button-selections-across-fields.js
@@ -1,0 +1,33 @@
+/**
+ * Gravity Wiz // Gravity Forms // Limit Radio Button Selections across Multiple Fields.
+ * https://gravitywiz.com/
+ *
+ * Instruction Video: https://www.loom.com/share/3d42f3c88ab14f23ad63d491bb77bac4
+ *
+ * * Instructions:
+ *     1. Install our free Custom Javascript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+// Update radio button field ids to target
+var fieldIds = [1, 3, 4];
+
+// Function to clear the same value in other fields
+function clearSameValue( changedFieldId, selectedValue ) {
+	$.each( fieldIds, function( index, fieldId ) {
+		if ( fieldId !== changedFieldId ) {
+			var $otherField = $( 'input[name="input_' + fieldId + '"][value="' + selectedValue + '"]' );
+			if ( $otherField.prop( 'checked' ) ) {
+				$otherField.prop( 'checked', false );
+			}
+		}
+	} );
+}
+
+// Attach change event listeners to the radio buttons
+$.each( fieldIds, function( index, fieldId ) {
+	$( 'input[name="input_' + fieldId + '"]' ).on( 'change', function() {
+		var selectedValue = $( this ).val();
+		clearSameValue( fieldId, selectedValue );
+	} );
+});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2615062924/67085

## Summary

Snippet to deselects options (in Radio Button field) if same option is selected in another field.

**David's loom of what we intend to achieve:**
https://www.loom.com/share/cd7b743b06184905ad4bd6906a6d8e88

**Loom of how this new snippet works:**
https://www.loom.com/share/3d42f3c88ab14f23ad63d491bb77bac4
