### PR TITLE
`gw-advanced-merge-tags.php`: Added `:selected` modifier to target selected checkbox by index on the Advanced Merge Tags snippet.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -452,12 +452,13 @@ class GW_Advanced_Merge_Tags {
 	 */
 	public function handle_field_modifiers( $value, $input_id, $modifier, $field, $raw_value, $format ) {
 
-		$modifiers = $field->get_modifiers();
+		$modifiers = $this->parse_modifiers( $modifier );
+
 		if ( empty( $modifiers ) ) {
 			return $value;
 		}
 
-		foreach ( $modifiers as $modifier ) {
+		foreach ( $modifiers as $modifier => $modifier_options ) {
 			switch ( $modifier ) {
 				case 'wordcount':
 					// Note: str_word_count() is not a great solution as it does not support characters with accents reliably.
@@ -490,13 +491,20 @@ class GW_Advanced_Merge_Tags {
 					// Example {My Address Field:1.6:abbr}
 					$default_countries = array_flip( GF_Fields::get( 'address' )->get_default_countries() );
 					return rgar( $default_countries, $value );
-				default:
+				case 'selected':
 					// 'selected' can be used over 'Checkbox' field to target the selected checkbox by its zero-based index.
-					if ( $field->type == 'checkbox' && strpos( $modifier, 'selected[' ) === 0 ) {
-						$index       = rgar( $this->parse_modifiers( $modifier ), 'selected' );
+					if ( $field->type == 'checkbox' ) {
+						$index = $modifier_options;
+						if ( $index !== 'selected' && is_numeric( $index ) ) {
+							$index = intval( $index );
+						} else {
+							break;
+						}
+
 						$value_array = explode( ',', $value );
 						return rgar( $value_array, $index );
 					}
+					break;
 			}
 		}
 

--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -492,8 +492,8 @@ class GW_Advanced_Merge_Tags {
 					return rgar( $default_countries, $value );
 				default:
 					// 'selected' can be used over 'Checkbox' field to target the selected checkbox by its zero-based index.
-					if ( $field->type == 'checkbox' && preg_match( '/selected\[(\d+)\]/', $modifier, $matches ) ) {
-						$index       = $matches[1];
+					if ( $field->type == 'checkbox' && strpos( $modifier, 'selected[' ) === 0 ) {
+						$index       = rgar( $this->parse_modifiers( $modifier ), 'selected' );
 						$value_array = explode( ',', $value );
 						return rgar( $value_array, $index );
 					}

--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -490,6 +490,13 @@ class GW_Advanced_Merge_Tags {
 					// Example {My Address Field:1.6:abbr}
 					$default_countries = array_flip( GF_Fields::get( 'address' )->get_default_countries() );
 					return rgar( $default_countries, $value );
+				default:
+					// 'selected' can be used over 'Checkbox' field to target the selected checkbox by its zero-based index.
+					if ( $field->type == 'checkbox' && preg_match( '/selected\[(\d+)\]/', $modifier, $matches ) ) {
+						$index       = $matches[1];
+						$value_array = explode( ',', $value );
+						return rgar( $value_array, $index );
+					}
 			}
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2616973134/67202

## Summary

Added support for a :selected modifier that would let you target the selected checkbox by its zero-based index in our [Advanced Merge Tags](https://gravitywiz.com/snippet-library/gw-advanced-merge-tags/) snippet.

**How this update works:**
https://www.loom.com/share/0cc9030f5e4a40b59911ff6af3315078