### PR TITLE
`gw-validate-that-a-value-exists.php`: Fixed an issue with validate value not working with AJAX.

### DIFF
--- a/gravity-forms/gw-validate-that-a-value-exists.php
+++ b/gravity-forms/gw-validate-that-a-value-exists.php
@@ -222,7 +222,7 @@ class GW_Value_Exists_Validation {
 									break;
 								}
 							}
-							values[ inputId ] = $( this ).val();
+							values[ sourceFieldId ] = $( this ).val();
 						} );
 						return values;
 					}

--- a/gravity-forms/gw-validate-that-a-value-exists.php
+++ b/gravity-forms/gw-validate-that-a-value-exists.php
@@ -222,7 +222,7 @@ class GW_Value_Exists_Validation {
 									break;
 								}
 							}
-							values[ sourceFieldId ] = $( this ).val();
+							values[ sourceFieldId ? sourceFieldId : inputId ] = $( this ).val();
 						} );
 						return values;
 					}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2622834298/67455

## Summary

We were erroneously mapping target field's ID when validating on AJAX side. Fixed it with `sourceFieldId`. This fix had nothing to do with GPUID.

Walkthrough of the issue:
https://www.loom.com/share/42e2401ba9854f64acaf52e8970954fb
