### PR TITLE
`gpecf-set-discount-amount-by-field-value.php`: Fixed PHP 8.2 warnings.

### DIFF
--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -17,6 +17,7 @@ class GPEP_Edit_Entry {
 	private $form_id;
 	private $delete_partial;
 	private $passed_through_entries;
+	private $process_feeds;
 
 	public function __construct( $options ) {
 

--- a/gp-easy-passthrough/gpep-edit-entry.php
+++ b/gp-easy-passthrough/gpep-edit-entry.php
@@ -17,6 +17,7 @@ class GPEP_Edit_Entry {
 	private $form_id;
 	private $delete_partial;
 	private $passed_through_entries;
+	private $refresh_token;
 	private $process_feeds;
 
 	public function __construct( $options ) {

--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -5,6 +5,8 @@
  */
 class GPECF_Discount_Amounts_By_Field_Value {
 
+	private $_args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class

--- a/gp-ecommerce-fields/gpecf-tax-amounts-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-tax-amounts-by-field-value.php
@@ -16,6 +16,8 @@
  */
 class GPECF_Tax_Amounts_By_Field_Value {
 
+	private $_args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class

--- a/gp-ecommerce-fields/gpecf-tax-inclusive-order-summary-markup.php
+++ b/gp-ecommerce-fields/gpecf-tax-inclusive-order-summary-markup.php
@@ -14,6 +14,8 @@
  */
 class GW_Tax_Inclusive_Order_Summary {
 
+	private $_args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2628106398/67682
https://secure.helpscout.net/conversation/2615336042/67099

## Summary

Formatting: Fixed PHP 8.2 warnings in a handful of snippets.

Error messages like:

Creation of dynamic property GPECF_Discount_Amounts_By_Field_Value::$_args is deprecated
Creation of dynamic property GPEP_Edit_Entry::$process_feeds is deprecated


