### PR TITLE
`gpld-block-date-range.php`: Fixed an issue where the end date is not included.

### DIFF
--- a/gp-limit-dates/gpld-block-date-ranges.php
+++ b/gp-limit-dates/gpld-block-date-ranges.php
@@ -16,7 +16,9 @@ function gpld_except_date_ranges( $options, $form, $field ) {
 	foreach ( $ranges as $range ) {
 		$start_date = new DateTime( $range[0] );
 		$end_date   = new DateTime( $range[1] );
-		$period     = new DatePeriod( $start_date, new DateInterval( 'P1D' ), $end_date );
+		// include end date.
+		$end_date->setTime( 0, 0, 1 );
+		$period = new DatePeriod( $start_date, new DateInterval( 'P1D' ), $end_date );
 
 		foreach ( $period as $date ) {
 			$options['exceptions'][] = $date->format( 'm/d/Y' );


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2629654339/67747?folderId=8114575

## Summary
The snippet doesn't include the End Date in the block dates. This PR will fix the issue.
