### PR TITLE
`gppa-show-place-name.php`: Fixed `gform is not defined` console error.

### DIFF
--- a/gp-address-autocomplete/gpaa-show-place-name.js
+++ b/gp-address-autocomplete/gpaa-show-place-name.js
@@ -1,0 +1,24 @@
+/**
+ * Gravity Perks // Address Autocomplete // Search & Show by Place Name
+ * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete/
+ *
+ * Find addresses by their name. For example, "Mount Trashmore" in Virginia Beach would resolve to
+ * an address of "310 Edwin Drive, Virginia Beach, VA 23462".
+ *
+ * Instructions:
+ *     1. Install this snippet with our free Code Chest plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+
+// Enable search by Place Name
+gform.addFilter( 'gpaa_autocomplete_options', function( options ) {
+	options.types = [ 'geocode', 'establishment' ];
+	options.fields.push( 'name' );
+	return options;
+} );
+
+// Display Place Name
+gform.addAction( 'gpaa_fields_filled', function ( place, instance, formId, fieldId ) {
+	jQuery( '#input_{0}_{1}_1'.gformFormat( formId, fieldId ) ).val( place.name );
+} );

--- a/gp-address-autocomplete/gpaa-show-place-name.php
+++ b/gp-address-autocomplete/gpaa-show-place-name.php
@@ -1,31 +1,6 @@
 <?php
 /**
- * Gravity Perks // Address Autocomplete // Search & Show by Place Name
- * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete/
- *
- * Find addresses by their name. For example, "Mount Trashmore" in Virginia Beach would resolve to
- * an address of "310 Edwin Drive, Virginia Beach, VA 23462".
- *
- * Developer's Note: The JS in this snippet cannot be included via the Custom Javascript plugin due
- * to an order-of-events issue with GPAA calling the options filter before the Custom Javascript plugin
- * has initialized.
+ * This snippet has evolved! 🦄
+ * Find the new version of this snippet here: 
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-address-autocomplete/gpaa-show-place-name.js
  */
-// Update "123" to your form ID or remove "_123" to apply to all forms.
-add_action( 'gform_pre_enqueue_scripts_123', function() {
-	?>
-	<script>
-		// Enable search by Place Name
-		gform.addFilter( 'gpaa_autocomplete_options', function( options ) {
-			options.types = [ 'geocode', 'establishment' ];
-			options.fields.push( 'name' );
-			return options;
-		} );
-		// Display Place Name
-		gform.addAction('gpaa_fields_filled', function ( place, instance, formId, fieldId ) {
-			// Update "123" to your form ID, update _1_1 to your field ID. If your field ID is 4, this would be _4_1.
-			jQuery('#input_123_1_1').val( place.name );
-			return place;
-		} );
-	</script>
-	<?php
-} );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2629624110/67745?folderId=8114575

## Summary
Fixed `ReferenceError: gform is not defined` console error. The issue here is that the `gform_pre_enqueue_scripts` is called twice. The first call is the culprit. But `wp_head` hook will suffice in this case.
<!-- Briefly explain what's new in this pull request. -->
