### PR TITLE
`gw-cache-buster.php`: Fixed issue with Cache Buster not clearing cookies with Paypal checkout and Nested entry.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -39,7 +39,6 @@ class GW_Cache_Buster {
 			return;
 		}
 
-		add_filter( 'gform_pre_render', array( $this, 'clear_gpnf_cookies' ) );
 		add_filter( 'gform_shortcode_form', array( $this, 'shortcode' ), 10, 3 );
 		add_filter( 'gform_save_and_continue_resume_url', array( $this, 'filter_resume_link' ), 15, 4 );
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_embed_url' ), 10, 4 );
@@ -47,22 +46,6 @@ class GW_Cache_Buster {
 
 		add_action( 'wp_ajax_nopriv_gfcb_get_form', array( $this, 'ajax_get_form' ) );
 		add_action( 'wp_ajax_gfcb_get_form', array( $this, 'ajax_get_form' ) );
-	}
-
-	public function clear_gpnf_cookies( $form ) {
-
-		if ( class_exists( 'GPNF_Session' ) && $this->is_cache_busting_applicable() ) {
-			$session     = new GPNF_Session( $form['id'] );
-			$cookie_name = $session->get_cookie_name();
-			foreach ( $_COOKIE as $name => $value ) {
-				if ( preg_match( '/^' . preg_quote( $cookie_name, '/' ) . '/', $name ) ) {
-					unset( $_COOKIE[ $name ] );
-					setcookie( $name, '', time() - ( 15 * 60 ), COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
-				}
-			}
-		}
-
-		return $form;
 	}
 
 	public function shortcode( $markup, $attributes, $content ) {
@@ -162,8 +145,11 @@ class GW_Cache_Buster {
 		// Still needed for the AJAX submission.
 		$ajax_url = add_query_arg(
 			array(
-				'action'  => 'gfcb_get_form',
-				'form_id' => $form_id,
+				'action'          => 'gfcb_get_form',
+				'form_id'         => $form_id,
+				'gpnf_context'    => array(
+					'path' => class_exists( 'GPNF_Session' ) ? esc_js( GPNF_Session::get_session_path() ) : '',
+				),
 			),
 			$ajax_url
 		);

--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -143,16 +143,19 @@ class GW_Cache_Buster {
 		$ajax_url       = remove_query_arg( $exclude_params, add_query_arg( $_GET, admin_url( 'admin-ajax.php' ) ) );
 
 		// Still needed for the AJAX submission.
-		$ajax_url = add_query_arg(
-			array(
-				'action'          => 'gfcb_get_form',
-				'form_id'         => $form_id,
-				'gpnf_context'    => array(
-					'path' => class_exists( 'GPNF_Session' ) ? esc_js( GPNF_Session::get_session_path() ) : '',
-				),
-			),
-			$ajax_url
+		$ajax_params = array(
+			'action'  => 'gfcb_get_form',
+			'form_id' => $form_id,
 		);
+
+		// Ensure AJAX parameters for GPNF are also correctly populated.
+		if ( class_exists( 'GPNF_Session' ) ) {
+			$ajax_params['gpnf_context'] = array(
+				'path' => esc_js( GPNF_Session::get_session_path() ),
+			);
+		}
+
+		$ajax_url = add_query_arg( $ajax_params, $ajax_url );
 
 		$lang = null;
 		if ( class_exists( 'Gravity_Forms_Multilingual' ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2630007391/67768/

## Summary

When Cache Buster is enabled, Nested Form fields are not being cleared when paying for a form using PayPal.

_Loom demonstrating the issue:_ https://www.loom.com/share/4816b6c7728a416083cfc706b28ff54a?sid=540ba7fe-133d-4e13-b4fb-b00912b4a181

When we submit form with Stripe checkout, `GPNF_Session::get_session_path` gets the correct session path, however, the same on paypal isn't true. It gets an empty session path. `GPNF_Session::delete_cookie`(L180) relies on getting correct cookie to delete it. Since, the session path isn't correct with paypal it fails. This only happens with Cache Buster.

_xDebug snapshot with Stripe:_
<img width="1535" alt="stripe" src="https://github.com/gravitywiz/snippet-library/assets/26293394/7ed7e745-e8e0-4edc-aa34-fbe7c6d7a840">


_xDebug snapshot with Paypal:_
<img width="1491" alt="paypal" src="https://github.com/gravitywiz/snippet-library/assets/26293394/d60beb92-5afb-489d-9f43-d925033ff65a">


The fix proposed here is to ensure we have removed all cookies for that form in cache buster scenario.



