### PR TITLE
`gp-address-autocomplete/gpaa-show-place-name.js`: Added change event when populating address field name.

### DIFF
--- a/gp-address-autocomplete/gpaa-show-place-name.js
+++ b/gp-address-autocomplete/gpaa-show-place-name.js
@@ -20,5 +20,5 @@ gform.addFilter( 'gpaa_autocomplete_options', function( options ) {
 
 // Display Place Name
 gform.addAction( 'gpaa_fields_filled', function ( place, instance, formId, fieldId ) {
-	jQuery( '#input_{0}_{1}_1'.gformFormat( formId, fieldId ) ).val( place.name );
+	jQuery( '#input_{0}_{1}_1'.gformFormat( formId, fieldId ) ).val( place.name ).trigger('change');
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2629624110/67745?folderId=6987275 

## Summary

Adds a change event emission so that the event gets propogated after the place name is set in the address field.

This was a suggestion from the customer and I think it makes sense as it may help avoid issues with the event not bubbling for anyone using this in the future.

