### PR TITLE
`gpaa-allow-browser-autocomplete.js`: Added snippet to allow browser autocomplete with GPAA.

### DIFF
--- a/gp-address-autocomplete/gpaa-allow-browser-autocomplete.js
+++ b/gp-address-autocomplete/gpaa-allow-browser-autocomplete.js
@@ -3,9 +3,8 @@
  * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete
  *
  * Instructions:
- *     1. Install our free Custom JavaScript for Gravity Forms plugin.
- *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
- *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ *     1. Install our free [Gravity Forms Code Chest](https://gravitywiz.com/gravity-forms-code-chest/) plugin.
+ *     2. Copy and paste the snippet into the JavaScript section of Code Chest for the form you wish to apply this snippet to.
  */
 window.gform.addFilter('gpaa_prevent_browser_autocomplete', function( preventBrowserAutocomplete, instance, formId, fieldId ) {
 	return false;

--- a/gp-address-autocomplete/gpaa-allow-browser-autocomplete.js
+++ b/gp-address-autocomplete/gpaa-allow-browser-autocomplete.js
@@ -1,0 +1,12 @@
+/**
+ * Gravity Perks // GP Address Autocomplete // Allow Browser Autocomplete
+ * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete
+ *
+ * Instructions:
+ *     1. Install our free Custom JavaScript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+window.gform.addFilter('gpaa_prevent_browser_autocomplete', function( preventBrowserAutocomplete, instance, formId, fieldId ) {
+	return false;
+});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2642022306/68309

## Summary

Filter whether browser autocomplete should be prevented, defaults to `true`. This provided an easy override to `false` (i.e. allow browser autocomplete).
