### PR TITLE
`gw-dynamic-range.php`: Fixed issue with decimal values on dynamic range.

### DIFF
--- a/gravity-forms/gw-dynamic-range.php
+++ b/gravity-forms/gw-dynamic-range.php
@@ -19,6 +19,8 @@
  */
 class GW_Dynamic_Range {
 
+	private $_args = array();
+
 	public function __construct( $args = array() ) {
 
 		$this->_args = wp_parse_args( $args, array(
@@ -222,8 +224,6 @@ class GW_Dynamic_Range {
 						if ( currentValue === false || currentValue === '' ) {
 							return;
 						}
-
-						currentValue = parseInt( currentValue );
 
 						let value = currentValue;
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2649614006/68685

## Summary

The Dynamic range snippet doesn't work on the front end, for the max value when a decimal is entered. The issue is because on the javascript we are typecasting the current value to integer: `currentValue = parseInt( currentValue );`. Overriding that fixes the issue.

**BEFORE:**
https://www.loom.com/share/c002e98098374e09b65e8782744c2062

**AFTER: (~30 seconds)**
https://www.loom.com/share/643a79c35fbc4c6986835a9e9dc52831
