### PR TITLE
`gw-populate-date.php`: Fixed an issue with default time not loading after conditional logic.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -244,7 +244,7 @@ class GW_Populate_Date {
 					$hour = 12;
 				}
 			}
-			$date = array( $hour, $minute, $ampm );
+			$date = "${hour}:${minute} ${ampm}";
 		} elseif ( $this->_args['enable_i18n'] ) {
 			$date = strftime( $format, $timestamp );
 		} else {

--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -244,6 +244,8 @@ class GW_Populate_Date {
 					$hour = 12;
 				}
 			}
+			// Ensure the time value is retained as a String.
+			// If saved in array format, it will not reload the value after conditional viewing/hiding.
 			$date = "${hour}:${minute} ${ampm}";
 		} elseif ( $this->_args['enable_i18n'] ) {
 			$date = strftime( $format, $timestamp );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2632728563/67897

## Summary

When using the [Populate Date/Time snippet](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-populate-date.php), if a Time field is shown with conditional logic, it is not populated.

We need to send the Time field, like the Date field, in a string data format and not array.

Summary of the snippet in action:
https://www.loom.com/share/b19cd15445664b8bb00c9898e0fdbdff