### PR TITLE
`gw-round-robin.php`: Fixed PHP 8.2 warnings.

### DIFF
--- a/gravity-forms/gw-round-robin.php
+++ b/gravity-forms/gw-round-robin.php
@@ -17,6 +17,8 @@
  */
 class GW_Round_Robin {
 
+	private $_args = array();
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class


### PR DESCRIPTION
## Context

Ticket: https://secure.helpscout.net/conversation/2655184620/68924/

## Summary

PHP 8.2 deprecation notice

`Creation of dynamic property GW_Round_Robin::$_args is deprecated`