### PR TITLE
`gw-all-fields-template.php`: Fixed logic for `nopricingfields` scenario.

### DIFF
--- a/gravity-forms/gw-all-fields-template.php
+++ b/gravity-forms/gw-all-fields-template.php
@@ -161,12 +161,7 @@ class GW_All_Fields_Template {
 			}
 
 			if ( $modifier === 'nopricingfields' && ! has_filter( 'gform_order_summary', array( $this, 'clear_order_summary' ) ) ) {
-
 				add_filter( 'gform_order_summary', array( $this, 'clear_order_summary' ) );
-
-				// Hide "Order Summary" label if `:nopricingfields` is used.
-				add_filter( 'gform_display_product_summary', array( $this, 'hide_order_summary_label' ) );
-
 			}
 
 			/**
@@ -220,10 +215,9 @@ class GW_All_Fields_Template {
 						$value = $this->get_all_fields_field_value( $field, $value );
 					}
 					break;
-				case 'nopricingfields':
 				case 'exclude':
 					// exclude the fields marked to be excluded, or exclude all pricing fields if 'nopricingfields' merge tag is used.
-					if ( in_array( (int) $field->id, $field_ids, true ) || ( $modifier == 'nopricingfields' && GFCommon::is_product_field( $field->type ) ) ) {
+					if ( in_array( (int) $field->id, $field_ids, true ) ) {
 
 						$exclude_full_value = true;
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2517551316/61937

## Summary

Make the logic cleaner, still continues to do the job well. Snapshot of how all the scenarios display correctly.

<img width="1746" alt="Screenshot 2024-07-20 at 12 47 16 PM" src="https://github.com/user-attachments/assets/2a64b3a6-38d9-4342-9453-8b67f5d62fa9">


`{all_fields}`
`{order_summary}`
`{all_fields:nopricingfields}`