### PR TITLE
`gw-disable-autocomplete.php`: Fixed issue where Firefox no longer honored the "off" value for the autocomplete attribute.

### DIFF
--- a/gravity-forms/gw-disable-autocomplete.php
+++ b/gravity-forms/gw-disable-autocomplete.php
@@ -10,13 +10,13 @@
  */
 // Disable auto-complete on form.
 add_filter( 'gform_form_tag', function( $form_tag ) {
-	$autocomplete = gw_get_browser_name( $_SERVER['HTTP_USER_AGENT'] ) === 'Chrome' ? 'password' : 'off';
+	$autocomplete = 'off';
 	return str_replace( '>', ' autocomplete="' . $autocomplete . '">', $form_tag );
 }, 11 );
 
 // Diable auto-complete on each field.
 add_filter( 'gform_field_content', function( $input ) {
-	$autocomplete = gw_get_browser_name( $_SERVER['HTTP_USER_AGENT'] ) === 'Chrome' ? 'password' : 'off';
+	$autocomplete = in_array( gw_get_browser_name( $_SERVER['HTTP_USER_AGENT'] ), array( 'Chrome', 'Firefox' ) ) ? 'new-password' : 'off';
 	return preg_replace( '/<(input|textarea)/', '<${1} autocomplete="' . $autocomplete . '" ', $input );
 }, 11 );
 

--- a/gravity-forms/gw-disable-autocomplete.php
+++ b/gravity-forms/gw-disable-autocomplete.php
@@ -4,7 +4,7 @@
  *
  * Disable browser auto-complete.
  *
- * @version 0.3
+ * @version 0.4
  * @license GPL-2.0+
  * @link    http://gravitywiz.com
  */


### PR DESCRIPTION
## Context

💬 Slack: https://gravitywiz.slack.com/archives/GMP0ZMNSE/p1721422667276589

## Summary

Dani reported that this snippet wasn't working for her in Firefox. I confirmed. I fixed.

**Notes:** 

- I simplified the logic on the form autocomplete attribute since, in my testing, it didn't actually have any impact on whether or not the individual inputs were auto-filled.
- I only tested in Chrome and Firefox and scoped the input changes as such. We may end up needing to default to this "new-password" value for all browsers at some point.
