### PR TITLE
`gpnf-hide-expired-nested-form-field.php`: Added snippet to Hide Expired Nested Form Field.

### DIFF
--- a/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
+++ b/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
@@ -12,7 +12,7 @@ function check_nested_form_expiration( $form ) {
 		return $form;
 	}
 
-	foreach( $form['fields'] as &$field ) {
+	foreach ( $form['fields'] as &$field ) {
 		if ( $field->type == 'form' && $field->gpnfForm ) {
 			$nested_form = GFAPI::get_form( $field->gpnfForm );
 			$is_expired  = GFFormDisplay::validate_form_schedule( $nested_form );

--- a/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
+++ b/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Gravity Perks // GP Nested Forms // Hide Nested Form Field if the Nested Form has expired.
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * Instruction Video: https://www.loom.com/share/798f30d73d254864aa6a65e7d16d390b
+ */
+add_filter( 'gform_pre_render', 'check_nested_form_expiration' );
+function check_nested_form_expiration( $form ) {
+	// Update '435' to the targeted Parent Form's ID.
+	if ( rgar( $form, 'id' ) != 435 || ! is_callable( 'gp_nested_forms' ) ) {
+		return $form;
+	}
+
+	foreach( $form['fields'] as &$field ) {
+		if ( $field->type == 'form' && $field->gpnfForm ) {
+			$nested_form = GFAPI::get_form( $field->gpnfForm );
+			$is_expired  = GFFormDisplay::validate_form_schedule( $nested_form );
+			if ( $is_expired ) {
+				$field->visibility = 'hidden';
+			}
+		}
+	}
+	return $form;
+}

--- a/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
+++ b/gp-nested-forms/gpnf-hide-expired-nested-form-field.php
@@ -5,10 +5,10 @@
  *
  * Instruction Video: https://www.loom.com/share/798f30d73d254864aa6a65e7d16d390b
  */
-add_filter( 'gform_pre_render', 'check_nested_form_expiration' );
-function check_nested_form_expiration( $form ) {
-	// Update '435' to the targeted Parent Form's ID.
-	if ( rgar( $form, 'id' ) != 435 || ! is_callable( 'gp_nested_forms' ) ) {
+add_filter( 'gform_pre_render', function ( $form ) {
+	// Update to form IDs this is to be applied to.
+	$form_ids = array( 43, 532, 435 );
+	if ( ! in_array( rgar( $form, 'id' ), $form_ids ) || ! is_callable( 'gp_nested_forms' ) ) {
 		return $form;
 	}
 
@@ -22,4 +22,4 @@ function check_nested_form_expiration( $form ) {
 		}
 	}
 	return $form;
-}
+}, 10, 1 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2660146653/69147

## Summary

Snippet to hide a Nested Form field if the child form has expired (due to a schedule being set up on the child form). Currently, if the child form has expired, the modal will still open and display the form, but there will be an error when adding the entry:

**Demo:**
https://www.loom.com/share/798f30d73d254864aa6a65e7d16d390b