### PR TITLE
`gpml-acf-user-image-field.php`: Fixed PHP 8.2 warnings.

### DIFF
--- a/gp-media-library/gpml-acf-user-image-field.php
+++ b/gp-media-library/gpml-acf-user-image-field.php
@@ -12,6 +12,8 @@
  */
 class GPML_ACF_User_Image_Field {
 
+	private $_args = array();
+
 	public function __construct( $args ) {
 
 		$this->_args = wp_parse_args(

--- a/gp-media-library/gpml-ajax-upload.php
+++ b/gp-media-library/gpml-ajax-upload.php
@@ -16,6 +16,9 @@
  */
 class GPML_Ajax_Upload {
 
+	private $_args = array();
+	private $form_id;
+
 	public function __construct( $args = array() ) {
 
 		$this->_args = wp_parse_args( $args, array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2667457194/69503

## Summary

PHP Warning

```
Deprecated: Creation of dynamic property GPML_ACF_User_Image_Field::$_args is deprecated.
```