### PR TITLE
`gw-user-registration-update-by-email.php`: Fixed potential fatal warning generated with the snippet.

### DIFF
--- a/gravity-forms/gw-user-registration-update-by-email.php
+++ b/gravity-forms/gw-user-registration-update-by-email.php
@@ -105,9 +105,7 @@ class GW_UR_Update_By_Email {
 			add_action( 'gform_validation', array( $this, 'validate_role' ) );
 		}
 
-		// let's just be safe and reset current lead to false so it doesn't disrupt the normal flow of things...
-		//GFFormsModel::set_current_lead( false );
-
+		return $form;
 	}
 
 	public function add_created_by_by_email( $entry, $form ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2667097473/69480

## Summary

An error generated when the [GF User Registration Update by Email](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-user-registration-update-by-email.php) snippet is active. This fixes the issue.
