### PR TITLE
`gpnf-child-products-in-parent-order-summary.php`: Fixed an issue where nested form product field total in not include in woocommerce cart total.

### DIFF
--- a/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
+++ b/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
@@ -50,7 +50,7 @@ add_filter( 'gform_product_info', function( $product_info, $form, $entry ) {
 						}
 					}
 
-					$_child_products[ "{$nested_form_field_id}.{$child_entry['id']}.{$child_field_id}" ] = $child_product;
+					$_child_products[ "{$nested_form_field_id}.{$child_entry['id']}_{$child_field_id}" ] = $child_product;
 				}
 				$child_products = $child_products + $_child_products;
 			}


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2670405760/69619

## Summary
<!-- Briefly explain what's new in this pull request. -->
When the [Include Child Products Directly in Parent Form Order Summary](https://github.com/gravitywiz/snippet-library/blob/master/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php) snippet is active on a site that uses GSPC, the total from the Nested Forms is not added to the Woo product.

The fix here is to modify the child product key within the loop.
