### PR TITLE
`gspc-sync-field-max-to-wc-quantity.js`: Fixed an issue with max attribute when input is mapped as WooCommerce quantity.

### DIFF
--- a/gs-product-configurator/gspc-sync-field-max-to-wc-quantity.js
+++ b/gs-product-configurator/gspc-sync-field-max-to-wc-quantity.js
@@ -10,40 +10,18 @@
  *     3. Add "sync-max-to-quantity" to the Custom CSS Class setting of the fields you want to sync the max.
  */
 var $form = jQuery('#gform_GFFORMID');
-var $quantity = jQuery('.input-text.qty');
-var quantityMax = $quantity.attr('max');
-
 var getSyncedInputs = function() {
     return $form.find('.sync-max-to-quantity input');
 }
 
-// Create MutationObserver on $quantity's max attribute.
-var observer = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
-        if (mutation.attributeName === 'max') {
-            quantityMax = $quantity.attr('max');
-
-            getSyncedInputs()
-                .attr('max', quantityMax)
-                .each(function() {
-                    var $this = jQuery(this);
-                    if ($this.val() > quantityMax) {
-                        $this.val(quantityMax);
-                    }
-              });
-        }
+$form.on('found_variation', (event, variation) => {
+  var maxQty = variation.max_qty;
+  getSyncedInputs()
+    .attr('max', maxQty)
+    .each(function () {
+      var $this = jQuery(this);
+      if ($this.val() > maxQty) {
+        $this.val(maxQty);
+      }
     });
-});
-
-observer.observe($quantity[0], {
-    attributes: true,
-    attributeFilter: ['max']
-});
-
-// Listen to input events on the synced inputs to ensure they don't exceed the max.
-getSyncedInputs().on('input', function() {
-    var $this = jQuery(this);
-    if ($this.val() > quantityMax) {
-        $this.val(quantityMax);
-    }
 });


### PR DESCRIPTION

## Context
When the input is mapped as woocommerce quantity, the max input attribute is not set to the maximum quantity of the selected product. This PR fixed the issue by using the `found_variation` action to listen to changes instead of using the mutation observer.

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2677576845/69900

## Summary

<!-- Briefly explain what's new in this pull request. -->
