### PR TITLE
`gpld-inline-datepicker-only-for-mobile-devies.php`: Added snippet for inline datepicker to work only on mobile devices.

### DIFF
--- a/gp-limit-dates/gpld-inline-datepicker-only-for-mobile-devies.php
+++ b/gp-limit-dates/gpld-inline-datepicker-only-for-mobile-devies.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Gravity Perks // GP Limit Dates // Inline Datepicker only on Mobile Devices.
+ * http://gravitywiz.com/documentation/gp-limit-dates/
+ *
+ * Instruction Video: https://www.loom.com/share/2e3e9838f2994b619402d18ff9f96114
+ */
+// Replace 278 with your Form ID, and 3 with your Date Field ID
+add_filter( 'gpld_limit_dates_options_278_3', function( $options, $form, $field ) {
+	if ( ! wp_is_mobile() ) {
+		$options['inlineDatepicker'] = false;
+	}
+	return $options;
+}, 10, 3);


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2675073655/69822

## Summary

Totally missed creating this PR. Doing so now..

Snippet to only apply inline date picker for mobile devices.

EDIT: Lost track of this totally, from what i recall the [JS hook](https://docs.gravityforms.com/gform_datepicker_options_pre_init/) suggested by Dave was causing issues with the broken display on the non-inline datepicker (desktop view)
