### PR TITLE
`gpnf-copy-parent-value-manually.js`: Fixed an issue where source field value is not copied over if it is a dropdown or radio button field.

### DIFF
--- a/gp-nested-forms/gpnf-copy-parent-value-manually.js
+++ b/gp-nested-forms/gpnf-copy-parent-value-manually.js
@@ -25,7 +25,9 @@ gform.addAction( 'gpnf_init_nested_form', function( childFormId, gpnf ) {
 
 function copyParentFormValue( parentFormId, parentFieldId, childFormId, childFieldId ) {
 
-	var value = jQuery ( '#input_{0}_{1}'.gformFormat( parentFormId, parentFieldId ) ).val();
+	var value = jQuery ( '#input_{0}_{1}'.gformFormat( parentFormId, parentFieldId ) ).val() ||
+		jQuery('input[name="input_{0}"]:checked'.gformFormat( parentFieldId )).val() ||
+		jQuery('input[name="input_{0}"]:selected'.gformFormat( parentFieldId )).val();
 
 	// Delaying setting value so Populate Anything can pick up the change event.
 	setTimeout( function() {


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2670546355/69628

## Summary
The `gpnf-copy-parent-value-manually.js` snippet doesn't work when the parent form source field is a Radio button field.
This PR would fix the issue.
<!-- Briefly explain what's new in this pull request. -->
