### PR TITLE
`gpnf-disable-sessions.php`: Fixed an issue where non privileged users are not able to edit or delete entries.

### DIFF
--- a/gp-nested-forms/gpnf-disable-sessions.php
+++ b/gp-nested-forms/gpnf-disable-sessions.php
@@ -17,4 +17,17 @@ add_action( 'wp_ajax_nopriv_gpnf_session', 'gw_gpnf_disable_session', 9 );
 function gw_gpnf_disable_session() {
 	remove_action( 'wp_ajax_gpnf_session', array( gp_nested_forms(), 'ajax_session' ) );
 	remove_action( 'wp_ajax_nopriv_gpnf_session', array( gp_nested_forms(), 'ajax_session' ) );
+	// Delete previous stored session.
+	$session = new GPNF_Session( '4' ); // Update "4" to the ID of the parent form.
+	$session->delete_cookie();
 }
+
+// Allow non-admin users to edit or delete entry.
+add_filter( 'gpnf_can_user_edit_entry', function( $can_user_edit_entry, $entry ) {
+	// Update "5" to the ID of the child form.
+	if ( $entry['form_id'] == '5' ) {
+		return true;
+	}
+
+	return $can_user_edit_entry;
+}, 10 , 2);


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2677531768/69897

## Summary
When the GPNF disable session snippet is active, non-privileged users can not edit or delete entries. This PR will fix the issue.
<!-- Briefly explain what's new in this pull request. -->
