### PR TITLE
`gw-require-unique-values.php`: Fixed issue with Product Value comparison.

### DIFF
--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -184,6 +184,10 @@ class GW_Require_Unique_Values {
 			$value = basename( rgars( $_FILES, sprintf( 'input_%d/name', $field->id ) ) );
 		} else {
 			$value = $field->get_value_submission( array() );
+			// Product values are stored as Value|Price, we just need to compare Value.
+			if ( $field->type == 'product' && strpos( $value, '|' ) ) {
+				$value = explode( '|', $value )[0];
+			}
 		}
 
 		if ( $input_id && is_array( $value ) && isset( $value[ $input_id ] ) ) {

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -185,8 +185,8 @@ class GW_Require_Unique_Values {
 		} else {
 			$value = $field->get_value_submission( array() );
 			// Product values are stored as Value|Price, we just need to compare Value.
-			if ( $field->type == 'product' && strpos( $value, '|' ) ) {
-				$value = explode( '|', $value )[0];
+			if ( rgar( $field, 'enablePrice' ) ) {
+				$value = GFCommon::get_selection_value( $value );
 			}
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2686989633/70358

## Summary

The snippet doesn't work when the fields involved are Product Choice fields having similar label/value property but different prices.