### PR TITLE
`gpnf-disable-sessions.php:` Fixed an issue where unauthenticated users cannot edit or delete entries.

### DIFF
--- a/gp-nested-forms/gpnf-disable-sessions.php
+++ b/gp-nested-forms/gpnf-disable-sessions.php
@@ -15,6 +15,22 @@
 add_action( 'wp_ajax_gpnf_session', 'gw_gpnf_disable_session', 9 );
 add_action( 'wp_ajax_nopriv_gpnf_session', 'gw_gpnf_disable_session', 9 );
 function gw_gpnf_disable_session() {
+
 	remove_action( 'wp_ajax_gpnf_session', array( gp_nested_forms(), 'ajax_session' ) );
 	remove_action( 'wp_ajax_nopriv_gpnf_session', array( gp_nested_forms(), 'ajax_session' ) );
+
+	// Delete previous stored session, both as a convenience for users first install the snippet with existing sessions
+	// and as a security precaution to prevent malicious users from creating artificial session cookies.
+	$session = new GPNF_Session( rgpost( 'form_id' ) );
+	$session->delete_cookie();
+
 }
+
+add_filter( 'gpnf_can_user_edit_entry', function( $can_user_edit_entry, $entry, $current_user ) {
+	// Logged-in users can always edit their entries. Otherwise, only allow editing if the entry does not have a parent
+	// and does not belong to a session.
+	if ( ! $current_user && (int) gform_get_meta( $entry['id'], GPNF_Entry::ENTRY_PARENT_KEY ) === 0 ) {
+		$can_user_edit_entry = true;
+	}
+	return $can_user_edit_entry;
+}, 10, 3 );


### PR DESCRIPTION
Closed #874. 

## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2677531768/69897

## Summary

The title says it all. Supported by https://github.com/gravitywiz/gp-nested-forms/pull/287.
