### PR TITLE
`gpfup-require-camera.js`: Fixed issue with some Android Phones.

### DIFF
--- a/gp-file-upload-pro/gpfup-require-camera.js
+++ b/gp-file-upload-pro/gpfup-require-camera.js
@@ -13,6 +13,8 @@
  */
 gform.addAction( 'gpfup_uploader_ready', function( gpfup ) {
 	gpfup.Uploader.bind( 'PostInit', function() {
-		$( gpfup.$field ).find( 'input[type="file"]' ).attr( 'capture', 'camera' );
+		$( gpfup.$field ).find( 'input[type="file"]' )
+			.attr( 'capture', 'camera' )
+			.attr( 'accept', 'image/*' );
 	}, gpfup );
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2700871854/71092

## Summary

When using the [Require Camera for Uploads snippet](https://gravitywiz.com/snippet-library/gpfup-require-camera/) and a restriction is set on a field (ex: jpg, png, pdf), Android phones will allow the user to select images from the camera roll, even though they shouldn't be allowed to. This is not the case with iPhones.

This seems more of like something because of a recent update for Chrome Android: https://stackoverflow.com/questions/77876374/html-input-type-file-not-working-to-pull-up-camera-for-pixel-android-14-comb

As a fix, we are adding the `accept` attribute can help restrict it to images from the camera.

**Loom walkthrough with demo of the fix (tested on a Pixel7 via browserstack):**
https://www.loom.com/share/9fdffe90df88495888b5b3e7c38edac6