### PR TITLE
`gspc-hidden-product-handler.php`: Added snippet to remove url for Hidden Catalog Products on Cart.

### DIFF
--- a/gs-product-configurator/gspc-hidden-product-handler.php
+++ b/gs-product-configurator/gspc-hidden-product-handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Wiz // Remove URL and Edit Button for Hidden Products
+ * Gravity Wiz // Remove URL and Edit Button for Hidden Products in Cart.
  * https://gravitywiz.com/
  *
  * Plugin Name:  Remove URL & Edit Button for Hidden Products in Cart
@@ -52,7 +52,7 @@ class GW_Hidden_Product_Handler {
 	 * Remove the URL for hidden products in the cart.
 	 *
 	 * @param string $product_name  The product name.
-	 * @param array  $cart_item	 The cart item data.
+	 * @param array  $cart_item     The cart item data.
 	 * @param string $cart_item_key The cart item key.
 	 *
 	 * @return string Modified product name without link for hidden products.

--- a/gs-product-configurator/gspc-hidden-product-handler.php
+++ b/gs-product-configurator/gspc-hidden-product-handler.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Gravity Wiz // Remove URL and Edit Button for Hidden Products
+ * https://gravitywiz.com/
+ *
+ * Plugin Name:  Remove URL & Edit Button for Hidden Products in Cart
+ * Plugin URI:   https://gravitywiz.com/
+ * Description:  Remove the product link and edit button for hidden WooCommerce products in the cart.
+ * Author:       Gravity Wiz
+ * Version:      1.0
+ * Author URI:   https://gravitywiz.com/
+ */
+
+class GW_Hidden_Product_Handler {
+
+	private $_args = array();
+
+	public function __construct( $args = array() ) {
+
+		$this->_args = wp_parse_args( $args, array(
+			'form_id'  => false,
+			'field_id' => false,
+		) );
+
+		add_action( 'init', array( $this, 'init' ) );
+
+	}
+
+	public function init() {
+		add_filter( 'woocommerce_cart_item_name', array( $this, 'remove_url_for_hidden_product' ), 10, 3 );
+		add_filter( 'gspc_cart_item_edit_link', array( $this, 'maybe_remove_edit_button' ), 10, 2 );
+	}
+
+	/**
+	 * Helper function to check if the product is hidden.
+	 *
+	 * @param array $cart_item The cart item data.
+	 *
+	 * @return bool True if the product is hidden, false otherwise.
+	 */
+	public function is_hidden_product( $cart_item ) {
+		$product = $cart_item['data'];
+
+		if ( ! ( $product instanceof WC_Product ) ) {
+			return false;
+		}
+
+		return ( $product->get_catalog_visibility() === 'hidden' );
+	}
+
+	/**
+	 * Remove the URL for hidden products in the cart.
+	 *
+	 * @param string $product_name  The product name.
+	 * @param array  $cart_item	 The cart item data.
+	 * @param string $cart_item_key The cart item key.
+	 *
+	 * @return string Modified product name without link for hidden products.
+	 */
+	public function remove_url_for_hidden_product( $product_name, $cart_item, $cart_item_key ) {
+		if ( $this->is_hidden_product( $cart_item ) ) {
+			// Remove the link for hidden products
+			$product_name = strip_tags( $product_name );
+		}
+
+		return $product_name;
+	}
+
+	/**
+	 * Remove the edit button for hidden products in the cart.
+	 *
+	 * @param string $edit_link The edit link HTML.
+	 * @param array  $cart_item The cart item data.
+	 *
+	 * @return string Modified edit link (empty) if the product is hidden.
+	 */
+	public function maybe_remove_edit_button( $edit_link, $cart_item ) {
+		if ( $this->is_hidden_product( $cart_item ) ) {
+			// Remove the edit link for hidden products
+			return '';
+		}
+
+		return $edit_link;
+	}
+}
+
+// Initialize the class with no specific arguments
+new GW_Hidden_Product_Handler();

--- a/gs-product-configurator/gspc-hidden-product-handler.php
+++ b/gs-product-configurator/gspc-hidden-product-handler.php
@@ -1,88 +1,18 @@
 <?php
 /**
- * Gravity Wiz // Remove URL and Edit Button for Hidden Products in Cart.
- * https://gravitywiz.com/
- *
- * Plugin Name:  Remove URL & Edit Button for Hidden Products in Cart
- * Plugin URI:   https://gravitywiz.com/
- * Description:  Remove the product link and edit button for hidden WooCommerce products in the cart.
- * Author:       Gravity Wiz
- * Version:      1.0
- * Author URI:   https://gravitywiz.com/
+ * Gravity Shop // Product Configurator // Remove URL for Hidden Products in Cart.
+ * https://gravitywiz.com/documentation/gs-product-configurator/
  */
-
-class GW_Hidden_Product_Handler {
-
-	private $_args = array();
-
-	public function __construct( $args = array() ) {
-
-		$this->_args = wp_parse_args( $args, array(
-			'form_id'  => false,
-			'field_id' => false,
-		) );
-
-		add_action( 'init', array( $this, 'init' ) );
-
-	}
-
-	public function init() {
-		add_filter( 'woocommerce_cart_item_name', array( $this, 'remove_url_for_hidden_product' ), 10, 3 );
-		add_filter( 'gspc_cart_item_edit_link', array( $this, 'maybe_remove_edit_button' ), 10, 2 );
-	}
-
-	/**
-	 * Helper function to check if the product is hidden.
-	 *
-	 * @param array $cart_item The cart item data.
-	 *
-	 * @return bool True if the product is hidden, false otherwise.
-	 */
-	public function is_hidden_product( $cart_item ) {
-		$product = $cart_item['data'];
-
-		if ( ! ( $product instanceof WC_Product ) ) {
-			return false;
-		}
-
-		return ( $product->get_catalog_visibility() === 'hidden' );
-	}
-
-	/**
-	 * Remove the URL for hidden products in the cart.
-	 *
-	 * @param string $product_name  The product name.
-	 * @param array  $cart_item     The cart item data.
-	 * @param string $cart_item_key The cart item key.
-	 *
-	 * @return string Modified product name without link for hidden products.
-	 */
-	public function remove_url_for_hidden_product( $product_name, $cart_item, $cart_item_key ) {
-		if ( $this->is_hidden_product( $cart_item ) ) {
-			// Remove the link for hidden products
-			$product_name = strip_tags( $product_name );
-		}
-
+add_filter( 'woocommerce_cart_item_name', function ( $product_name, $cart_item, $cart_item_key ) {
+	$product = $cart_item['data'];
+	if ( ! ( $product instanceof WC_Product ) ) {
 		return $product_name;
 	}
 
-	/**
-	 * Remove the edit button for hidden products in the cart.
-	 *
-	 * @param string $edit_link The edit link HTML.
-	 * @param array  $cart_item The cart item data.
-	 *
-	 * @return string Modified edit link (empty) if the product is hidden.
-	 */
-	public function maybe_remove_edit_button( $edit_link, $cart_item ) {
-		if ( $this->is_hidden_product( $cart_item ) ) {
-			// Remove the edit link for hidden products
-			return '';
-		}
-
-		return $edit_link;
+	// Remove the link for hidden products
+	if ( $product->get_catalog_visibility() === 'hidden' ) {
+		$product_name = strip_tags( $product_name );
 	}
-}
 
-// Initialize the class with no specific arguments
-new GW_Hidden_Product_Handler();
+	return $product_name;
+}, 10, 3 );

--- a/gs-product-configurator/gspc-unlink-hidden-products-in-cart.php
+++ b/gs-product-configurator/gspc-unlink-hidden-products-in-cart.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Shop // Product Configurator // Remove URL for Hidden Products in Cart.
+ * Gravity Shop // Product Configurator // Unlink Hidden Products in Cart.
  * https://gravitywiz.com/documentation/gs-product-configurator/
  */
 add_filter( 'woocommerce_cart_item_name', function ( $product_name, $cart_item, $cart_item_key ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2695302163/70820

## Summary

When a Woo product has a catalog visibility of hidden, the cart item still shows its product link. This snippet removes it.


**BEFORE:**
<img width="796" alt="Screenshot 2024-09-11 at 6 22 00 PM" src="https://github.com/user-attachments/assets/d39b5436-e7ef-4b7c-bc69-748c90c2a256">

**AFTER:**
<img width="766" alt="Screenshot 2024-09-11 at 6 22 27 PM" src="https://github.com/user-attachments/assets/713485f3-58aa-4a1b-b72b-7740d2b9f6cd">

