### PR TITLE
`gw-none-of-the-above-checkbox.js`: Added setting to not disable None of the Above by default.

### DIFF
--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -21,9 +21,10 @@
  */
 $( '.gw-none-of-the-above' ).each( function() {
 
-	var $field  = $( this );
-	var $last   = $field.find( '.gchoice:last-child input' );
-	var $others = $field.find( 'input' ).not( $last );
+	var $disable_nota = false;
+	var $field        = $( this );
+	var $last         = $field.find( '.gchoice:last-child input' );
+	var $others       = $field.find( 'input' ).not( $last );
 
 	// If "None of the Above" choice is checked by default.
 	if ( $last.prop( 'checked' ) ) {
@@ -45,7 +46,7 @@ $( '.gw-none-of-the-above' ).each( function() {
 	} );
 
 	$others.on( 'click', function() {
-		if ( $others.filter( ':checked' ).length ) {
+		if ( $others.filter( ':checked' ).length && $disable_nota ) {
 			$last.prop( 'disabled', true );
 		} else {
 			$last.prop( 'disabled', false );

--- a/gravity-forms/gw-none-of-the-above-checkbox.js
+++ b/gravity-forms/gw-none-of-the-above-checkbox.js
@@ -21,10 +21,10 @@
  */
 $( '.gw-none-of-the-above' ).each( function() {
 
-	var $disable_nota = false;
-	var $field        = $( this );
-	var $last         = $field.find( '.gchoice:last-child input' );
-	var $others       = $field.find( 'input' ).not( $last );
+	var disable_nota = false;
+	var $field       = $( this );
+	var $last        = $field.find( '.gchoice:last-child input' );
+	var $others      = $field.find( 'input' ).not( $last );
 
 	// If "None of the Above" choice is checked by default.
 	if ( $last.prop( 'checked' ) ) {
@@ -46,7 +46,7 @@ $( '.gw-none-of-the-above' ).each( function() {
 	} );
 
 	$others.on( 'click', function() {
-		if ( $others.filter( ':checked' ).length && $disable_nota ) {
+		if ( $others.filter( ':checked' ).length && disable_nota ) {
 			$last.prop( 'disabled', true );
 		} else {
 			$last.prop( 'disabled', false );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2711484484/71608

## Summary

Variable added at the top for specifying whether the "None of the Above" should be disabled - default to false which will change the default behavior of this snippet.

Loom Demonstration:
https://www.loom.com/share/a142a6a2a4da481b83d1d18937c12747