### PR TITLE
`gw-disable-expired-forms.php`: Added snippet to disable expired forms.

### DIFF
--- a/gravity-forms/gw-disable-expired-forms.php
+++ b/gravity-forms/gw-disable-expired-forms.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms // Disable Expired Forms
+ * https://gravitywiz.com/
+ *
+ * Video: https://www.loom.com/share/e2eff9a9b4744f1eb9fc8e1f2e8fd1cb
+ */
+add_action( 'init', function() {
+	$threshold = 1;
+
+	$forms = GFAPI::get_forms();
+	foreach( $forms as $form ) {
+		$schedule_end = rgar( $form, 'scheduleEnd' );
+		if ( ! $schedule_end ) {
+			continue;
+		}
+
+		$date = DateTime::createFromFormat( 'm/d/Y', $schedule_end );
+		$date->modify( "+{$threshold} days" );
+
+		$current_date = new DateTime();
+		if ( $date <= $current_date ) {
+			$form['is_active'] = 0;
+			GFAPI::update_form( $form );
+		}
+	}
+}, 5 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2696916682/70897

## Summary

A snippet that checks on load if the scheduled end date is beyond a given range and if so, updates the form status to "inactive". This checks all forms globally on load but only apply if a form schedule end date is set and that date is beyond a threshold value.

Snippet Demo: https://www.loom.com/share/e2eff9a9b4744f1eb9fc8e1f2e8fd1cb
