### PR TITLE
`gpnf-gflow-restart-workflow-for-child-entry-when-edited.php`: Added snippet to restart workflow for child entry when edited.

### DIFF
--- a/gp-nested-forms/gpnf-gflow-restart-workflow-for-child-entry-when-edited.php
+++ b/gp-nested-forms/gpnf-gflow-restart-workflow-for-child-entry-when-edited.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Restart Workflow for Child Entries when edited
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * Instruction Video: https://www.loom.com/share/0df02d719d4546fea88946a7eb3030cb
+ */
+add_filter( 'gform_entry_post_save', function ( $entry, $form ) {
+	if ( rgar( $entry, 'gpnf_entry_parent' ) && gravity_flow()->is_workflow_detail_page() ) {
+		$api = new Gravity_Flow_API( $form['id'] );
+		$api->restart_workflow( $entry );
+	}
+	return $entry;
+}, 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2710141085/71536

## Summary

Snippe to restart a GravityFlow Workflow within the child form when the child form entry is edited in a GravityFlow Step. 

Demo:
https://www.loom.com/share/0df02d719d4546fea88946a7eb3030cb