### PR TITLE
`gpnf-set-created-by-property-on-child-entries-after-user-registration.php`: Added snippet for GP Nested Forms that sets the created by property on the child entries after user account is created.

### DIFF
--- a/gp-nested-forms/gpnf-set-created-by-property-on-child-entries-after-user-registration.php
+++ b/gp-nested-forms/gpnf-set-created-by-property-on-child-entries-after-user-registration.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Set Created By Propery on Child Entries After User Account Registration.
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * Set the created by property of the child entries that is embedded on a user registration form
+ * with the user id of the account that is created after the parent form is submittted.
+ *
+ * Instructions:
+ *   1. Install per https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *   2. Configure the snippet based on inline instructions.
+ */
+add_action( 'gform_user_registered', 'add_created_by_property', 10, 4 );
+function add_created_by_property( $user_id, $feed, $entry, $user_pass ) {
+	// Update '123' with the Id of the form.
+	if ( $entry['form_id'] !== '123' ) {
+		return;
+	}
+
+	$parent_entry  = new GPNF_Entry( $entry );
+	$child_entries = $parent_entry->get_child_entries();
+
+	foreach ( $child_entries as $child_entry ) {
+		GFAPI::update_entry_property( $child_entry['id'], 'created_by', $user_id );
+		$child_entry['created_by'] = $user_id;
+	}
+}


### PR DESCRIPTION
Added new snippet for GP Nested Forms that sets the created by property on the child entries after user account is created.

## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2719134672/71947/

## Summary

When a nested form is submitted by a non-logged-in user, the created by property is not set on both the parent form entry and the child entries. However, when a, create user feed, is on the parent form to create a user account, it sets the created by property on the parent form but doesn't set that of the child form entries. This snippet sets the created by property on the child form entries, that is linked to the user registration parent form. 