### PR TITLE
`gw-populate-date`: Fixed PHP 8.2 deprecation notice.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -246,7 +246,7 @@ class GW_Populate_Date {
 			}
 			// Ensure the time value is retained as a String.
 			// If saved in array format, it will not reload the value after conditional viewing/hiding.
-			$date = "${hour}:${minute} ${ampm}";
+			$date = "{$hour}:{$minute} {$ampm}";
 		} elseif ( $this->_args['enable_i18n'] ) {
 			$date = strftime( $format, $timestamp );
 		} else {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2721507824/72066

## Summary

The [GW Populate Date](https://gravitywiz.com/snippet-library/gw-populate-date/) snippet is causing a deprecation warning for PHP 8.2:

**Deprecated: Using ${var} in strings is deprecated, use {$var} instead**

Relates to line 249 in the snippet:
`$date = "${hour}:${minute} ${ampm}";`

In PHP 8.2, the recommended way to use string interpolation with variables is to place the dollar sign inside the curly braces. Reference [link](https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing.complex)
