### PR TITLE
`gpeb-process-feeds-on-edit.php`: Added the ability to exclude certain feeds from being processed.

### DIFF
--- a/gp-entry-blocks/gpeb-process-feeds-on-edit.php
+++ b/gp-entry-blocks/gpeb-process-feeds-on-edit.php
@@ -25,6 +25,16 @@ add_filter( 'gform_entry_post_save', function( $entry, $form ) {
 	$filter_priority = rand( 100000, 999999 );
 	add_filter( 'gform_is_feed_asynchronous', '__return_false', $filter_priority );
 
+	add_filter( 'gform_addon_pre_process_feeds', function( $feeds, $entry, $form ) {
+		// Array of feed ids to exclude
+		$excluded_feed_ids = array( 103, 104 );
+		$feeds             = array_filter( $feeds, function( $feed ) use ( $excluded_feed_ids ) {
+			return ! in_array( $feed['id'], $excluded_feed_ids );
+		} );
+
+		return $feeds;
+	}, 10, 3 );
+
 	$addons = \GFAddon::get_registered_addons();
 
 	foreach ( $addons as $addon ) {
@@ -38,4 +48,3 @@ add_filter( 'gform_entry_post_save', function( $entry, $form ) {
 
 	return $entry;
 }, 10, 2 );
-

--- a/gp-entry-blocks/gpeb-process-feeds-on-edit.php
+++ b/gp-entry-blocks/gpeb-process-feeds-on-edit.php
@@ -9,6 +9,9 @@
  * Note, delayed feeds will still not be processed.
  */
 add_filter( 'gform_entry_post_save', function( $entry, $form ) {
+	// Array of feed ids to exclude for processing, if you want all feeds to be process use an empty array.
+	$excluded_feed_ids = array( 103, 104 );
+
 	if ( ! function_exists( 'gp_entry_blocks' ) ) {
 		return $entry;
 	}
@@ -25,10 +28,8 @@ add_filter( 'gform_entry_post_save', function( $entry, $form ) {
 	$filter_priority = rand( 100000, 999999 );
 	add_filter( 'gform_is_feed_asynchronous', '__return_false', $filter_priority );
 
-	add_filter( 'gform_addon_pre_process_feeds', function( $feeds, $entry, $form ) {
-		// Array of feed ids to exclude
-		$excluded_feed_ids = array( 103, 104 );
-		$feeds             = array_filter( $feeds, function( $feed ) use ( $excluded_feed_ids ) {
+	add_filter( 'gform_addon_pre_process_feeds', function( $feeds, $entry, $form ) use ( $excluded_feed_ids ) {
+		$feeds = array_filter( $feeds, function( $feed ) use ( $excluded_feed_ids ) {
 			return ! in_array( $feed['id'], $excluded_feed_ids );
 		} );
 


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2720318050/72019

## Summary
Added the ability to exclude certain feeds from being processed by specifying their feed IDs.
<!-- Briefly explain what's new in this pull request. -->
