### PR TITLE
`gpfup-enforce-exact-dimensions.js`: Added snippet to enforce exact dimensions on file upload.

### DIFF
--- a/gp-file-upload-pro/gpfup-enforce-exact-dimensions.js
+++ b/gp-file-upload-pro/gpfup-enforce-exact-dimensions.js
@@ -1,0 +1,30 @@
+/**
+ * Gravity Perks // File Upload Pro // Enforce Exact Width or Height
+ * https://gravitywiz.com/path/to/article/
+ *
+ * By default, the exact exact width *and* height settings applying cropping for conformity.
+ * This snippet enforces exact dimensions and any image other the specified width and height is rejected.
+ * The dimensions which are needed to be applied for exact match must be saved on Min Dimensions settings.
+ *
+ * Instruction Video: https://www.loom.com/share/4b28e2dbdbbb4b399b7220d3d77d71f5
+ *
+ * 1. Install this snippet with our free Code Chest plugin.
+ *    https://gravitywiz.com/gravity-forms-code-chest/
+ */
+window.gform.addFilter( 'gpfup_meets_minimum_requirement', function ( meetsMinimum, imageSize, formId, fieldId, GPFUP ) {
+	if ( imageSize.width == GPFUP.minWidth && imageSize.height == GPFUP.minHeight ) {
+		return true;
+	}
+	return false;
+} );
+
+window.gform.addFilter( 'gpfup_strings', function( strings, formId, fieldId ) {
+	// REPLACE 1 with the field id of your File Upload Pro field
+	if ( formId != GFFORMID && fieldId == 1 ) {
+		return strings;
+	}
+
+	// Alter the message, if needed.
+	strings.does_not_meet_minimum_dimensions = 'This image does not meet the exact dimensions: {minWidth}x{minHeight}px.';
+	return strings;
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2720536211/72026/

💬 Slack: https://gravitywiz.slack.com/archives/GMP0ZMNSE/p1727779512582999

## Summary

Snippet to force users to upload an image of a specific size. So if a user uploads a different-sized image, a validation error will be thrown.

Current GPFUP code logic only adds validation setting for min dimensions [here](https://github.com/gravitywiz/gp-file-upload-pro/blob/44623cfbe4c8ffaee8352f013baf8e92655df9b0/js/src/frontend/GPFUPField.ts#L522-L578)

We are going to use the filter for that and apply the exact settings.

Loom Demo:
https://www.loom.com/share/4b28e2dbdbbb4b399b7220d3d77d71f5