### PR TITLE
`gpnf-override-parent-merge-tag-on-submission.php`: Fixed an issue with parent merge tags not updating Time value on entry edit.

### DIFF
--- a/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
+++ b/gp-nested-forms/gpnf-override-parent-merge-tag-on-submission.php
@@ -156,7 +156,8 @@ class GPNF_Override_Parent_Merge_Tags {
 				$formula = apply_filters( 'gform_calculation_formula', $formula, $form, $field, $entry );
 
 				// Process/Calculate the formula
-				$parsed_formula   = GFCommon::replace_variables( $formula, $form, $entry, false, false, false, 'text' );
+				$parsed_formula = GFCommon::replace_variables( $formula, $form, $entry, false, false, false, 'text' );
+				// phpcs:ignore Squiz.PHP.Eval.Discouraged
 				$calculated_value = eval( 'return ' . $parsed_formula . ';' );
 
 				// Update the entry with the recalculated value


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2725972610/72284

## Summary

The snippet [gpnf-override-parent-merge-tag-on-submission](https://gravitywiz.com/snippet-library/gpnf-override-parent-merge-tag-on-submission/) works for all default values besides the "Hour", "Minute" and "AM/PM" default values from the Time field.

**Steps to Reproduce the issue:**
1. Create a parent and child form
2. add a Time field to both forms. On the child form, set the "Hour", "Minute" and "AM/PM" default values to the {Parent:X} merge tag.
3. install and configure snippet [gpnf-override-parent-merge-tag-on-submission](https://gravitywiz.com/snippet-library/gpnf-override-parent-merge-tag-on-submission/)
4. Go to parent form, enter a random time, add a new child entry, and then submit the parent form.
5. Go to edit parent entry and change the values of the time field, then update.
6. Now go to child entry and notice that time has not been overwritten by the new time.

The issue was because the time field stores the value as a string on entry, so "11:12 PM". So if the time field has its field ID 7, we will have `$entry[7]` containing that time string "11:12 PM". So we must fetch the string part via `7` and not `7.1`, `7.2` etc. This is what this proposed update focuses on.

**After Update:**
https://www.loom.com/share/be2f4d27721c4af691f0776bf57baa60
