### PR TITLE
`gpi-waiting-list.php`: Fixed issue with conditional logic not working for negative stock.

### DIFF
--- a/gp-inventory/gpi-waiting-list.php
+++ b/gp-inventory/gpi-waiting-list.php
@@ -63,6 +63,9 @@ class GPI_Waiting_List {
 		add_filter( 'gform_field_input', array( $this, 'remove_gform_field_input_filters' ), 15, 2 );
 
 		add_filter( 'gform_pre_render', array( $this, 'add_waiting_list_to_single_product' ) );
+
+		// Allow negative stock to be used for conditional logic validation.
+		add_filter( 'gpi_allow_negative_stock', array( $this, 'allow_negative_stock_for_conditional_logic' ), 10, 3 );
 	}
 
 	public function is_applicable_form( $form ) {
@@ -257,6 +260,14 @@ class GPI_Waiting_List {
 		}
 
 		return $form;
+	}
+
+	public function allow_negative_stock_for_conditional_logic( $allow_negative_stock, $target_field, $form ) {
+		if ( ! $this->is_applicable_form( $form ) ) {
+			return $allow_negative_stock;
+		}
+
+		return true;
 	}
 
 }


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2729999524/72460

## Summary

GP Inventory won't allow for conditional logic when available inventory is less than 0, with the waiting list snippet.

**BEFORE:**
https://www.loom.com/share/335c4889740e4e17acc2db6f922bd64f

**AFTER**:
https://www.loom.com/share/05e89df338944105a4acdc19fc3f39c2