### PR TITLE
`gw-disable-submit-button-until-required-fields-are-filled-out.php`: Fixed a compatibility issue with GP Populate Anything.

### DIFF
--- a/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
+++ b/gravity-forms/gw-disable-submit-button-until-required-fields-are-filled-out.php
@@ -32,14 +32,15 @@ class GW_Disable_Submit {
 		}
 
 		if ( ! self::$script_output ) {
-			$this->script();
+			add_action( 'wp_footer', array( $this, 'output_script' ) );
+			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
 			self::$script_output = true;
 		}
 
 		return $form;
 	}
 
-	public function script() {
+	public function output_script() {
 		?>
 
 		<script type="text/javascript">
@@ -81,6 +82,15 @@ class GW_Disable_Submit {
 						// Check if field becomes empty on deleting file(s)
 						$(document).on( 'click', '.gform_delete_file', function() {
 							self.runCheck();
+						});
+
+						// Check when fields are repopulated because of GPPA
+						$(document).on( 'gppa_updated_batch_fields', function() {
+							self.runCheck();
+						});
+						// GPPA logic may enable submit button, disable that logic.
+						gform.addFilter( 'gppa_disable_form_navigation_toggling', function() { 
+							return true; 
 						});
 
 						self.runCheck();


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2740666744/72953

## Summary

The Disable Submit Button Until Required Fields Are Filled Out snippet is conflicting with GPPA, causing the form to break. Populated fields just pulse and don't update.

Matt A's loom explaining the issue:
https://www.loom.com/share/e98e2369db5a43278f5d2706612fad54

After the update (fix):
https://www.loom.com/share/76f4bf19d9554486bde1a39e74e97ea4
