### PR TITLE
`gw-preserve-datepicker-date-selection-when-changing-months.js`: Fixed an issue with edge cases like 29 February, 31 April etc.

### DIFF
--- a/gravity-forms/gw-preserve-datepicker-date-selection-when-changing-months.js
+++ b/gravity-forms/gw-preserve-datepicker-date-selection-when-changing-months.js
@@ -18,21 +18,9 @@ gform.addFilter( 'gform_datepicker_options_pre_init', function( optionsObj, form
 		var selectedDate = $(this).datepicker('getDate');
 		var day = selectedDate ? selectedDate.getDate() : 1;
 
-		// Helper function to check if the given year is a leap year
-		const isLeapYear = year => new Date(year, 1, 29).getMonth() === 1;
-
-		// Determine the maximum days for the selected month
-		let maxDay;
-		if (month === 2) {
-			// February
-			maxDay = isLeapYear(year) ? 29 : 28;
-		} else if ([4, 6, 9, 11].includes(month)) {
-			// April, June, September, November
-			maxDay = 30;
-		} else {
-			// All other months
-			maxDay = 31;
-		}
+		// Create a date with the first of the selected month and year
+		var newDate = new Date(year, month, 0); // Last day of the previous month (i.e., correct for leap years)
+		var maxDay = newDate.getDate();
 
 		// Adjust the day if it exceeds the maximum days in the selected month
 		day = Math.min(day, maxDay);

--- a/gravity-forms/gw-preserve-datepicker-date-selection-when-changing-months.js
+++ b/gravity-forms/gw-preserve-datepicker-date-selection-when-changing-months.js
@@ -18,9 +18,28 @@ gform.addFilter( 'gform_datepicker_options_pre_init', function( optionsObj, form
 		var selectedDate = $(this).datepicker('getDate');
 		var day = selectedDate ? selectedDate.getDate() : 1;
 
-		// Set the new date with the updated month and year
+		// Helper function to check if the given year is a leap year
+		const isLeapYear = year => new Date(year, 1, 29).getMonth() === 1;
+
+		// Determine the maximum days for the selected month
+		let maxDay;
+		if (month === 2) {
+			// February
+			maxDay = isLeapYear(year) ? 29 : 28;
+		} else if ([4, 6, 9, 11].includes(month)) {
+			// April, June, September, November
+			maxDay = 30;
+		} else {
+			// All other months
+			maxDay = 31;
+		}
+
+		// Adjust the day if it exceeds the maximum days in the selected month
+		day = Math.min(day, maxDay);
+
+		// Set the new date with the updated month, year, and adjusted day
 		$(this).datepicker('setDate', new Date(year, month - 1, day));
 	}
-  
-    return optionsObj;
+
+	return optionsObj;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2725332347/72239

## Summary

Issues with edge cases. For instance, if we had the selection as 31 October and then we chose the month of April. Since it cannot select 31st April, it is going to end up selection as 1st of May (outside our month selection of April). Likewise, 30 April and then selecting February would select 2nd March (for non-leap) and 1st March (for leap year). All these edge cases have been handled with a `maxDay`, so any date selection is capped to that max value.

**BEFORE:**
https://www.loom.com/share/cdf3a97e31684d3899311a24c6aeb6f6

**AFTER:**
https://www.loom.com/share/45ad6bb1f061409195bbc20910846c3e

