### PR TITLE
`gw-cache-buster.php`: Fixed fatal error from `get_default_theme` function.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -72,7 +72,7 @@ class GW_Cache_Buster {
 			unset( $form_styles['theme'] );
 		}
 		$form['styles'] = GFFormDisplay::get_form_styles( $form_styles );
-		$form['theme'] = ! empty( $form_theme ) ? $form_theme : GFForms::get_default_theme();
+		$form['theme']  = $form_theme;
 		return $form;
 	}
 


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2755652844/73591

## Summary

<!-- Briefly explain what's new in this pull request. -->
Fixed fatal error issue that is coming from the `get_default_theme` function.