### PR TITLE
`gw-cache-buster.php`: Fixed GP Multi-Page Navigation compatibility issue where custom starting page is not applied.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -9,7 +9,7 @@
  * Plugin URI:  https://gravitywiz.com/cache-busting-with-gravity-forms/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
- * Version:     0.6.1
+ * Version:     0.6.2
  * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
@@ -300,6 +300,14 @@ class GW_Cache_Buster {
 		add_filter( 'gform_form_theme_slug', function( $slug, $form ) {
 			return rgar( $_REQUEST, 'form_theme' ) ?: $slug;
 		}, 10, 2 );
+
+		add_filter( 'gpmpn_default_page_' . $form_id, function( $page ) {
+			if ( rgars( $_REQUEST, 'atts/page' ) && rgget( 'gpmpn_page' ) ) {
+				return rgget( 'gpmpn_page' );
+			}
+
+			return rgars( $_REQUEST, 'atts/page', $page );
+		} );
 
 		$atts = rgpost( 'atts' );
 


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2755652844/73591

## Summary

<!-- Briefly explain what's new in this pull request. -->
When cache buster is enabled on a form, the `GPMPN`, the [custom starting page](https://gravitywiz.com/documentation/gravity-forms-multi-page-navigation/#custom-starting-page) is not applied to the form. This fix here is to use the `gpmpn_default_page` filter hook to pass in the custom page param.