### PR TITLE
`gpecf-set-discount-amount-by-field-value.php`: Fixed an issue with comma values in discount calculations.

### DIFF
--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -106,8 +106,7 @@ class GPECF_Discount_Amounts_By_Field_Value {
 
 					self.setDiscountAmount = function( value ) {
 						// Clean the value to remove the thousand separator (could be , or . depending on currency settings).
-						var thousandSeparator = window.gf_global.gf_currency_config.thousand_separator;
-						value = value.replace(new RegExp(thousandSeparator, 'g'), '');
+						value = gformCleanNumber( value, '', '', window.gf_global.gf_currency_config.decimal_separator );
 
 						if ( value.indexOf( '|' ) !== -1 ) {
 							value = value.split( '|' )[0];

--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -105,6 +105,10 @@ class GPECF_Discount_Amounts_By_Field_Value {
 					};
 
 					self.setDiscountAmount = function( value ) {
+						// Clean the value to remove the thousand separator (could be , or . depending on currency settings).
+						var thousandSeparator = window.gf_global.gf_currency_config.thousand_separator;
+						value = value.replace(new RegExp(thousandSeparator, 'g'), '');
+
 						if ( value.indexOf( '|' ) !== -1 ) {
 							value = value.split( '|' )[0];
 						}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2768471028/74224

## Summary

When using the snippet along with a calculated Number field, if the number is greater than 1000, and so includes a comma, only the digits in front of the comma are being copied to the Discount field.

**BEFORE:**
<img width="200" alt="Screenshot 2024-11-22 at 12 25 39 AM" src="https://github.com/user-attachments/assets/c5f65d93-07c8-4e98-8e41-5362d7f1bffc">

**AFTER:**
<img width="160" alt="Screenshot 2024-11-22 at 12 25 58 AM" src="https://github.com/user-attachments/assets/172ff034-ec70-4926-9d62-f4772cf2f077">
