### PR TITLE
`gw-cache-buster.php`: Fixed missing comma after tabindex in the $att…

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -117,7 +117,7 @@ class GW_Cache_Buster {
 			'description'  => $form_args['display_description'],
 			'field_values' => $form_args['field_values'],
 			'ajax'         => $form_args['ajax'],
-			'tabindex'     => $form_args['tabindex']
+			'tabindex'     => $form_args['tabindex'],
 			'theme'        => rgar( $form, 'theme' ),
 			'styles'       => rgar( $form, 'styles' ),
 		);


### PR DESCRIPTION
## Context

Missing comma after 'tabindex' in the $atts array causing a fatal error on install

## Summary

Added comma after `'tabindex'     => $form_args['tabindex']` on line 120.
