### PR TITLE
`gspc-clear-stale-entries-on-load.php`: Added asnippet to clear stale entries on site load.

### DIFF
--- a/gs-product-configurator/gspc-clear-stale-entries-on-load.php
+++ b/gs-product-configurator/gspc-clear-stale-entries-on-load.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Gravity Shop // Product Configurator // Clear stale Entries on load
+ * https://gravitywiz.com/documentation/gravity-shop-product-configurator/
+ *
+ * Although stale entries are cleared via the `woocommerce_cleanup_sessions` cron schedule that runs twice daily,
+ * this snippet will clear the stale entries on site load.
+ */
+
+add_action( 'woocommerce_set_cart_cookies', function( $set ) {
+	if ( ! $set && class_exists( 'GS_Product_Configurator\Entry_Lifecycle' ) ) {
+		$entry_lifecycle = new GS_Product_Configurator\Entry_Lifecycle();
+		$entry_lifecycle->cleanup_stale_entries();
+	}
+} );


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2762295831/73881


## Summary
**GSPC**: Added a new snippet to clear stale entries on site load.
<!-- Briefly explain what's new in this pull request. -->
