### PR TITLE
`gppa-force-dyn-pop-on-gv-edit.php`: Fixed an issue with the snippet dynamic population.

### DIFF
--- a/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
+++ b/gp-populate-anything/gppa-force-dyn-pop-on-gv-edit.php
@@ -13,7 +13,7 @@ add_filter( 'gravityview/edit_entry/field_value', function( $field_value, $field
 	// End customizing
 
 	if ( $field->formId == $form_id && in_array( $field->id, $field_ids_to_populate ) ) {
-		$populated_field = gp_populate_anything()->populate_field( $field, $_this->form, gp_populate_anything()->get_posted_field_values( $_this->form ), $_this->entry );
+		$populated_field = gp_populate_anything()->populate_field( $field, $_this->form, gp_populate_anything()->get_posted_field_values( $_this->form ) );
 
 		if ( $field->storageType === 'json' ) {
 			$field_value = json_encode( $populated_field['field_value'] );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2771470716/74423
and others

## Summary

_Note from Samuel- "The [Force Dynamic Population When Editing via GravityView](https://gravitywiz.com/snippet-library/gppa-force-dyn-pop-on-gv-edit/) snippet is not working, but it appears you have a working version in your gist here: https://gist.github.com/saifsultanc/766625ff2122a82e48394d08074492ce"_

This minor edit was done quite a few months back, but wasn't merged here on Snippet Library. I think the issue was with the `$_this->entry` not having the updated field values. So instead of passing it, leave the parameter empty (null pass). The logic inside GPPA's `populate_field` will itself fetch the updated values. That's about it.
