### PR TITLE
`gpuid-fill-sequence-gaps.php`: Fixed an issue with the snippet not working.

### DIFF
--- a/gp-unique-id/gpuid-fill-sequence-gaps.php
+++ b/gp-unique-id/gpuid-fill-sequence-gaps.php
@@ -13,15 +13,15 @@ add_filter( 'gpui_sequential_unique_id_pre_insert_519_5', function ( $uid, $form
 	global $wpdb;
 
 	$result = $wpdb->get_results( $wpdb->prepare( "
-		select value 
-		from {$wpdb->prefix}rg_lead_detail 
-		where form_id = %d and field_number = %d", $form_id, $field_id ) );
+		select meta_value 
+		from {$wpdb->prefix}gf_entry_meta 
+		where form_id = %d and meta_key = %d", $form_id, $field_id ) );
 
 	if ( empty( $result ) ) {
 		return $uid;
 	}
 
-	$_uids   = wp_list_pluck( $result, 'value' );
+	$_uids   = wp_list_pluck( $result, 'meta_value' );
 	$form    = GFAPI::get_form( $form_id );
 	$field   = GFFormsModel::get_field( $form, $field_id );
 	$numbers = array();

--- a/gp-unique-id/gpuid-fill-sequence-gaps.php
+++ b/gp-unique-id/gpuid-fill-sequence-gaps.php
@@ -12,9 +12,11 @@
 add_filter( 'gpui_sequential_unique_id_pre_insert_519_5', function ( $uid, $form_id, $field_id ) {
 	global $wpdb;
 
+	$table_name = GFFormsModel::get_entry_meta_table_name();
+
 	$result = $wpdb->get_results( $wpdb->prepare( "
 		select meta_value 
-		from {$wpdb->prefix}gf_entry_meta 
+		from {$table_name}
 		where form_id = %d and meta_key = %d", $form_id, $field_id ) );
 
 	if ( empty( $result ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2790631747/75478

## Summary

The snippet does not seem to work, it hasn't been update in over 2 years. The DB we are accessing is `wp_rg_lead_detail`, but it seems GF 2.3+ it's expected that the `wp_gf_entry_meta` should be used instead. GF codebase for context: https://github.com/gravityforms/gravityforms/blob/master/export.php#L892-L910

So we just apply the DB update, and that fixes the issue.

Here is how it works after the update:
https://www.loom.com/share/1819b282338d4832a68ce985787b16bb