### PR TITLE
`gppa-click-image-choice-image-wrapper.js`: Added snippet to trigger dynamic populate on Image Choice's Wrapper getting clicked.

### DIFF
--- a/experimental/gppa-click-image-choice-image-wrapper.js
+++ b/experimental/gppa-click-image-choice-image-wrapper.js
@@ -1,0 +1,23 @@
+/**
+ * Gravity Wiz // GP Populate Anything // Trigger GPPA update on Image Choice Wrapper Click.
+ * http://gravitywiz.com/documentation/gravity-forms-populate-anything
+ *
+ * Instructions:
+ *     1. Install our free Custom Javascript for Gravity Forms plugin.
+ *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
+ *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ */
+// If Image Choice's Image Wrapper is clicked, make sure to trigger the `change.gppa` event.
+window.gform.addAction(
+	'gform_input_change',
+	(elem , formId, fieldId) => {
+		if (
+			!$(elem)
+				.parent()
+				.hasClass('gfield-image-choice-wrapper-inner')
+		) {
+			return;
+		}
+		$(elem).trigger('change.gppa');
+	}
+);


### PR DESCRIPTION
## Context

https://github.com/gravitywiz/gp-populate-anything/pull/578/files#r1890791270

💬 GF Issue reported: https://github.com/gravityforms/gravityforms/issues/3050

## Summary

Reference: https://github.com/gravitywiz/gp-populate-anything/pull/578/files#r1890791270

Clicking the Image Wrapper does not trigger click on the image choices, this addresses that till Gravity Forms releases a patch for it natively.
