### PR TITLE
`gpnf-delay-child-notifications-for-parent-payment.php`: Added send notification if no payment status for parent entry.

### DIFF
--- a/gp-nested-forms/gpnf-delay-child-notifications-for-parent-payment.php
+++ b/gp-nested-forms/gpnf-delay-child-notifications-for-parent-payment.php
@@ -9,7 +9,7 @@
  * Plugin URI:   http://gravitywiz.com/documentation/gravity-forms-nested-forms/
  * Description:  Delay GP Nested Forms child form notification until payment processing is completed.
  * Author:       Gravity Wiz
- * Version:      1.1
+ * Version:      1.1.1
  * Author URI:   http://gravitywiz.com
  */
 class GW_GPNF_Delay_Child_Notifications {
@@ -43,12 +43,13 @@ class GW_GPNF_Delay_Child_Notifications {
 
 	public function gpnf_should_send_notification( $should_send_notification, $notification, $context, $parent_form, $nested_form_field, $entry, $child_form ) {
 		if ( $context === 'parent' && $this->is_applicable_form( $parent_form['id'] ) ) {
-			$parent_entry             = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
-			$should_send_notification = in_array( rgar( $parent_entry, 'payment_status' ), array( 'Paid', 'Active' ), true );
+			$parent_entry   = GFAPI::get_entry( rgar( $entry, 'gpnf_entry_parent' ) );
+			$payment_status = rgar( $parent_entry, 'payment_status', '' );
+
+			$should_send_notification = in_array( $payment_status, array( '', 'Paid', 'Active' ), true );
 		}
 
 		return $should_send_notification;
-
 	}
 
 	public function gform_post_payment_completed( $entry ) {


### PR DESCRIPTION
## Context

This PR allows to send notification instantly even if parent entry doesn't have payment status.

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2794049850/75576

## Summary

Delay notification only checks for the payment status of parent entry `Paid` & `Active`. But, it doesn't send notification if there is no payment status for the parent entry.

So, this fix checks whether the payment status is available or not. If not, it allows to send notification. 
