### PR TITLE
`gppa-remove-empty-choices.js`: Fixed an issue with empty choices not getting removed.

### DIFF
--- a/gp-populate-anything/gppa-remove-empty-choices.js
+++ b/gp-populate-anything/gppa-remove-empty-choices.js
@@ -13,7 +13,7 @@ $containers.each( function() {
 } );
 
 // Show/hide checkboxes when the field is manipulated.
-$containers.bind( 'DOMNodeInserted DOMNodeRemoved', function() {
+$containers.bind( 'DOMNodeInserted DOMNodeRemoved change.gppa', function() {
 	gwizRemoveEmptyChoices( $( this ) );
 } );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2804238036/75977

## Summary

The snippet to remove choices, which is used in [this tutorial](https://gravitywiz.com/preferred-contact-method-gravity-forms/), isn't working as expected.

**BEFORE:**
https://www.loom.com/share/010f6586aa44455293a1cc6116f9a86c

**AFTER:**
https://www.loom.com/share/7826aadc3ccc4cddb2b36937a1f06319
