### PR TITLE
`gw-validate-that-a-value-exists.php`: Fixed an issue with script not working with value validation snippet.

### DIFF
--- a/gravity-forms/gw-validate-that-a-value-exists.php
+++ b/gravity-forms/gw-validate-that-a-value-exists.php
@@ -176,7 +176,8 @@ class GW_Value_Exists_Validation {
 
 		// Do not output main script if AJAX is enabled
 		if ( ! $is_ajax_enabled && $this->is_applicable_form( $form ) && ! self::$is_script_output && ! $this->is_ajax_submission( $form['id'], $is_ajax_enabled ) ) {
-			$this->output_script();
+			add_action( 'wp_footer', array( $this, 'output_script' ) );
+			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
 		}
 
 		return $form;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2810746176/76183

## Summary

The snippet throws an error on the console
<img width="390" alt="Screenshot 2025-01-06 at 10 30 38 PM" src="https://github.com/user-attachments/assets/4de60196-62a7-4138-9635-6356e4dde16f" />

When declaring the script on `load_form_script`, we just need to ensure that its registered on the footer and not directly invoked (like [here](https://github.com/gravitywiz/snippet-library/blob/master/gw-snippet-template.php#L86))

This wasn't evident with GF 2.8 and prior. GF 2.9 updated exposed that issue.