### PR TITLE
`gpld-default-to-min-date.js`: Migrated from `experimental` folder.

### DIFF
--- a/gp-limit-dates/gpld-default-to-min-date.js
+++ b/gp-limit-dates/gpld-default-to-min-date.js
@@ -1,0 +1,20 @@
+/**
+ * Gravity Perks // GP Limit Dates // Default value to the minimum date allowed
+ * https://gravitywiz.com/documentation/gravity-forms-limit-dates/
+ *
+ * Experimental Snippet 🧪
+ *
+ * Instructions:
+ * 1. Install our free Custom Javascript for Gravity Forms plugin.
+ *    Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
+ * 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
+ * 3. Update `formId` variable accordingly
+ */
+var fieldId = 5;
+
+/* Not ideal to use the setTimeout, but it helps make sure the datepicker is ready to go. */
+setTimeout( function () {
+	jQuery( '#input_GFFORMID_' + fieldId )
+		.val( GPLimitDates.getDateValue( '', 'minDate', fieldId, GFFORMID, GPLimitDatesDataGFFORMID ) )
+		.change();
+} );


### PR DESCRIPTION
## Context

https://www.notion.so/gravitywiz/Gravity-Perks-GP-Limit-Dates-Default-value-to-the-minimum-date-allowed-15200ab68edf8022a322e2fc18cb2edb?pvs=4

## Summary

Migrated from experimental.
