### PR TITLE
`gpml-gfur-delete-previous-image.php`: Migrated.

### DIFF
--- a/experimental/gpml-gfur-delete-previous-image.php
+++ b/experimental/gpml-gfur-delete-previous-image.php
@@ -1,20 +1,6 @@
 <?php
 /**
- * Gravity Perks // Media Library + Gravity Forms User Registration // Delete Previous Image
- * https://gravitywiz.com/documentation/gravity-forms-media-library/
+ * We're no longer using the experimental folder for experimental snippets. 🚧
+ * You can now find the snippet here:
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-media-library/gpml-gfur-delete-previous-image.php
  */
-add_filter( 'update_user_metadata', function( $return, $object_id, $meta_key, $meta_value, $prev_value ) {
-
-	// Update "your_meta_key" to the user meta key you are mapping your GPML-enabled field to.
-	if ( $meta_key !== 'your_meta_key' ) {
-		return $return;
-	}
-
-	$prev_value = get_user_meta( $object_id, $meta_key, true );
-	$file_id    = attachment_url_to_postid( $prev_value );
-	if ( $file_id ) {
-		wp_delete_attachment( $file_id );
-	}
-
-	return $return;
-}, 10, 5 );


### PR DESCRIPTION
## Context

https://www.notion.so/gravitywiz/Gravity-Perks-Media-Library-Gravity-Forms-User-Registration-Delete-Previous-Image-15200ab68edf8014ab37ff8d1a6ba6f4?pvs=4

## Summary

Migrated.
