### PR TITLE
`gppa-gpeb-force-rehydration-on-edit.php`: Fixed issue with rehydration not working when editing entries with GP Entry Blocks.

### DIFF
--- a/gp-populate-anything/gppa-gpeb-force-rehydration-on-edit.php
+++ b/gp-populate-anything/gppa-gpeb-force-rehydration-on-edit.php
@@ -23,7 +23,7 @@ add_filter( 'gpeb_edit_form_entry', function( $entry ) {
 	$form = GFAPI::get_form( $form_id );
 	foreach ( $form['fields'] as &$field ) {
 		if ( in_array( $field->id, $field_ids ) ) {
-			$hydrated_field      = gp_populate_anything()->populate_field( $field, $form, array(), gp_populate_anything()->get_posted_field_values( $form ) );
+			$hydrated_field      = gp_populate_anything()->populate_field( $field, $form, gp_populate_anything()->get_posted_field_values( $form ), array() );
 			$entry[ $field->id ] = $hydrated_field['field_value'];
 		}
 	}

--- a/gp-populate-anything/gppa-gpeb-force-rehydration-on-edit.php
+++ b/gp-populate-anything/gppa-gpeb-force-rehydration-on-edit.php
@@ -16,14 +16,14 @@ add_filter( 'gpeb_edit_form_entry', function( $entry ) {
 	// Update (or remove) "4", "5", and "6" to the field IDs that should be rehydrated.
 	$field_ids = array( 4, 5, 6 );
 
-	if ( ! is_callable( array( 'GP_Populate_Anything', 'populate_field' ) ) || ! isset( $GLOBALS['gppa-field-values'] ) || $entry['form_id'] != $form_id ) {
+	if ( ! is_callable( array( gp_populate_anything(), 'populate_field' ) ) || ! isset( $GLOBALS['gppa-field-values'] ) || $entry['form_id'] != $form_id ) {
 		return $entry;
 	}
 
 	$form = GFAPI::get_form( $form_id );
 	foreach ( $form['fields'] as &$field ) {
 		if ( in_array( $field->id, $field_ids ) ) {
-			$hydrated_field      = gp_populate_anything()->populate_field( $field, $form, array(), $entry );
+			$hydrated_field      = gp_populate_anything()->populate_field( $field, $form, array(), gp_populate_anything()->get_posted_field_values( $form ) );
 			$entry[ $field->id ] = $hydrated_field['field_value'];
 		}
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2810857077/76190

## Summary

https://gravitywiz.com/snippet-library/gppa-gpeb-force-rehydration-on-edit/
The snippet above to rehydrate populate fields when editing an entry via GPEB is no longer working.

Here's a video demo of the issue (Samuel): https://www.loom.com/share/21999b9a22ac4255aa76555a82bb5aac?sid=d9d2c107-da16-43dd-98ad-342f5804091d

Fix similar to https://github.com/gravitywiz/snippet-library/pull/935
