### PR TITLE
`gpnf-child-products-in-parent-order-summary.php`: Added support for merging child products in parent order summary.

### DIFF
--- a/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
+++ b/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
@@ -7,11 +7,13 @@
  *
  * 1. Add a Calculated Product to your parent form.
  * 2. Add your Nested Form field with the :total modifier.
- * 3. Copy and paste this snippet into your theme's functions.php file.
+ * 3. Optional: If you want to merge duplicates, assign 'true' to the $merge_duplicates variable.
+ * 4. Copy and paste this snippet into your theme's functions.php file.
  *
  * Now the Calculated Product field on your parent form will be replaced with the products from each child entry.
  */
-add_filter( 'gform_product_info', function( $product_info, $form, $entry ) {
+$merge_duplicates = false;
+add_filter( 'gform_product_info', function( $product_info, $form, $entry ) use ( $merge_duplicates ) {
 
 	foreach ( $form['fields'] as $field ) {
 
@@ -52,7 +54,29 @@ add_filter( 'gform_product_info', function( $product_info, $form, $entry ) {
 
 					$_child_products[ "{$nested_form_field_id}.{$child_entry['id']}_{$child_field_id}" ] = $child_product;
 				}
-				$child_products = $child_products + $_child_products;
+
+				if ( $merge_duplicates ) {
+					// Loop through $_child_products and compare with $child_products.
+					foreach ( $_child_products as $key => $_child_product ) {
+						$match_found = false;
+
+						foreach ( $child_products as &$child_product ) {
+							// Check if the name and price match
+							if ( $child_product['name'] == $_child_product['name'] && $child_product['price'] == $_child_product['price'] ) {
+								$child_product['quantity'] += $_child_product['quantity'];
+
+								$match_found = true;
+								unset($_child_products[$key]);
+								break;
+							}
+						}
+					}
+				}
+
+				// If there are remaining products in $_child_products (after merging) or if we are not merging, add them to $child_products.
+				if ( ! empty( $_child_products ) || ! $merge_duplicates ) {
+					$child_products = array_merge( $child_products, $_child_products );
+				}
 			}
 		}
 

--- a/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
+++ b/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
@@ -66,7 +66,7 @@ add_filter( 'gform_product_info', function( $product_info, $form, $entry ) use (
 								$child_product['quantity'] += $_child_product['quantity'];
 
 								$match_found = true;
-								unset($_child_products[$key]);
+								unset( $_child_products[ $key ] );
 								break;
 							}
 						}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2807549547/76063

## Summary

Include Child Products Directly in Parent Form Order Summary after combining identical products into single lines on the order summary.

Matt A's loom:
https://www.loom.com/share/14394db590894d0b937e4d546067f4a6

After update, similar products of two nested will be merged like this on the order summary-

<img width="856" alt="Screenshot 2025-01-09 at 6 42 12 PM" src="https://github.com/user-attachments/assets/ef429817-e672-49ef-8077-8b9df968787f" />
