### PR TITLE
`gpecf-set-discount-amount-by-field-value.php`: Fixed JavaScript error in snippet and updated to use new `gform.Currency.cleanNumber` method if available.

### DIFF
--- a/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
+++ b/gp-ecommerce-fields/gpecf-set-discount-amount-by-field-value.php
@@ -106,7 +106,13 @@ class GPECF_Discount_Amounts_By_Field_Value {
 
 					self.setDiscountAmount = function( value ) {
 						// Clean the value to remove the thousand separator (could be , or . depending on currency settings).
-						value = gformCleanNumber( value, '', '', window.gf_global.gf_currency_config.decimal_separator );
+						if ( gform.Currency && typeof gform.Currency.cleanNumber === 'function' ) {
+							// Gravity Forms 2.9 deprecates gformCleanNumber in favor of gform.Currency.cleanNumber.
+							value = gform.Currency.cleanNumber( value, '', '', window.gf_global.gf_currency_config.decimal_separator ).toString();
+						} else {
+							// For Gravity Forms prior to 2.9.
+							value = gformCleanNumber( value, '', '', window.gf_global.gf_currency_config.decimal_separator ).toString();
+						}
 
 						if ( value.indexOf( '|' ) !== -1 ) {
 							value = value.split( '|' )[0];


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2815392542/76495

## Summary

The snippet no longer works as expected, and it's generating an error message in the browser console.

Samuel's Loom: https://www.loom.com/share/f20a87f7858a4de4bbf4186c2c7047ad?sid=e469a05c-164f-4048-980f-67289ff45b94

Post update:
<img width="281" alt="Screenshot 2025-01-10 at 9 26 30 PM" src="https://github.com/user-attachments/assets/a2dc27ae-bd1a-40f1-ad49-16407000b2ff" />

Also making a note `gform.Currency.cleanNumber` since `gformCleanNumber` has been deprecated with GF 2.9.
<img width="671" alt="Screenshot 2025-01-10 at 9 26 50 PM" src="https://github.com/user-attachments/assets/a42e322f-9eaa-4195-b91d-026775dd98ed" />
