### PR TITLE
`gpcp-product-pricing-labels.js`: Fixed an issue with decimal comma prices.

### DIFF
--- a/gp-conditional-pricing/gpcp-product-pricing-labels.js
+++ b/gp-conditional-pricing/gpcp-product-pricing-labels.js
@@ -8,7 +8,7 @@
 	function update_price_labels() {
 		$( 'label[data-gpcp-template], option[data-gpcp-template]' ).each( function() {
 			var $priceElem = $( this ).is( 'option' ) ? $( this ) : $( this ).siblings( 'input' );
-			var price = gformFormatMoney( $priceElem.val().split( '|' )[1] );
+			var price = gformFormatMoney( $priceElem.val().split( '|' )[1], true );
 			var template = $( this ).attr( 'data-gpcp-template' );
 			$( this ).html( template.replace( '{price}', price ) );
 		} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2816007580/76520

## Summary

Snippet is incorrectly handling values containing non-zero values after the comma for prices in Euros.

**Steps to reproduce:**
1. Steps to Reproduce
2. Set default currency in Gravity Forms to Euros.
3. Create a basic form (I included my export).
4. Add a product field. Set field type to drop down.
5. Add demo choices with varying prices. Make sure to include some that have nonzero numbers after the comma (e.g. 7,50)
6. Add this JS [snippet](https://gravitywiz.com/snippet-library/gpcp-product-pricing-labels-2/). Needs this [PHP counterpart](https://gravitywiz.com/snippet-library/gpcp-product-pricing-labels/)
7. Preview form

**FORM SETUP:**
<img width="455" alt="Screenshot 2025-01-13 at 4 54 16 PM" src="https://github.com/user-attachments/assets/acbf60df-c51f-4dd8-adf6-5a6b5c47b145" />

**BEFORE**:
<img width="293" alt="Screenshot 2025-01-13 at 4 54 24 PM" src="https://github.com/user-attachments/assets/dfb46e34-3bda-4410-becc-7c2616fdf49e" />

**AFTER**:
<img width="280" alt="Screenshot 2025-01-13 at 4 54 35 PM" src="https://github.com/user-attachments/assets/abb8dc81-d22c-4954-9889-28049dba64e8" />


The snippet uses the Gravity Forms method `gformFormatMoney`, which is defined as : `function gformFormatMoney(text, isNumeric){`. The `gformFormatMoney` relies on `currency.toMoney(text, isNumeric)`. 

Current logic we have does not define `isNumeric` as `true` when calling `gformFormatMoney` which causes the formatting issue with decimal comma currency values.

