### PR TITLE
`gw-populate-date.php`: Fixed an issue with Radio Button used as Modifier with Populate Date Snippet.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -368,6 +368,11 @@ class GW_Populate_Date {
 						var $input = self.getInputs( inputId ),
 							value  = self.getCleanNumber( $input.val(), gformExtractFieldId( inputId ), self.formId );
 
+						// Cannot retrieve value from `gfield_radio` directly on `$input`.
+						if ( ! $input.val() && $input.hasClass( 'gfield_radio' ) ) {
+							value = $input.find('input[type="radio"]:checked').val();
+						}
+
 						value = gform.applyFilters( 'gwpd_get_field_value', value, $input, inputId );
 
 						if ( ! value || isNaN( value ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2819440177/76669

## Summary

The "Populate Date" snippet is not working with the Radio field as the input field, but it functions correctly with the Number and Dropdown fields. Need to add separate logic to get exact value from the selected choice in the targetted `gfield_radio`.