### PR TITLE
`gw-submission-limit.php`: Fixed fatal error: `Cannot redeclare GW_Submission_Limit::$_args`.

### DIFF
--- a/gravity-forms/gw-submission-limit.php
+++ b/gravity-forms/gw-submission-limit.php
@@ -6,14 +6,13 @@
  * the visitor's IP address, the user's ID, the user's role, a specific form URL, or the value of a specific field.
  * These "limiters" can be combined to create more complex limitations.
  *
- * @version 3.0
+ * @version 3.0.1
  * @author  David Smith <david@gravitywiz.com>
  * @license GPL-2.0+
  * @link    http://gravitywiz.com/better-limit-submission-per-time-period-by-user-or-ip/
  */
 class GW_Submission_Limit {
 
-	var $_args;
 	var $_notification_event;
 
 	private static $forms_with_individual_settings = array();


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2819966166/76685

## Summary

This snippet causes a following fatal error just by adding it to the website.

`Fatal error: Cannot redeclare GW_Submission_Limit::$_args`

This PR fixes this issue.

