### PR TITLE
`gw-cache-buster.php`: Fixed an issue with Cache Buster and Expired Forms.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -262,15 +262,18 @@ class GW_Cache_Buster {
 					// We probably don't need this since everything else should already be loaded by this point but since
 					// GF is using it as their standard for triggering the `gform_post_render` event, I figured we should follow suit.
 					gform.initializeOnLoaded( function() {
-						// Form has been rendered. Trigger post render to initialize scripts.
+						// Form has been rendered. Trigger post render to initialize scripts if form is not restricted (expired).
 						<?php
-							echo sprintf(
-								'gform.initializeOnLoaded(function() {%s});',
-								GFFormDisplay::post_render_script(
-									$form_id,
-									GFFormDisplay::get_current_page( $form_id )
-								)
-							);
+							$form_restriction_error = rgars( GFFormDisplay::$submission, $form_id . '/form_restriction_error' );
+							if ( ! $form_restriction_error ) {
+								echo sprintf(
+									'gform.initializeOnLoaded(function() {%s});',
+									GFFormDisplay::post_render_script(
+										$form_id,
+										GFFormDisplay::get_current_page( $form_id )
+									)
+								);
+							}
 						?>
 					} );
 				} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2827184964/77017

## Summary

When using Cache Buster with a form that has a schedule, if the form is expired, the following PHP warning is being thrown, and the form expiration message does not show:

`PHP Warning:  Undefined array key "page_number" in ...\plugins\gravityforms\form_display.php on line 727`

As Gravity Forms does it [here](https://github.com/gravityforms/gravityforms/blob/master/includes/api.php#L1800) to check for form expiration, we have added the logic on the required spot at Cache Buster. Since, an expired form won't have a page number set.

```php
$form_restriction_error = rgars( GFFormDisplay::$submission, $form_id . '/form_restriction_error' );
```

**Post Update:**
<img width="296" alt="Screenshot 2025-01-23 at 9 17 32 AM" src="https://github.com/user-attachments/assets/d1c65ddc-d8c8-4b4c-a184-255da8b7cefe" />
