### PR TITLE
`gpld-conditional-limits.php`: Fixed issue where GP Limit Dates' frontend assets were not being enqueued when using snippet.

### DIFF
--- a/gp-limit-dates/gpld-conditional-limits.php
+++ b/gp-limit-dates/gpld-conditional-limits.php
@@ -29,6 +29,11 @@ class GPLD_Conditional_Limits {
 		add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ), 10, 2 );
 		add_filter( 'gform_enqueue_scripts', array( $this, 'enqueue_form_scripts' ) );
 		add_action( 'gform_field_validation', array( $this, 'validate' ), 11, 4 );
+
+        // Enables date limits for the form field, allowing the `gp-limit-dates` script to be enqueued.
+		add_filter( "gpld_has_limit_dates_enabled_{$this->_args['form_id']}_{$this->_args['field_id']}", function ( $result, $field ) {
+			return true;
+		}, 10, 2 );
 	}
 
 	public function enqueue_form_scripts( $form ) {

--- a/gp-limit-dates/gpld-conditional-limits.php
+++ b/gp-limit-dates/gpld-conditional-limits.php
@@ -31,9 +31,7 @@ class GPLD_Conditional_Limits {
 		add_action( 'gform_field_validation', array( $this, 'validate' ), 11, 4 );
 
         // Enables date limits for the form field, allowing the `gp-limit-dates` script to be enqueued.
-		add_filter( "gpld_has_limit_dates_enabled_{$this->_args['form_id']}_{$this->_args['field_id']}", function ( $result, $field ) {
-			return true;
-		}, 10, 2 );
+		add_filter( "gpld_has_limit_dates_enabled_{$this->_args['form_id']}_{$this->_args['field_id']}", '__return_true', 10, 2 );
 	}
 
 	public function enqueue_form_scripts( $form ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2819363473/76665

## Summary

This snippet works only if the `Minimum Date` or `Maximum Date` field is set in the GP Limit Dates perk.

The issue arises when neither date is set, as the `gp-limit-dates` JavaScript is not enqueued, causing it to not function.

To resolve this, add the following filter to ensure the JavaScript is enqueued for the form and field.


