### PR TITLE
`gppa-acf-date-formatter.php`: Fixed date formatting issue caused by timezone offset resulting in a one-day discrepancy.

### DIFF
--- a/gp-populate-anything/gppa-acf-date-formatter.php
+++ b/gp-populate-anything/gppa-acf-date-formatter.php
@@ -13,14 +13,24 @@
  * Plugin URI:   http:///gravitywiz.com.com/documentation/gravity-forms-populate-anything/
  * Description:  This snippet will format the value from a ACF Date field that is retrieved from the database and convert it into a Gravity Forms format Date field.
  * Author:       Gravity Wiz
- * Version:      0.1
+ * Version:      0.2
  * Author URI:   http://gravitywiz.com
  */
 add_filter( 'gppa_process_template_value', function( $template_value, $field, $template_name, $populate, $object, $object_type, $objects ) {
-
 	if ( strpos( $field->cssClass, 'gppa-format-acf-date' ) === false ) {
 		return $template_value;
 	}
 
-	return wp_date( 'd/m/Y', strtotime( $template_value ) );
+	$timezone = new DateTimeZone( 'UTC' );
+
+	try {
+		// Attempt to parse the date value.
+		$date = new DateTime( $template_value );
+		$date->setTimezone( $timezone ); // Ensure it's parsed as UTC.
+
+		return wp_date( 'd/m/Y', $date->getTimestamp(), $timezone );
+	} catch ( Exception $e ) {
+		// Handle invalid date formats gracefully.
+		return $template_value;
+	}
 }, 10, 7 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2826054984/76967

Similar ticket: https://secure.helpscout.net/conversation/2601997622/66482

## Summary

While using ACF & [this snippet](https://gravitywiz.com/snippet-library/gppa-acf-date-formatter/) together resulting in a one-day discrepancy. 

This issue was related to timezone. 

Here's the customers screencast explains this issue.

https://video.tsttechnology.com/conversations/cf879d60-9004-5cec-99c4-0d8fde4dba88
