### PR TITLE
`gpmpn-dropdown-navigation.js`: Added page names in dropdown navigation.

### DIFF
--- a/gp-multi-page-navigation/gpmpn-dropdown-navigation.js
+++ b/gp-multi-page-navigation/gpmpn-dropdown-navigation.js
@@ -7,6 +7,7 @@
  * This snippet is designed to be used with the Gravity Forms Code Chest plugin.
  * https://gravitywiz.com/gravity-forms-code-chest/
  */
+const pageNameTemplate = 'Step {pageNumber}: {pageName}';
 function updateNavigationState(  ) {
 	// hide if visible
 	$( '#gf_page_steps_GFFORMID' ).attr( 'hidden', 'true' );
@@ -33,10 +34,15 @@ function updateNavigationState(  ) {
 	}
 
 	$( '#gf_page_steps_GFFORMID .gf_step' ).each( function(  ) {
-		var $div = $( this );
+		var $div       = $( this );
 		var stepNumber = $div.find('.gf_step_number').text();
-		var $a = $div.find('a');
-		var $option = $('<option></option>').text( 'Step ' + stepNumber );
+		var pageName   = $div.find('.gf_step_label').text().trim();
+		var optionText = pageNameTemplate
+            .replace('{pageNumber}', stepNumber)
+            .replace('{pageName}', pageName);
+
+		var $a      = $div.find('a');
+		var $option = $('<option></option>').text( optionText );
 
 		if ( $a.length > 0 ) {
 			// found a tag, add the link to the dropdown option


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2825118959/76919

## Summary

Provide variable at the top of the snippet that will be used as an option name template. Include a merge tag for the page number and page name.
`const pageNameTemplate = 'Step {pageNumber}: {pageName}';`

The steps in dropdown will follow this template. Like so -

<img width="159" alt="Screenshot 2025-01-24 at 10 58 29 PM" src="https://github.com/user-attachments/assets/80acec87-e503-4b50-b064-30ea3b2693bc" />

