### PR TITLE
`gw-advanced-merge-tags.php`: Added support for `:all_fields` modifier to show data for dynamically populated entries.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -507,25 +507,6 @@ class GW_Advanced_Merge_Tags {
 					}
 					break;
 				case 'all_fields':
-					// {all_fields} merge tag support needs to get the entry IDs from the raw value.
-					$entries = json_decode( $raw_value, true );
-
-					// loop through each entry ID and get the {all_fields} output.
-					$output  = '';
-					foreach ( $entries as $entry_id ) {
-						$entry = GFAPI::get_entry( $entry_id );
-						$form  = GFAPI::get_form( $entry['form_id'] );
-
-						// Get the {all_fields} output for each entry.
-						$all_fields_output = GFCommon::replace_variables( '{all_fields}', $form, $entry, false, false, false );
-
-						$output .= $all_fields_output;
-					}
-
-					// if no entries were found, return the original value.
-					$value = $output ? $output : $value;
-					break;
-				case 'all_fields':
 					// Only to be applied for GPPA scenarios, where we may using dynamically populated entry ID data.
 					if ( ! is_callable( 'gp_populate_anything' ) || ! gp_populate_anything()->is_field_dynamically_populated( $field ) ) {
 						break;

--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -529,7 +529,7 @@ class GW_Advanced_Merge_Tags {
 						// Get the {all_fields} output for each entry.
 						$all_fields_output = GFCommon::replace_variables( '{all_fields}', $form, $entry, false, false, false );
 
-						$output .= $all_fields_output;
+						$output .= $all_fields_output . '<br>';
 					}
 
 					// if no entries were found, return the original value.

--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -525,6 +525,35 @@ class GW_Advanced_Merge_Tags {
 					// if no entries were found, return the original value.
 					$value = $output ? $output : $value;
 					break;
+				case 'all_fields':
+					// Only to be applied for GPPA scenarios, where we may using dynamically populated entry ID data.
+					if ( ! is_callable( 'gp_populate_anything' ) || ! gp_populate_anything()->is_field_dynamically_populated( $field ) ) {
+						break;
+					}
+
+					// {all_fields} merge tag support needs to get the entry IDs from the raw value.
+					$entries = json_decode( $raw_value, true );
+					
+					// loop through each entry ID and get the {all_fields} output.
+					$output  = '';
+					foreach ( $entries as $entry_id ) {
+						$entry = GFAPI::get_entry( $entry_id );
+						$form  = GFAPI::get_form( $entry['form_id'] );
+
+						// Safety check: Ensure the entry belongs to the same form as the field.
+						if ( $field->{'gppa-choices-primary-property'} != $entry['form_id'] ) {
+							break;
+						}
+
+						// Get the {all_fields} output for each entry.
+						$all_fields_output = GFCommon::replace_variables( '{all_fields}', $form, $entry, false, false, false );
+
+						$output .= $all_fields_output;
+					}
+
+					// if no entries were found, return the original value.
+					$value = $output ? $output : $value;
+					break;
 			}
 		}
 

--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -506,6 +506,25 @@ class GW_Advanced_Merge_Tags {
 						return rgar( $value_array, $index );
 					}
 					break;
+				case 'all_fields':
+					// {all_fields} merge tag support needs to get the entry IDs from the raw value.
+					$entries = json_decode( $raw_value, true );
+
+					// loop through each entry ID and get the {all_fields} output.
+					$output  = '';
+					foreach ( $entries as $entry_id ) {
+						$entry = GFAPI::get_entry( $entry_id );
+						$form  = GFAPI::get_form( $entry['form_id'] );
+
+						// Get the {all_fields} output for each entry.
+						$all_fields_output = GFCommon::replace_variables( '{all_fields}', $form, $entry, false, false, false );
+
+						$output .= $all_fields_output;
+					}
+
+					// if no entries were found, return the original value.
+					$value = $output ? $output : $value;
+					break;
 			}
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2826241649/76973

## Summary

 Adding an `:all_fields` modifier that can be applied to Multi Select fields' merge tags (e.g. {Multi Select A:1:all_fields})

Demo of the update:

https://www.loom.com/share/8d065e7769fd445b92c6c5c341c73ebf