### PR TITLE
`gw-limit-columns-in-survey-field-to-single-selection.js`: Fixed issue with snippet not working with GF2.5 theme.

### DIFF
--- a/gravity-forms/gw-limit-columns-in-survey-field-to-single-selection.js
+++ b/gravity-forms/gw-limit-columns-in-survey-field-to-single-selection.js
@@ -33,6 +33,16 @@ $( document ).on( 'change', `#field_${GFFORMID}_${fieldId} input[type="radio"]`,
 		const $radiosInColumn = $table.find( `input[type="radio"][aria-labelledby*="${columnId}"]` );
 
 		// Deselect all other radio buttons in the same column.
-		$radiosInColumn.not( $selectedRadio ).prop( 'checked', false );
+		$radiosInColumn.not($selectedRadio).each(function () {
+			let $radio = $(this);
+			let $parentTd = $radio.closest('td');
+
+			$radio.prop('checked', false);
+
+			// if gsurvey-likert-selected class is added to the parent td, remove it (GF 2.5 Theme). 
+			if ( $parentTd.length && $parentTd.hasClass( 'gsurvey-likert-selected' ) ) {
+				$parentTd.removeClass( 'gsurvey-likert-selected' );
+			}
+		});
 	}
 });


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2816944674/76575

## Summary

The snippet wasn't working for the Gravity Forms 2.5 Theme. It was working, just the `gsurvey-likert-selected` CSS class was no there. I don't know my local backup was messed up and it wasn't showing GF 2.5 Theme correctly, as @mcglenn07 pointed out. Thanks to him!
