### PR TITLE
`gpnf-gv-duplicate-child-entries.php`: Fixed URL in the snippet header.

### DIFF
--- a/gp-nested-forms/gpnf-gv-duplicate-child-entries.php
+++ b/gp-nested-forms/gpnf-gv-duplicate-child-entries.php
@@ -2,7 +2,7 @@
 /**
  * This snippet has graduated from the experimental folder. 🎓
  * You can now find the snippet here:
- * https://github.com/gravitywiz/snippet-library/gp-nested-forms/gpnf-duplicate-child-entries-on-parent-duplication.php
+ * https://github.com/gravitywiz/snippet-library/blob/master/gp-nested-forms/gpnf-duplicate-child-entries-on-parent-duplication.php
  *
  * Experimental Snippet 🧪
  */


### PR DESCRIPTION
## Context

https://secure.helpscout.net/conversation/2835085683/77419?viewId=14964

## Summary

The snippet was migrated to a new location, but the URL provided was incorrect. The correct URL has been added.