### PR TITLE
`gpnf-gflow-auto-attach-child-entries.php`: Added snippet to Auto-attach Child Entries to Parent when Editing via Gravity Flow.

### DIFF
--- a/gp-nested-forms/gpnf-gflow-auto-attach-child-entries.php
+++ b/gp-nested-forms/gpnf-gflow-auto-attach-child-entries.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Auto-attach Child Entries to Parent when Editing via Gravity Flow.
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * By default, when adding a new child entry to a Nested Form field while editing a parent entry via Gravity Flow, the
+ * child entry is saved to the session and will not be attached to the parent entry unless you click "Submit" on the
+ * workflow.
+ *
+ * Use this snippet to automatically attach the child entry to the parent as soon as the child form is submitted.
+ */
+add_filter( 'gpnf_set_parent_entry_id', function( $parent_entry_id ) {
+	if ( ! $parent_entry_id && is_callable( 'gravity_flow' ) && gravity_flow()->is_workflow_detail_page() ) {
+		$parent_entry_id = rgget( 'lid' );
+	}
+	return $parent_entry_id;
+} );

--- a/gp-nested-forms/gpnf-gflow-auto-attach-child-entries.php
+++ b/gp-nested-forms/gpnf-gflow-auto-attach-child-entries.php
@@ -11,7 +11,7 @@
  */
 add_filter( 'gpnf_set_parent_entry_id', function( $parent_entry_id ) {
 	if ( ! $parent_entry_id && is_callable( 'gravity_flow' ) && gravity_flow()->is_workflow_detail_page() ) {
-		$parent_entry_id = rgget( 'lid' );
+		$parent_entry_id = rgget( 'lid' ) ? rgget( 'lid' ) : $parent_entry_id;
 	}
 	return $parent_entry_id;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2834613157/77386

## Summary

A new child form entry that is added within a GravityFlow update input workflow is not auto-attached to the parent form until the parent form is submitted.

Similar to GravityView: https://gravitywiz.com/snippet-library/gpnf-gv-auto-attach-child-entries/

Loom: https://www.loom.com/share/44434c1fc8b346e1bcbcac3240e629cd