### PR TITLE
`gw-cache-buster.php`: Fixed an issue with Cache Buster plugin causing fatal error.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -9,7 +9,7 @@
  * Plugin URI:  https://gravitywiz.com/cache-busting-with-gravity-forms/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
- * Version:     0.6.3
+ * Version:     0.6.4
  * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
@@ -68,7 +68,7 @@ class GW_Cache_Buster {
 			// Form styles specifically set to false disables inline form css styles.
 			$form_styles = false;
 		} else {
-			$form_styles = ! empty( $style_settings ) ? json_decode( $style_settings, true ) : array();
+			$form_styles = is_array( $style_settings ) ? $style_settings : ( ! empty( $style_settings ) ? json_decode( $style_settings, true ) : array() );
 		}
 
 		// Removing theme from styles for consistency. $form['theme'] should be used instead.


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2840306289/77678

## Summary

Cache Buster is causing fatal error when the following filter is used with GF Gutenberg Blocks.
`add_filter( 'gfcb_enable_cache_buster', '__return_true' );`

Following fatal error occurs:
`PHP Fatal error:  Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in ...`

Add an additional check to the logic to ensure `json_decode` is not processed on a value that is already correctly set in the `array` form. For further context, here is a debug snapshot of the values at this code line on a simple gravity forms block:
<img width="459" alt="Screenshot 2025-02-06 at 12 14 52 AM" src="https://github.com/user-attachments/assets/a4e917ac-c922-4834-834e-b1c14ec30cbe" />
