### PR TITLE
`gspc-update-post-status-on-wc-order-status-change.php`: Added snippet to update the post status of the post created by Gravity Forms Advanced Post Creation when the WooCommerce order status is changed.

### DIFF
--- a/gs-product-configurator/gspc-update-post-status-on-wc-order-status-change.php
+++ b/gs-product-configurator/gspc-update-post-status-on-wc-order-status-change.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Gravity Forms Advanced Post Creation // Product Configurator
+ *
+ * This snippet will update the post status of the post created by Gravity Forms Advanced Post Creation when the WooCommerce order status is changed.
+ *
+ * Possible statuses are: publish, future, draft, pending, private, trash, wc-active, wc-switched, wc-expired, wc-pending-cancel, wc-pending, wc-processing, wc-on-hold, wc-completed, wc-cancelled, wc-refunded, wc-failed
+ *
+ * https://gravitywiz.com/documentation/gs-product-configurator/
+ *
+ *  Instructions:
+ *    1. Install per https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *    2. Configure the snippet based on inline instructions.
+ */
+
+class GSPC_Update_Post_Status_On_WC_Order_Status_Change {
+	private $_args;
+
+	public function __construct( $args = array() ) {
+		$this->_args = wp_parse_args( $args, array(
+			'form_id'     => false,
+			'post_status' => 'draft',
+		) );
+
+		if ( ! empty( $this->_args['post_status'] ) ) {
+			// Change `woocommerce_order_status_cancelled` to the WooCommerce order status you want to trigger the post status update.
+			add_action( 'woocommerce_order_status_cancelled', array( $this, 'update_post_status' ) );
+		}
+
+	}
+
+	/**
+	 * Update the post status.
+	 *
+	 * @param  int  $subscription_id  The subscription ID.
+	 */
+	function update_post_status( $subscription_id ) {
+		$order = wc_get_order( $subscription_id );
+
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			return;
+		}
+
+		$order_items = $order->get_items();
+
+		foreach ( $order_items as $order_item ) {
+			$item = \GS_Product_Configurator\WC_Order_Item::from( $order_item );
+
+			$entry_ids = $item->get_entry_ids();
+
+			if ( empty( $entry_ids ) ) {
+				continue;
+			}
+
+			foreach ( $entry_ids as $entry_id ) {
+				if ( ! GFAPI::entry_exists( $entry_id ) ) {
+					continue;
+				}
+
+				if ( ! $this->is_applicable_form( $entry_id ) ) {
+					continue;
+				}
+
+				$posts_data = maybe_unserialize( gform_get_meta( $entry_id, 'gravityformsadvancedpostcreation_post_id' ) );
+
+				if ( ! $posts_data ) {
+					continue;
+				}
+
+				foreach ( $posts_data as $post_data ) {
+					$post_id = $post_data['post_id'] ?? null;
+					if ( $post_id ) {
+						wp_update_post( array(
+							'ID'          => $post_id,
+							'post_status' => $this->_args['post_status'],
+						) );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check if the form is applicable.
+	 *
+	 * @param  int  $entry_id  The entry ID.
+	 *
+	 * @return bool
+	 */
+	public function is_applicable_form( $entry_id ) {
+		if ( empty( $this->_args['form_id'] ) ) {
+			return true;
+		}
+
+		$entry   = GFAPI::get_entry( $entry_id );
+		$form_id = rgar( $entry, 'form_id' );
+
+		return (int) $form_id === (int) $this->_args['form_id'];
+	}
+}
+
+new GSPC_Update_Post_Status_On_WC_Order_Status_Change( array(
+	'form_id'     => 123, // Add `form_id` when you want to target a specific form.
+	'post_status' => 'wc-expired', // Add the post status you want to update the post to.
+) );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2836308120/77517

## Summary

The customer wants to use  GSPC, WooCommerce Subscriptions and the Gravity Forms Advanced Post Creation (APC) add-on to create posts that expire when the linked Woo subscription ends.

Workflow
- A user completes a form and adds the product to their cart.
- They complete checkout, creating a WooCommerce subscription.
- The APC add-on creates a post based on the form submission.
- When the subscription expires or is canceled, the post status should be updated accordingly.

Here's the loom that I created for the WooCommerce order status changed. It also works in a same way for the WooCommerce subscription.

https://www.loom.com/share/b608fa876460414a8961eeea7d86480e?sid=a3d1e9b7-62e0-40d3-89dc-729c335ef71a