### PR TITLE
`gw-advanced-merge-tags.php`: Added support for the `gravatar` modifier to retrieve Gravatar image.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -506,6 +506,12 @@ class GW_Advanced_Merge_Tags {
 						return rgar( $value_array, $index );
 					}
 					break;
+				case 'gravatar':
+					if ( $field->type !== 'email' ) {
+						break;
+					}
+
+					return $this->generate_gravatar($value, $modifiers);
 			}
 		}
 
@@ -543,6 +549,41 @@ class GW_Advanced_Merge_Tags {
 		return $parsed;
 	}
 
+	/**
+	 * Generate a Gravatar image URL or image tag.
+	 *
+	 * @param $email
+	 * @param $modifiers
+	 *
+	 * @return string
+	 */
+	public function generate_gravatar( $email, $modifiers ) {
+		$format  = rgar( $modifiers, 'format' );
+		$size    = rgar( $modifiers, 'size', 64 );
+		$default = rgar( $modifiers, 'default' );
+
+		$params = array();
+
+		if ( $default ) {
+			$params['d'] = htmlentities( $default );
+		}
+
+		if ( $size ) {
+			$params['s'] = htmlentities($size);
+		}
+
+		$base_url = 'https://www.gravatar.com/avatar';
+		$hash     = hash( 'sha256', strtolower( trim( $email ) ) );
+		$query    = http_build_query( $params );
+
+		$gravatar_url = sprintf( '%s/%s?%s', $base_url, $hash, $query );
+
+		if ( $format === 'url' ) {
+			return $gravatar_url;
+		}
+
+		return "<img src='{$gravatar_url}' alt='Gravatar Image'/>";
+	}
 }
 
 function gw_advanced_merge_tags( $args = array() ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2846718264/78000

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

This PR will add a modifier to Advanced Merge Tags that will fetch the Gravatar image for a given email address.

**Returns the default Gravatar Image**
`{Email A:1:gravatar}`

**Returns the Gravatar image at 200px**
`{Email A:1:gravatar,size[200]}`

**Returns the URL of the Gravatar image**
`{Email A:1:gravatar,format[url]}`

Loom

https://www.loom.com/share/fdc28f226d75429f8fe090a29b8ab41f?sid=fa6452ea-b9ce-471e-9815-904eded3d0b4
