### PR TITLE
`gw-add-attachments-by-field.php`: Added multiple fields option for the snippet.

### DIFF
--- a/gravity-forms/gw-add-attachments-by-field.php
+++ b/gravity-forms/gw-add-attachments-by-field.php
@@ -12,7 +12,7 @@
 add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 
 	$notification_name = 'Notification A';
-	$upload_field_id   = 1;
+	$upload_field_ids  = array( 1 );
 
 	return gw_add_attachments_by_field( $notification, $form, $entry, $notification_name, $upload_field_id );
 }, 10, 3 );
@@ -20,12 +20,12 @@ add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 add_filter( 'gform_notification', function( $notification, $form, $entry ) {
 
 	$notification_name = 'Notification B';
-	$upload_field_id   = 2;
+	$upload_field_ids  = array( 2, 3 );
 
-	return gw_add_attachments_by_field( $notification, $form, $entry, $notification_name, $upload_field_id );
+	return gw_add_attachments_by_field( $notification, $form, $entry, $notification_name, $upload_field_ids );
 }, 10, 3 );
 
-function gw_add_attachments_by_field( $notification, $form, $entry, $notification_name, $upload_field_id ) {
+function gw_add_attachments_by_field( $notification, $form, $entry, $notification_name, $upload_field_ids ) {
 
 	if ( $notification['name'] !== $notification_name ) {
 		return $notification;
@@ -34,22 +34,24 @@ function gw_add_attachments_by_field( $notification, $form, $entry, $notificatio
 	$notification['attachments'] = rgar( $notification, 'attachments', array() );
 	$upload_root                 = RGFormsModel::get_upload_root();
 
-	$field = GFAPI::get_field( $form, $upload_field_id );
-	$url   = rgar( $entry, $field->id );
+	foreach ( $upload_field_ids as $upload_field_id ) {
+		$field = GFAPI::get_field( $form, $upload_field_id );
+		$url   = rgar( $entry, $field->id );
 
-	if ( empty( $url ) ) {
-		return $notification;
-	}
+		if ( empty( $url ) ) {
+			continue;
+		}
 
-	if ( $field->multipleFiles ) {
-		$uploaded_files = json_decode( stripslashes( $url ), true );
-		foreach ( $uploaded_files as $uploaded_file ) {
-			$attachment                    = preg_replace( '|^(.*?)/gravity_forms/|', $upload_root, $uploaded_file );
+		if ( $field->multipleFiles ) {
+			$uploaded_files = json_decode( stripslashes( $url ), true );
+			foreach ( $uploaded_files as $uploaded_file ) {
+				$attachment                    = preg_replace( '|^(.*?)/gravity_forms/|', $upload_root, $uploaded_file );
+				$notification['attachments'][] = $attachment;
+			}
+		} else {
+			$attachment                    = preg_replace( '|^(.*?)/gravity_forms/|', $upload_root, $url );
 			$notification['attachments'][] = $attachment;
 		}
-	} else {
-		$attachment                    = preg_replace( '|^(.*?)/gravity_forms/|', $upload_root, $url );
-		$notification['attachments'][] = $attachment;
 	}
 
 	return $notification;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2850770125/78183

## Summary

Ability to specify multiple Upload field IDs. Currently, it only accepts one field ID.

**Sample form with 3 file upload fields:**
<img width="250" alt="Screenshot 2025-02-18 at 10 51 47 AM" src="https://github.com/user-attachments/assets/e8318e26-0898-4b73-97e8-17ba1da0e3c9" />

**Snippet set to upload 2 out of those 3 fields:**
<img width="250" alt="Screenshot 2025-02-18 at 10 52 06 AM" src="https://github.com/user-attachments/assets/e3d3b6d5-1d92-4fe6-bfdf-4592a9bf4778" />

**Notification sent with only the two target file uploads sent:**
<img width="250" alt="Screenshot 2025-02-18 at 10 52 39 AM" src="https://github.com/user-attachments/assets/3398777a-644f-4aeb-bd32-3cae204a2fd0" />
