### PR TITLE
`gppa-use-acf-choice-label.php`: Fixed PHP fatal error when ACF field set return value as return `Both (array)`.

### DIFF
--- a/gp-populate-anything/gppa-use-acf-choice-label.php
+++ b/gp-populate-anything/gppa-use-acf-choice-label.php
@@ -22,5 +22,10 @@ add_filter( 'gppa_process_template_value', function( $template_value, $field, $t
 
 	$label = get_field( str_replace( 'meta_', '', $field->{'gppa-values-templates'}['value'] ), $object->ID );
 
+	// When the ACF field's return value as Both (Value and Label), the `$label` is an array. So, we need to get the label from the array.
+	if ( rgars( $label, '0/label' ) ) {
+		$label[0] = $label[0]['label'];
+	}
+
 	return $label;
 }, 10, 7 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2846332119/77984

## Summary

User is attempting to grab the Label of an ACF field using this snippet: https://gravitywiz.com/snippet-library/gppa-use-acf-choice-label/.

This works as intended when the ACF field's return value is set to `label`, but their field is set to `Both (Array)`, so the following error is being thrown.

`Uncaught Error: str_contains(): Argument #1 ($haystack) must be of type string, array given
in /wp-includes/blocks.php on line 1817`

This PR fixes this fatal error.