### PR TITLE
`gw-update-posts.php`: Fixed issue where snippet returned ID instead of value when GPPA dynamically populates post field.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -279,6 +279,16 @@ class GW_Update_Posts {
 	 * @return mixed
 	 */
 	public function return_ids_instead_of_names( $value, $field, $template_name, $populate, $object, $object_type, $objects, $template ) {
+		// Check if this is for the specific form we want.
+		if ( $field->formId != $this->_args['form_id'] ) {
+			return $value;
+		}
+
+		// Don't want to return IDs for post objects used in the populates field dynamically using GPPA.
+		if ( rgar( $field, 'gppa-values-enabled' ) === true  && rgar( $field, 'gppa-values-object-type' ) === 'post' ) {
+			return $value;
+		}
+
 		if ( strpos( $template, 'taxonomy_' ) === 0 ) {
 			$taxonomy = preg_replace( '/^taxonomy_/', '', $template );
 			$terms    = wp_get_post_terms( $object->ID, $taxonomy, array( 'fields' => 'ids' ) );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2844608881/77895

## Summary

By default, when we use GPPA to get a term, like category of a post, it returns the Term name. However, when this snippet  which is used to update posts, is also active on the website, Populate Anything will return the Term ID when getting the category of a post instead of the name. The set up is what I showed in the video.

So the expected behaviour is that, even with the snippet active on the website, Populate Anything should still return the Term Name when populating Terms of a post.

Here's a video demo of the issue 

https://www.loom.com/share/afe25a1453834809aa249fc342d52205?sid=dc46a634-5708-4627-b91c-789a6109a4ce

