### PR TITLE
Update gpaa-single-line-as-input.php with instructions on using multiple address fields

### DIFF
--- a/gp-address-autocomplete/gpaa-single-line-as-input.php
+++ b/gp-address-autocomplete/gpaa-single-line-as-input.php
@@ -132,6 +132,8 @@ class GPAA_Single_Line_Input {
 
 }
 
+# Configuration
+
 // Duplicate then modify the next 7 lines to add another address field
 // Configuration for the first address field
 new GPAA_Single_Line_Input( array(

--- a/gp-address-autocomplete/gpaa-single-line-as-input.php
+++ b/gp-address-autocomplete/gpaa-single-line-as-input.php
@@ -7,6 +7,8 @@
  *
  * Use a Single Line Text field as autocomplete input and populate the Single Line Text field with the full address.
  *
+ * Supports multiple address fields by adding multiple configuration blocks at the end of the snippet.
+ *
  * Note: This snippet will require the user to make a selection from the auto-suggested addresses.
  *
  * Plugin Name:  GP Address Autocomplete - Use Single Line Text field as Autocomplete Input
@@ -130,10 +132,12 @@ class GPAA_Single_Line_Input {
 
 }
 
-// Configuration
+// Duplicate then modify the next 7 lines to add another address field
+// Configuration for the first address field
 new GPAA_Single_Line_Input( array(
 	'form_id'              => 123,     // The ID of your form.
 	'address_field_id'     => 4,       // The ID of the Address field.
 	'single_line_field_id' => 5,        // The ID of the Single Line Text field.
 	// 'use_full_address'     => true,    // Uncomment to use the full street address if you don't want an abbreviated street address.
 ) );
+


### PR DESCRIPTION
Added instructions on how to use the snippet for multiple address fields.

## Summary

The configuration block can be added multiple times to support adding multiple address fields in the same form or over different forms.  There was a question about it in the loom video.
