### PR TITLE
`gpi-inventory-shortcode.php`: Deprecated snippet as functionality is now in GPI 1.0.

### DIFF
--- a/gp-inventory/gpi-inventory-shortcode.php
+++ b/gp-inventory/gpi-inventory-shortcode.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * WARNING! THIS SNIPPET IS DEPRECATED. 🚧
+ *
  * Gravity Perks // Inventory // Inventory Shortcode
  * https://gravitywiz.com/documentation/gravity-forms-inventory/
  *


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/GPI-1-0-1871242613d84640b0b5b189c64e9230?pvs=4 

💬 GPI Changes: https://github.com/gravitywiz/gp-inventory/pull/118

## Summary

Deprecates this snippet as the shortcode functionality is now in GPI 1.0.

