### PR TITLE
`gpeb-remove-fields-on-edit.php`: Fixed incorrect title in the header.

### DIFF
--- a/gp-entry-blocks/gpeb-remove-fields-on-edit.php
+++ b/gp-entry-blocks/gpeb-remove-fields-on-edit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Perks // Entry Blocks // Set Fields as Readonly On Edit
+ * Gravity Perks // Entry Blocks // Remove Fields On Edit
  * https://gravitywiz.com/documentation/gravity-forms-entry-blocks/
  *
  * Remove fields from the Entry Blocks edit form by automatically setting the field's visibility to "administrative".


### PR DESCRIPTION
## Context

Just something I noticed.

## Summary

The snippet was incorrectly titled "Set Fields as Readonly On Edit", this PR renames it to "Remove Fields On Edit".
