### PR TITLE
`gw-min-and-max-character-limit.php`: Added support to run validation only when the field has a value.

### DIFF
--- a/gravity-forms/gw-min-and-max-character-limit.php
+++ b/gravity-forms/gw-min-and-max-character-limit.php
@@ -85,6 +85,11 @@ class GW_Minimum_Characters {
 			}
 		}
 
+		// If value is empty, don't do validation.
+		if ( empty( $value ) ) {
+			return $result;
+		}
+
 		$char_count      = mb_strlen( $value );
 		$is_min_reached  = $this->_args['min_chars'] !== false && $char_count >= $this->_args['min_chars'];
 		$is_max_exceeded = $this->_args['max_chars'] !== false && $char_count > $this->_args['max_chars'];


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2867998139/78938

## Summary

Min Max character limit validation make sense when the field has a value. If we want to make sure field has a value, that can be handled through field `Required` rules. 

So, this we can do min max character limit validation only for the filed that has a value.
