### PR TITLE
`gw-entry-count-shortcode-advanced.php`: Added support for merge tags in field filters.

### DIFF
--- a/gravity-forms/gw-entry-count-shortcode-advanced.php
+++ b/gravity-forms/gw-entry-count-shortcode-advanced.php
@@ -61,6 +61,11 @@ add_filter( 'gform_shortcode_entry_count', function( $output, $atts ) {
 
 		$filter_pairs = explode(',', $atts['field_filters']); // Split by comma
 		foreach ($filter_pairs as $pair) {
+			// Replace merge tags in filter pair.
+			if ( GFCommon::has_merge_tag( $pair ) ) {
+				$pair = GFCommon::replace_variables_prepopulate( $pair );
+			}
+
 			$parts = explode(':', $pair);
 
 			if (count($parts) === 3) {


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2857827771/78525

## Summary

This PR supports merge tags in the `field_filters` attribute. That means the following shortcode will work as expected.

`[gravityforms action="entry_count" id="21" field_filters="31:is:{user:user_login},29:is:"]`