### PR TITLE
`gwaft-template-collapsible.php`: Fixed an issue with page numbers and hidden fields.

### DIFF
--- a/gravity-forms/gwaft-template-collapsible.php
+++ b/gravity-forms/gwaft-template-collapsible.php
@@ -25,7 +25,14 @@ add_filter( 'gwaft_template_output', function( $content, $slug, $name, $data, $s
 	$pages = $data['form']['pagination']['pages'];
 	$page_groups = array();
 	foreach ( $data['items'] as $item ) {
-		$page_groups[ $item['field']['pageNumber'] ][] = $item;
+		$field = $item['field'];
+		// Skip hidden fields.
+		if ( $field->type == 'hidden' || $field->visibility == 'hidden' ) {
+			continue;
+		}
+		// Adjust pageNumber to be zero-based.
+		$page_index = $field->pageNumber - 1;
+		$page_groups[ $page_index ][] = $item;
 	}
 	ob_start();
 	?>

--- a/gravity-forms/gwaft-template-collapsible.php
+++ b/gravity-forms/gwaft-template-collapsible.php
@@ -27,7 +27,7 @@ add_filter( 'gwaft_template_output', function( $content, $slug, $name, $data, $s
 	foreach ( $data['items'] as $item ) {
 		$field = $item['field'];
 		// Skip hidden fields.
-		if ( $field->type == 'hidden' || $field->visibility == 'hidden' ) {
+		if ( $field->type === 'hidden' || $field->visibility === 'hidden' ) {
 			continue;
 		}
 		// Adjust pageNumber to be zero-based.


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2849211669/78114

## Summary

The collapsible templates snippet does not work because the values of `$page_groups` and `$pages` are an "index" behind. 

<img width="277" alt="Screenshot 2025-03-08 at 10 11 55 AM" src="https://github.com/user-attachments/assets/eabcd7f4-3b55-4a04-b4c3-45bea9305bb2" />

Adjustment for the index issue, and adding a field visibility check.


**BEFORE** Customer described issue (was also reproduced locally with a simple form):
https://app.screencast.com/wVMGdfNrt8gY2

**AFTER** the snippet update:
https://www.loom.com/share/457a4df1ae314b92a54e5f18b3e7ad71