### PR TITLE
`gw-choice-counter.php`: Fixed Choice Counter not triggering quantity updates.

### DIFF
--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -143,6 +143,7 @@ class GW_Choice_Count {
 
 							if( parseInt( countField.val() ) != parseInt( count ) ) {
 								countField.val( count ).change();
+								countField[0].dispatchEvent( new Event( 'change', { bubbles: true } ) );
 							}
 						}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2866195352/78865

## Summary

The snippet above is used to get the number of selected choices in a multi-choice field. It works, but it appears it doesn't properly trigger the change event, which also doesn't update the form total.

Fix to ensure the change event triggers properly. This would include native event listeners and Gravity Forms logic.

**BEFORE:**
https://www.loom.com/share/53434d41b639452f8162cb6f1c33fe4e

**AFTER:**
https://www.loom.com/share/3ff480ee39254a3f895d785945b79cef
