### PR TITLE
`gcoai-stream-to-paragraph-field.js`: Fixed duplicate code and an issue with snippet not working.

### DIFF
--- a/gc-openai/gcoai-stream-to-paragraph-field.js
+++ b/gc-openai/gcoai-stream-to-paragraph-field.js
@@ -27,15 +27,15 @@ $streamFieldInput.on( 'change', function() {
 	$input = $( `#input_GFFORMID_${responseFieldId}` );
 	var inputValue = this.value;
 
-	// Get HTML from response field if TinyMCE is available.
-	if (window.tinyMCE) {
-		var html = $streamFieldInput.closest( '.gfield' ).find('.gcoai-output').html();
+	// Check if the response field has TinyMCE enabled.
+	var tiny = window.tinyMCE && tinyMCE.get( $input.attr( 'id' ) );
 
+	// Get HTML for the response field if TinyMCE is available.
+	if (tiny) {
+		var html = $streamFieldInput.closest( '.gfield' ).find('.gcoai-output').html();
+		
 		// Set HTML content in TinyMCE.
-		var tiny = tinyMCE.get( $input.attr( 'id' ) );
-		if (tiny) {
-			tiny.setContent( html );
-		}
+		tiny.setContent( html );
 	} else {
 		// If TinyMCE is not available, use plain text.
 		$input.val( inputValue );
@@ -57,13 +57,4 @@ if ( $wpEditor.length ) {
 
 $( `#input_GFFORMID_${promptFieldId}` ).on( 'blur', function() {
 	$streamButton.trigger( 'click' );
-} );
-
-$wpEditor = $newButton.parents('.wp-editor-container');
-if ($wpEditor.length) {
-	$newButton.insertAfter($wpEditor);
-}
-
-$( `#input_GFFORMID_${promptFieldId}` ).on('blur', function() {
-	$streamButton.trigger('click');
 });


### PR DESCRIPTION
## Context

⛑️ Ticket(s): [https://secure.helpscout.net/conversation/2853989407/78340?viewId=8172236](https://secure.helpscout.net/conversation/2853989407/78340?viewId=8172236)

## Summary

If the Response field is set to a plain text Paragraph field and there are rich text enabled Paragraph fields elsewhere on the form, the `gcoai-stream-to-paragraph-field` snippet fails to copy OpenAI's output to the Response field. This happens because the code checks if TinyMCE is globally available, not whether the specific Response field has TinyMCE enabled.

This PR fixes this by modifying the TinyMCE detection to specifically check if the target Response field has TinyMCE enabled, rather than just checking if TinyMCE exists globally.

Additionally, this PR removes duplicate code at the end of the snippet.