### PR TITLE
`gpeb-process-feeds-on-edit.php`: Fixed an issue with the snippet causing fatal error.

### DIFF
--- a/gp-entry-blocks/gpeb-process-feeds-on-edit.php
+++ b/gp-entry-blocks/gpeb-process-feeds-on-edit.php
@@ -29,6 +29,12 @@ add_filter( 'gform_entry_post_save', function( $entry, $form ) {
 	add_filter( 'gform_is_feed_asynchronous', '__return_false', $filter_priority );
 
 	add_filter( 'gform_addon_pre_process_feeds', function( $feeds, $entry, $form ) use ( $excluded_feed_ids ) {
+		// If no feeds are present, return.
+		if ( ! is_array( $feeds ) ) {
+			return $feeds;
+		}
+
+		// Filter feeds excluding the ones in the excluded feed ids array.
 		$feeds = array_filter( $feeds, function( $feed ) use ( $excluded_feed_ids ) {
 			return ! in_array( $feed['id'], $excluded_feed_ids );
 		} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2878525752/79569

## Summary

The snippet is supposed to process feeds on a form when the entry is updated via GPEB, however, it's causing a critical error. Fixed the issue by adding a safety check.
