### PR TITLE
`gptos-terms-only-modifier.php`: Added snippet to only display terms with the TOS checkbox.

### DIFF
--- a/gp-terms-of-service/gptos-terms-only-modifier.php
+++ b/gp-terms-of-service/gptos-terms-only-modifier.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Gravity Perks // Terms of Service // Add a `:terms_only` modifier.
+ * https://gravitywiz.com/documentation/gravity-forms-terms-of-service/
+ *
+ * Add a `:terms_only` modifier to the {all_fields} merge tag to only display the terms.
+ * 
+ * Instruction Video: https://www.loom.com/share/d69c48bea2d1429ab019310d2bc6c1e6
+ */
+add_filter( 'gform_merge_tag_filter', function ( $value, $merge_tag, $options, $field ) {
+	if ( $field['type'] != 'tos' ) {
+		return $value;
+	}
+
+	$options = explode( ',', $options );
+	if ( ! in_array( 'terms_only', $options ) ) {
+		return $value;
+	}
+
+	if ( $merge_tag != 'all_fields' ) {
+		$value = '<ul><li>' . $value . '</li></ul>';
+	}
+
+	$value = wpautop( $field->get_terms( GFAPI::get_form( $field->formId ) ) );
+
+	return $value;
+}, 11, 4 );

--- a/gp-terms-of-service/gptos-terms-only-modifier.php
+++ b/gp-terms-of-service/gptos-terms-only-modifier.php
@@ -8,7 +8,7 @@
  * Instruction Video: https://www.loom.com/share/d69c48bea2d1429ab019310d2bc6c1e6
  */
 add_filter( 'gform_merge_tag_filter', function ( $value, $merge_tag, $options, $field ) {
-	if ( $field['type'] != 'tos' ) {
+	if ( $field['type'] !== 'tos' ) {
 		return $value;
 	}
 
@@ -17,7 +17,7 @@ add_filter( 'gform_merge_tag_filter', function ( $value, $merge_tag, $options, $
 		return $value;
 	}
 
-	if ( $merge_tag != 'all_fields' ) {
+	if ( $merge_tag !== 'all_fields' ) {
 		$value = '<ul><li>' . $value . '</li></ul>';
 	}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2876696517/79496

https://gravitywiz.slack.com/archives/GMP0ZMNSE/p1741974702635409

## Summary

Added a `:terms_only` merge tag modifier that would allow you to display the terms in notifications or confirmations without also having to display the value /text of the checkbox.

https://www.loom.com/share/d69c48bea2d1429ab019310d2bc6c1e6