### PR TITLE
`gwaft-template-collapsible.php`: Added Order Summary as an additional last page.

### DIFF
--- a/gravity-forms/gwaft-template-collapsible.php
+++ b/gravity-forms/gwaft-template-collapsible.php
@@ -29,6 +29,7 @@ add_filter( 'gwaft_template_output', function( $content, $slug, $name, $data, $s
 
 		// Add Order Summary as a separate last page.
 		if ( ! $field && rgar( $item, 'label' ) == apply_filters( 'gwaft_order_summary_label', 'Order Summary' ) ) {
+			// Storing order summary page as '-1' to be the last page, and avoid conflicts with the actual page numbers.
 			$page_groups[-1][] = $item;
 			$pages[-1]         = apply_filters( 'gwaft_order_summary_label', 'Order Summary' );
 			continue;

--- a/gravity-forms/gwaft-template-collapsible.php
+++ b/gravity-forms/gwaft-template-collapsible.php
@@ -25,9 +25,17 @@ add_filter( 'gwaft_template_output', function( $content, $slug, $name, $data, $s
 	$pages = $data['form']['pagination']['pages'];
 	$page_groups = array();
 	foreach ( $data['items'] as $item ) {
-		$field = $item['field'];
+		$field = rgar( $item, 'field' );
+
+		// Add Order Summary as a separate last page.
+		if ( ! $field && rgar( $item, 'label' ) == apply_filters( 'gwaft_order_summary_label', 'Order Summary' ) ) {
+			$page_groups[-1][] = $item;
+			$pages[-1]         = apply_filters( 'gwaft_order_summary_label', 'Order Summary' );
+			continue;
+		}
+
 		// Skip hidden fields.
-		if ( $field->type === 'hidden' || $field->visibility === 'hidden' ) {
+		if ( ! $field || $field->type === 'hidden' || $field->visibility === 'hidden' ) {
 			continue;
 		}
 		// Adjust pageNumber to be zero-based.


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2872221797/79232

## Summary

When using the [all fields collapsible sections](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gwaft-template-collapsible.php) snippet, if there is a pricing field on the form, the order summary is included in its own section. However, this also causes the page names to be showing incorrectly on the sections, and the section the order summary is included in does not have a title.

Matt A's loom explaining the issue:
https://www.loom.com/share/48c97b4b77054d36ab5c64973bd8ea84

Handle the "Order Summary" page has been proposed with this PR.

How this update works:
https://www.loom.com/share/728fc541438d4041a8e8e91ceee87e58
