### PR TITLE
`gw-populate-date.php`: Added support for dynamic populated modifier values trigerring Populate Date updates.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -4,7 +4,7 @@
  *
  * Provides the ability to populate a Date field with a modified date based on the current date or a user-submitted date.
  *
- * @version   2.8
+ * @version   2.9
  * @author    David Smith <david@gravitywiz.com>
  * @license   GPL-2.0+
  * @link      http://gravitywiz.com/populate-dates-gravity-form-fields/
@@ -288,6 +288,17 @@ class GW_Populate_Date {
 
 			( function( $ ) {
 
+				if ( ! String.prototype.format ) {
+					String.prototype.format = function() {
+						var args = arguments;
+						return this.replace( /{(\d+)}/g, function( match, number ) { 
+							return typeof args[ number ] !== 'undefined'
+								? args[ number ]
+								: match;
+						});
+					};
+				}
+
 				window.GWPopulateDate = function( args ) {
 
 					var self = this;
@@ -306,6 +317,19 @@ class GW_Populate_Date {
 							self.$sourceInputs.change( function() {
 								self.populateDate( self.sourceFieldId, self.targetFieldId, self.getModifier(), self.format );
 							} );
+
+							// Listen for any dynamic content loaded on modifier field (if existing) to refresh values on Target.
+							if ( self.modifier && self instanceof GWPopulateDate ) {
+								var modifier = self.modifier.inputId;
+
+								if ( modifier ) {
+									var modifierParent = '#field_' + self.formId + '_' + modifier;
+									var modifierTarget = '#input_' + self.formId + '_' + modifier;
+									$( modifierParent ).on( 'change', modifierTarget, function() {
+										self.populateDate( self.sourceFieldId, self.targetFieldId, self.getModifier(), self.format );
+									} );
+								}
+							}
 
 							// Listen for GPPA's new `gppa_updated_batch_fields`
 							$( document ).on( 'gppa_updated_batch_fields', function ( e, formId, updatedFieldIDs ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2875355741/79394

## Summary

Populate Date Snippet doesn't work when [modifying the date by field value](https://gravitywiz.com/populate-dates-gravity-form-fields/#modify-date-by-field-value) and the input field is populated.


If the source date is selected, a change in modifier value (via GPPA) does not trigger the target date field update. This PR proposes adding a check for the dynamic content loaded and triggering further updates.

**BEFORE:**
https://www.loom.com/share/05c946d24eaf4fd4a7132ff98e075ef8

**AFTER:**
https://www.loom.com/share/4dc0dc1ee8fd4cfb859aa79029a9c81e