### PR TITLE
`gpld-push-min-date-to-next-day-after-set-time.php`: Fixed an issue with timezones.

### DIFF
--- a/gp-limit-dates/gpld-push-min-date-to-next-day-after-set-time.php
+++ b/gp-limit-dates/gpld-push-min-date-to-next-day-after-set-time.php
@@ -13,7 +13,8 @@ add_filter( 'gpld_limit_dates_options_123_4', function( $options ) {
 	$current_time = new DateTime( wp_timezone_string() );
 	$cutoff_time  = ( new DateTime( wp_timezone_string() ) )->setTime( $cutoff_hour, 0 );
 	if ( $current_time > $cutoff_time ) {
-		$options['minDate'] = wp_date( 'm/d/Y', strtotime( 'midnight tomorrow', $current_time->getTimestamp() ) );
+		$tomorrow           = new DateTime( 'tomorrow midnight', $current_time->getTimezone() );
+		$options['minDate'] = wp_date( 'm/d/Y', $tomorrow->getTimestamp() );
 	}
 	return $options;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2875355741/79394

## Summary

The snippet above doesn't work, if the site timezone is set to something like Chicago.
Steps to recreate the issue
Here's the video demo of the issue: https://www.loom.com/share/4d5d42b268764351ac52ed29fe69d865?sid=0e71fa96-ff02-4be0-908b-52a85d4ae7b4


We had `strtotime( 'midnight tomorrow', $current_time->getTimestamp() )`  which caused issues because `strtotime()` interprets relative times in UTC, which seems to getting incorrect results in different timezones

This fix proposed here ensures that "tomorrow midnight" is correctly calculated in the same timezone as `$current_time` by using new a `DateTime` object specifying "tomorrow midnight".