### PR TITLE
`gppa-populate-child-entries.php`: Fixed an issue with missing cookie values.

### DIFF
--- a/gp-populate-anything/gppa-populate-child-entries.php
+++ b/gp-populate-anything/gppa-populate-child-entries.php
@@ -66,7 +66,20 @@ class GPPA_Populate_Child_Entries {
 		} else {
 			$session = new GPNF_Session( $field->formId );
 			$cookie  = $session->get_cookie();
-			$value   = rgar( $cookie, 'hash', '' );
+
+			// try to find cookie, if available.
+			if ( ! $cookie ) {
+				$cookie_name = 'gpnf_form_session_';
+				$pattern = '/^' . preg_quote( $cookie_name, '/' ) . '[\w\W]*/';
+				$matches = preg_grep($pattern, array_keys($_COOKIE));
+				if ( ! empty( $matches ) ) {
+					foreach ( $matches as $matched_cookie ) {
+						$cookie = json_decode(stripslashes( $_COOKIE[ $matched_cookie ] ), true);
+					}
+				}
+			}
+
+			$value = rgar( $cookie, 'hash', '' );
 		}
 
 		return $value;

--- a/gp-populate-anything/gppa-populate-child-entries.php
+++ b/gp-populate-anything/gppa-populate-child-entries.php
@@ -70,8 +70,8 @@ class GPPA_Populate_Child_Entries {
 			// try to find cookie, if available.
 			if ( ! $cookie ) {
 				$cookie_name = 'gpnf_form_session_';
-				$pattern = '/^' . preg_quote( $cookie_name, '/' ) . '[\w\W]*/';
-				$matches = preg_grep($pattern, array_keys($_COOKIE));
+				$pattern     = '/^' . preg_quote( $cookie_name, '/' ) . '[\w\W]*/';
+				$matches     = preg_grep( $pattern, array_keys( $_COOKIE ) );
 				if ( ! empty( $matches ) ) {
 					foreach ( $matches as $matched_cookie ) {
 						$cookie = json_decode(stripslashes( $_COOKIE[ $matched_cookie ] ), true);


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2882383665/79731

## Summary

The temporary parent entry ID doesn't populate the field on the form after the form is submitted and opened again. The cookie wasn't found strangely. Added logic to look out for the cookie in this context.
