### PR TITLE
`gw-field-to-field-conditional-logic.php`: Fixed an issue with numeric comparison in field to field conditional logic.

### DIFF
--- a/gravity-forms/gw-field-to-field-conditional-logic.php
+++ b/gravity-forms/gw-field-to-field-conditional-logic.php
@@ -265,6 +265,11 @@ class GF_Field_To_Field_Conditional_Logic {
 			$_rule_cache[ $entry_id ][ $rule['value'] ] = $value;
 		}
 
+		// Clean number values to ensure proper comparison.
+		if ( GFCommon::is_numeric( $value ) ) {
+			$value = GFCommon::clean_number( $value );
+ 		}
+
 		$rule['value'] = $value;
 
 		return $rule;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2885654688/79887

## Summary

When using the [Field to Field Conditional Logic snippet](https://github.com/gravitywiz/snippet-library/blob/master/gravity-forms/gw-field-to-field-conditional-logic.php), if a numeric field value has thousand separators, the conditional logic works on the frontend form, but fails on submission.

Matt A's loom:
 https://www.loom.com/share/c2f1e00a73044c2fb4121c9e822b550e

Loom describing the fix and quick walkthrough:
https://www.loom.com/share/dc56e01f090d4a2c81c50e7fe589f400