### PR TITLE
`gppa-use-choice-value-instead-of-label.php`: Added new snippet.

### DIFF
--- a/gp-populate-anything/gppa-use-choice-value-instead-of-label.php
+++ b/gp-populate-anything/gppa-use-choice-value-instead-of-label.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Use Choice Value Instead of Label in Admin
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/ 
+ *
+ * By default, Populate Anything will display choice labels in the Entry List and Entry Detail views.
+ * This snippet reverts to the default Gravity Forms behavior of showing values instead for Populate Anything enabled fields.
+ */
+add_action('admin_init', function() {
+	remove_filter( 'gform_entry_field_value', array( gp_populate_anything(), 'entry_field_value' ), 20 );
+	remove_filter( 'gform_entries_field_value', array( gp_populate_anything(), 'entries_field_value' ), 20 );
+});


### PR DESCRIPTION
## Context

📓 Notion: https://www.notion.so/gravitywiz/Doc-Update-GPPA-How-to-display-choice-values-instead-of-labels-when-viewing-an-entry-1af00ab68edf819d9673d7c674855483?pvs=4

## Summary

This snippet shows field values rather than labels on GPPA enabled fields when viewing an entry in the backend.
