### PR TITLE
`gpnf-set-created-by-property-on-child-entries-after-user-registration.php`: Fixed typo in the header.

### DIFF
--- a/gp-nested-forms/gpnf-set-created-by-property-on-child-entries-after-user-registration.php
+++ b/gp-nested-forms/gpnf-set-created-by-property-on-child-entries-after-user-registration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gravity Perks // Nested Forms // Set Created By Propery on Child Entries After User Account Registration.
+ * Gravity Perks // Nested Forms // Set Created By Property on Child Entries After User Account Registration.
  * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
  *
  * Set the created by property of the child entries that is embedded on a user registration form


### PR DESCRIPTION
## Context

Update request from support.

## Summary

Glenn reported typo: "Propery" ➡️ "Property"
