### PR TITLE
`gppa-lmt-remove-commas.php`: Added new snippet.

### DIFF
--- a/gp-populate-anything/gppa-lmt-remove-commas.php
+++ b/gp-populate-anything/gppa-lmt-remove-commas.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Gravity Perks // Populate Anything // Remove Commas From Live Merge Tag
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ *
+ * Remove commas from the value copied with a Live Merge Tag
+ * This is useful when copying values over 1,000 from a Number field to a Quantity field.
+ */
+// Update "123" to your form ID; and "4" to the field ID you are copying from.
+add_filter( 'gppa_live_merge_tag_value_123_4', function( $value ) {
+	return str_replace( ',', '', $value );
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2893446866/81553?viewId=14960

## Summary

This snippet removes commas from the copied value when using a Live Merge Tag. The specific use case it was written for is when copying values over 1,000 from a Number field to a Quantity field. The comma was preventing the value from being copied correctly.
