### PR TITLE
`gw-user-registration-prevent-populating-mapped-fields.php`: Added a snippet to prevent mapped fields from being populated with saved values from the User Registration feed.

### DIFF
--- a/gravity-forms/gw-user-registration-prevent-populating-mapped-fields.php
+++ b/gravity-forms/gw-user-registration-prevent-populating-mapped-fields.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Gravity Wiz // Gravity Forms User Registration // Prevent Population Of Mapped Fields With The Saved Values
+ * https://gravitywiz.com/
+ *
+ * Prevent population of mapped fields with the saved values. This snippet prevent the population of mapped fields with the saved values while displaying the form.
+ *
+ * Instructions:
+ *
+ *  1. Install the snippet.
+ *     https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ */
+add_action( 'gform_user_registration_user_data_pre_populate', function ( $mapped_fields, $form, $feed ) {
+	// Replace "1" with the form ID you want to prevent the population of mapped fields.
+	if ( $form['id'] !== 1 ) {
+		return $mapped_fields;
+	}
+
+	// Replace "3" with the field ID you want to display empty.
+	$mapped_fields[3] = '';
+
+	// Want to overwrite all mapped fields? Uncomment the line below.
+	// $mapped_fields = array();
+
+	return $mapped_fields;
+}, 10, 3 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2875771201/79417

## Summary

This snippet prevents mapped fields from being populated with saved values from the User Registration feed.