### PR TITLE
`gpnf-limit-entry-min-max-from-field.php`: Fixed an issue with the snippet not working correctly on form load.

### DIFF
--- a/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
+++ b/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
@@ -150,7 +150,7 @@ class GP_Nested_Forms_Dynamic_Entry_Min_Max {
 							var $maxField = $( '#' + maxFieldId );
 							var value = parseInt($maxField.val());
 
-							return value ? value : self.defaultMax;
+							return isNaN(value) ? Infinity : (value || self.defaultMax);
 						});
 
 						gform.addAction( 'gform_input_change', function( el, formId, fieldId ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2897379455/81715

## Summary

When using the [Dynamically Set Entry Min/Max From Field Value](https://gravitywiz.com/snippet-library/gpnf-limit-entry-min-max-from-field/) snippet, the Nested Form shows "maximum number reached" before any child entry is even added.

The key issue was default-ing to a zero max value.
