### PR TITLE
`gpnf-attach-child-entry-by-field.php`: Fixed an issue with snippet not working on nested modal failed validation.

### DIFF
--- a/gp-nested-forms/gpnf-attach-child-entry-by-field.php
+++ b/gp-nested-forms/gpnf-attach-child-entry-by-field.php
@@ -52,7 +52,7 @@ class GPNF_Attach_Child_Entry_By_Field {
 	}
 
 	public function hide_parent_entry_id_field( $form ) {
-		if ( ! $this->is_applicable_child_form( $form ) || rgar( $_REQUEST, 'action' ) !== 'gpnf_refresh_markup' ) {
+		if ( ! $this->is_applicable_child_form( $form ) || ( rgar( $_REQUEST, 'action' ) !== 'gpnf_refresh_markup' ) && ! rgpost( 'gform_submission_method' ) ) {
 			return $form;
 		}
 		foreach ( $form['fields'] as &$field ) {

--- a/gp-nested-forms/gpnf-attach-child-entry-by-field.php
+++ b/gp-nested-forms/gpnf-attach-child-entry-by-field.php
@@ -52,7 +52,11 @@ class GPNF_Attach_Child_Entry_By_Field {
 	}
 
 	public function hide_parent_entry_id_field( $form ) {
-		if ( ! $this->is_applicable_child_form( $form ) || ( rgar( $_REQUEST, 'action' ) !== 'gpnf_refresh_markup' ) && ! rgpost( 'gform_submission_method' ) ) {
+		if ( 
+			! $this->is_applicable_child_form( $form ) || 
+			( ! in_array( rgar( $_REQUEST, 'action' ), array( 'gpnf_refresh_markup', 'gpnf_edit_entry' ), true ) 
+			  && ! rgpost( 'gform_submission_method' ) ) 
+		) {		
 			return $form;
 		}
 		foreach ( $form['fields'] as &$field ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2896177464/81660

## Summary

When a required field in the nested form is not filled out and the validation is displayed, the hidden field (hidden by the snippet) is also displayed.

Loom: https://www.loom.com/share/750a1f3a31be4bce8c1100adb8087922

The logic for hiding the field with the filter `gform_pre_render` does not seem to work post validation fail on Nested Form Modal. This is because a condition in an edge case check `rgar( $_REQUEST, 'action' ) !== 'gpnf_refresh_markup' )` is true on Nested Form submission. We can add an additionally check for `gform_submission_method` on POST to ensure we correctly validate for hidden field scenario.
