### PR TITLE
`gpi-disable-object-cache.php`: Added new snippet to disable object cache in GP Inventory.

### DIFF
--- a/gp-inventory/gpi-disable-object-cache.php
+++ b/gp-inventory/gpi-disable-object-cache.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Gravity Perks // Inventory // Disable Object Cache
+ * https://gravitywiz.com/documentation/gravity-forms-inventory/
+ *
+ * GP Inventory caches objects to improve performance. This snippet disables object caching for a specific form.
+ *
+ * Instructions:
+ *
+ *  1. Install the snippet.
+ *     https://gravitywiz.com/documentation/managing-snippets/#where-do-i-put-snippets
+ */
+
+
+// This snippet disables object caching for a specific form.
+add_filter( 'gpi_should_cache_object', function ( $cache, $form_id ) {
+	if ( $form_id === 123 ) { // Update "123" to your form ID
+		return false;
+	}
+
+	return $cache;
+}, 10, 2 );
+
+// This snippet disables object caching for all forms.
+add_filter( 'gpi_should_cache_object', '__return_false' );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2894376170/81592

## Summary

This snippet helps to disable object cache in GP Inventory.
