### PR TITLE
`gpnf-limit-entry-min-max-from-field.php`: Fixed an issue with entry min max recalculation logic not working.

### DIFF
--- a/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
+++ b/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
@@ -154,9 +154,18 @@ class GP_Nested_Forms_Dynamic_Entry_Min_Max {
 						});
 
 						gform.addAction( 'gform_input_change', function( el, formId, fieldId ) {
+							// Force Knockout to recalculate the max when the number has changed
 							if ( el.id === maxFieldId ) {
-								// Force Knockout to recalculate the max when the number has changed
-								window[ 'GPNestedForms_{0}_{1}'.gformFormat( self.parentFormId, self.nestedFormFieldId ) ].viewModel.entries.valueHasMutated();
+								const gpnfViewModel = window[ 'GPNestedForms_{0}_{1}'.gformFormat( self.parentFormId, self.nestedFormFieldId ) ]?.viewModel;
+
+								// Use the standard Knockout method if available.
+								if ( typeof gpnfViewModel?.entries?.valueHasMutated === 'function' ) {
+									gpnfViewModel.entries.valueHasMutated();
+								// Fallback for scenarios where 'entries' is a computed observable (no valueHasMutated).
+								// Trigger reactivity by reassigning a shallow copy of the observable array.
+								} else if ( typeof gpnfViewModel?.entriesRaw === 'function' ) {
+									gpnfViewModel.entriesRaw( gpnfViewModel.entriesRaw()?.slice() );
+								}
 							}
 						} );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2900858881/81887

## Summary

The snippet to set the min/max of nested form entries is generating errors in the browser console and affecting the Nested Forms field.

https://www.loom.com/share/4f8c17e6082a4b1f9f29ce1f61d296f0?sid=cb9a84fa-2b25-4c62-b6b9-3d76a9377702

This PR updates the logic for triggering Knockout reactivity when the max value field is changed in a GPNestedForms context.

Currently, we have `.valueHasMutated()` on the entries observable to force recalculation when max field value is changed. However, in some scenarios, entries is a computed observable (not writable) and does not support `.valueHasMutated()`, leading to a console error. This update adds a fallback by reassigning a shallow clone of entriesRaw() to itself.
