### PR TITLE
`gw-advanced-merge-tags.php`: Added `:selected` modifier to target selected multi select choice by index on the Advanced Merge Tags snippet.

### DIFF
--- a/gravity-forms/gw-advanced-merge-tags.php
+++ b/gravity-forms/gw-advanced-merge-tags.php
@@ -493,8 +493,8 @@ class GW_Advanced_Merge_Tags {
 					$default_countries = array_flip( GF_Fields::get( 'address' )->get_default_countries() );
 					return rgar( $default_countries, $value );
 				case 'selected':
-					// 'selected' can be used over 'Checkbox' field to target the selected checkbox by its zero-based index.
-					if ( $field->type == 'checkbox' ) {
+					// 'selected' can be used over 'Checkbox' or 'Multi Select' field to target the selected checkbox/multiselect choice by its zero-based index.
+					if ( $field->type == 'checkbox' || $field->type == 'multiselect' ) {
 						$index = $modifier_options;
 						if ( $index !== 'selected' && is_numeric( $index ) ) {
 							$index = intval( $index );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2893613491/81558

## Summary

Added support for a `:selected` modifier that would let you target the selected multi select choice by its zero-based index in our [Advanced Merge Tags](https://gravitywiz.com/snippet-library/gw-advanced-merge-tags/) snippet.

David's loom:
https://www.loom.com/share/a0f523d97c964e698c7d8b0ee56e2da2

All the documentation we have on the :selected modifier:
https://gravitywiz.com/gravity-wiz-weekly-233/#h-advanced-merge-tags-target-selected-checkboxes


After the update:
https://www.loom.com/share/02471d2ea98d456c8f0a2a41af4da937