### PR TITLE
`gw-rich-text-html-fields.php`: Fixed an issue where Rich Text HTML snippet only worked with Gravity Perks active.

### DIFF
--- a/gravity-forms/gw-rich-text-html-fields.php
+++ b/gravity-forms/gw-rich-text-html-fields.php
@@ -19,6 +19,12 @@ add_action( 'admin_init', function() {
 	}
 } );
 
+add_action( 'gform_field_standard_settings', function() {
+	if ( did_action( 'gform_field_standard_settings_200' ) < 1 ) {
+		do_action( 'gform_field_standard_settings_200', rgget( 'id' ) );
+	}
+} );
+
 add_action( 'gform_field_standard_settings_200', function() {
 	?>
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2913661025/82373

## Summary

The [Rich Text HTML Fields snippet](https://gravitywiz.com/snippet-library/gw-rich-text-html-fields/) doesn't work as expected unless the Gravity Perks base plugin is installed and active.

This fixes the issue.
