### PR TITLE
`gw-choice-counter.php`: Fixed an issue with Choice Counter not working for Image Choice field.

### DIFF
--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -90,9 +90,9 @@ class GW_Choice_Count {
 					// Event handler for all listeners to avoid DRY and to maintain a pointer reference to the function
 					// which we can use to explicity unbind event handlers
 					self.updateChoiceEventHandler = function() {
-						setTimeout( function() {
+						requestAnimationFrame( function() {
 							self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId, self.values );
-						}, 10 ); // 10ms delay gives DOM time to reflect input change
+						}); // 10ms delay gives DOM time to reflect input change
 					};
 
 					self.init = function() {

--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -90,7 +90,9 @@ class GW_Choice_Count {
 					// Event handler for all listeners to avoid DRY and to maintain a pointer reference to the function
 					// which we can use to explicity unbind event handlers
 					self.updateChoiceEventHandler = function() {
-						self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId, self.values );
+						setTimeout( function() {
+							self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId, self.values );
+						}, 10 ); // 10ms delay gives DOM time to reflect input change
 					};
 
 					self.init = function() {

--- a/gravity-forms/gw-choice-counter.php
+++ b/gravity-forms/gw-choice-counter.php
@@ -92,7 +92,7 @@ class GW_Choice_Count {
 					self.updateChoiceEventHandler = function() {
 						requestAnimationFrame( function() {
 							self.updateChoiceCount( self.formId, self.choiceFieldIds, self.countFieldId, self.values );
-						}); // 10ms delay gives DOM time to reflect input change
+						});
 					};
 
 					self.init = function() {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2917523082/82535

## Summary

The Choice Counter is not working with Image Choice Field. The count is 1 off; you select two, it shows 1. You select 3 it'll show 2.

This update addresses an off-by-one issue when counting selected options in Gravity Forms' Image Choice fields. The problem occurs because clicking on an image triggers a click on the associated label, which then toggles the underlying checkbox. However, the checkbox state wasn't immediately updated at the time of the event, so there was a slight delay before the DOM reflected the change.

Previously, the count was being calculated immediately on click, which sometimes captured the state before the checkbox had updated, leading to inaccurate totals.

**BEFORE:**
<img width="450" alt="Screenshot 2025-04-24 at 2 12 40 PM" src="https://github.com/user-attachments/assets/2166170e-83c1-41f9-b168-3a67465e4f59" />

**AFTER:**
<img width="500" alt="Screenshot 2025-04-24 at 2 12 31 PM" src="https://github.com/user-attachments/assets/187f4a32-f318-4071-87ff-79e5d386ac4f" />
