### PR TITLE
`gpqr-add-support-for-camera-zoom.js`: Added support for camera zoom during QR code scanning.

### DIFF
--- a/gp-qr-code/gpqr-add-support-for-camera-zoom.js
+++ b/gp-qr-code/gpqr-add-support-for-camera-zoom.js
@@ -1,0 +1,13 @@
+/**
+ * Gravity Perks // GP QR Code // Add Support for Camera Zoom
+ * https://gravitywiz.com/documentation/gravity-forms-qr-code/
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-code-chest/
+ */
+window.gform.addFilter( 'gpqr_scanner_config', function( config, instance, formats ) {
+	config['showZoomSliderIfSupported'] = true;
+	return config;
+} );


### PR DESCRIPTION

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2905448332/82090

Reference: https://github.com/gravitywiz/gp-qr-code/pull/30#issuecomment-2825270328

## Summary

By default, disable camera zoom during QR code scanning. This snippet helps you enable camera zoom during QR code scanning.
