### PR TITLE
`gpalf-count-only-non-blank-rows.js`: Added support to calculate only non-blank rows in a list field.

### DIFF
--- a/gp-auto-list-field/gpalf-count-only-non-blank-rows.js
+++ b/gp-auto-list-field/gpalf-count-only-non-blank-rows.js
@@ -1,0 +1,48 @@
+/**
+ * Gravity Perks // Auto List Field // Dynamic Row Labels for List Fields
+ * https://gravitywiz.com/documentation/gravity-forms-auto-list-field/
+ *
+ * Count only non-blank rows in a List field.
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet with our free Custom JavaScript plugin.
+ *    https://gravitywiz.com/gravity-forms-code-chest/
+ */
+gform.addFilter('gform_merge_tag_value_pre_calculation', function (value, match, isVisible, formulaField, formId) {
+	if (typeof match[3] === 'undefined' || match[3].indexOf(':count') === -1) {
+		return value;
+	}
+
+	var inputId = match[1];
+	var fieldId = parseInt(inputId, 10);
+
+	var $fieldWrapper = $(`#gform_${formId} #field_${formId}_${fieldId}`);
+	if ($fieldWrapper.length === 0) {
+		return value;
+	}
+
+	var $rows = $fieldWrapper.find('.gfield_list_group');
+	if ($rows.length === 0) {
+		return value;
+	}
+
+	var nonBlankCount = 0;
+
+	$rows.each(function () {
+		var isNonBlank = false;
+
+		$(this).find('input').each(function () {
+			if ($(this).val().trim() !== '') {
+				isNonBlank = true;
+				return false;
+			}
+		});
+
+		if (isNonBlank) {
+			nonBlankCount++;
+		}
+	});
+
+	return nonBlankCount;
+});


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2916143012/82450

## Summary

By default, GP Auto List Field calculates the all rows (including blank rows) when we use `:count` modifier. This snippet is useful when you want to count only non-blank rows.

![82450-Count-Non-Blank-Rows](https://github.com/user-attachments/assets/3672b0f8-ef09-430b-81ee-39b77c70e2a5)

