### PR TITLE
`gpnf-sortable-entries.php`: Fixed an issue with sortable entries not working correctly.

### DIFF
--- a/gp-nested-forms/gpnf-sortable-entries.php
+++ b/gp-nested-forms/gpnf-sortable-entries.php
@@ -237,12 +237,12 @@ class GPNF_Sortable_Entries {
 					}
 
 					gform.addAction( 'gpnf_session_initialized', function(gpnf) {
-						if ( gpnf.formId != self.formId ) {
+						if ( self.formId && gpnf.formId != self.formId ) {
 							return;
 						}
 
-						var $form = $( '#gform_' + self.formId );
-						var $field = $form.find( '#field_' + self.formId + '_' + self.fieldId );
+						var $form = $( '#gform_' + gpnf.formId );
+						var $field = $form.find( '#field_' + gpnf.formId + '_' + gpnf.fieldId );
 						var $entries = $field.find('.gpnf-nested-entries tbody');
 
 						$entries.sortable({


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2918586555/82589

## Summary

The snippet doesn't appear to work when applied to all forms and also all nested forms field on a form. It only works when the configuration is set to apply it to a specific form and specific Nested Forms field.

Loom of the issue (Samuel):
https://www.loom.com/share/bff4f13258cd4ddaa8fc24e7819558b7

After the update:
https://www.loom.com/share/837b523b30ad495c945a2e976fd896ac

