### PR TITLE
`gspc-remove-wc-product-from-entry-order-summary.php`: Fixed snippet removes only product name from order summary but retains product price and quantity.

### DIFF
--- a/gs-product-configurator/gspc-remove-wc-product-from-entry-order-summary.php
+++ b/gs-product-configurator/gspc-remove-wc-product-from-entry-order-summary.php
@@ -9,5 +9,6 @@ add_filter( 'init', function() {
 	if ( is_callable( 'gs_product_configurator' ) ) {
 		remove_filter( 'gppa_ajax_form_pre_render', array( gs_product_configurator()->wc_product_form_display, 'inject_base_price_product_field_gppa_ajax' ) );
 		remove_filter( 'gform_product_info', array( gs_product_configurator()->wc_product_form_display, 'inject_base_price_into_product_info' ) );
+		remove_filter( 'gform_pre_render', array( gs_product_configurator()->wc_product_form_display, 'inject_base_price_product_field' ), 5 );
 	}
 }, 16 );


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2916172481/82451

## Summary

This PR fixes the issue that snippet removes only product name from order summary but retains product price and quantity.

Before

![GSPC-BEFORE](https://github.com/user-attachments/assets/7cb2b955-50f6-4457-9ee4-d25418012f32)

After

![GSPC-AFTER](https://github.com/user-attachments/assets/e578ef4c-04a4-4111-83f4-9dc5f00984bc)


