### PR TITLE
`gppa-populate-child-entries.php`: Fixed field does not populate on first load issue.

### DIFF
--- a/gp-populate-anything/gppa-populate-child-entries.php
+++ b/gp-populate-anything/gppa-populate-child-entries.php
@@ -120,21 +120,17 @@ class GPPA_Populate_Child_Entries {
 
 						self.$peidField = $( '#input_{0}_{1}'.gformFormat( self.formId, self.fieldId ) );
 
-						if ( typeof window[ 'gpnfSessionPromise_' + self.formId ] === 'undefined' ) {
-							gform.addAction( 'gpnf_session_initialized', function() {
-								self.setupPeidField();
-							} );
-						} else {
-							self.setupPeidField();
-						}
-
+						// Make sure cookies are set.
+                        gform.addAction( 'gpnf_session_initialized', function() {
+                            self.setupPeidField();
+                        } );
 					};
 
 					self.setupPeidField = function() {
 
-						var gpnfCookie = $.parseJSON( self.getCookie( 'gpnf_form_session_{0}'.gformFormat( self.formId ) ) );
+						var gpnfCookie = $.parseJSON( self.getCookie( self.cookieName ));
 
-						if ( ! self.$peidField.val() ) {
+						if ( ! self.$peidField.val() && gpnfCookie ) {
 							self.$peidField
 								.val( gpnfCookie.hash )
 								.change();
@@ -182,6 +178,7 @@ class GPPA_Populate_Child_Entries {
 			'formId'             => $form['id'],
 			'fieldId'            => $this->get_parent_entry_id_field( $form ),
 			'nestedFormFieldIds' => wp_list_pluck( $this->get_nested_form_fields( $form ), 'id' ),
+			'cookieName'         => ( new GPNF_Session( $form['id'] ) )->get_cookie_name(),
 		);
 
 		$script = 'new GPPAPopulateChildEntries( ' . json_encode( $args ) . ' );';


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2917938488/82554

## Summary

Due to some JS error in console, field doesn't populate on first load. If we reload the page, it populates. 

Here's the loom recording of this issue. This PR fixes this issue.

https://www.loom.com/share/7fc577ae7c274ec48df5a1b3c36fe995?sid=26c1e9f0-ec10-473e-b6e7-bad4622b9ed8
