### PR TITLE
`gppa-force-lmt-populate-on-edit.php`: Added snippet to update Live Merge Tags when editing entries.

### DIFF
--- a/gp-populate-anything/gppa-force-lmt-populate-on-edit.php
+++ b/gp-populate-anything/gppa-force-lmt-populate-on-edit.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Gravity Forms // Populate Anything // Force Dynamic Population When Editing Entry.
+ * https://gravitywiz.com/documentation/gravity-forms-populate-anything/
+ *
+ * Instruction Video: https://www.loom.com/share/6a7f28fc0cde406798d5bad4b386a70a
+ *
+ * Use this snippet to force fields to be dynamically repopulated via Populate Anything when they are
+ * edited via the Gravity Forms edit entry screen.
+ */
+add_action( 'gform_after_update_entry', function ( $form, $entry_id ) {
+	$gppa_lmt = GP_Populate_Anything_Live_Merge_Tags::get_instance();
+	$entry    = GFAPI::get_entry( $entry_id );
+	foreach ( $form['fields'] as $field ) {
+		// For any field having Live Merge Tags.
+		if ( $gppa_lmt->has_live_merge_tag( $field->defaultValue ) ) {
+			$gppa_lmt->populate_lmt_whitelist( $form );
+			remove_all_filters('gform_pre_replace_merge_tags');
+
+			// Process the Live Merge Tags.
+			$merge_tag = preg_replace( '/@(?=\{)/', '', $field->defaultValue );
+			$value     = GFCommon::replace_variables( $merge_tag, $form, $entry );
+
+			// Store updated value on the entry.
+			GFFormsModel::update_entry_field_value( $form, $entry, $field, '', $field->id, $value );
+		}
+	}
+}, 15, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2918356655/82575

💬 Slack: https://gravitywiz.slack.com/archives/D042XMBHJ91/p1745768566723809?thread_ts=1745647036.839519&cid=D042XMBHJ91

## Summary

Live Merge Tags does not appear to be working when editing entries via the Entry Details page.

Snippet Demo:
https://www.loom.com/share/6a7f28fc0cde406798d5bad4b386a70a
