### PR TITLE
`gw-conditional-logic-operator-does-not-contain.php`: Fixed rule value for `does not contain` rule.

### DIFF
--- a/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
+++ b/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
@@ -45,14 +45,11 @@ class GF_CLO_Does_Not_Contain {
 				operators.does_not_contain = 'does not contain';
 				return operators;
 			} );
-			gform.addFilter( 'gform_conditional_logic_values_input', function( str, objectType, ruleIndex, selectedFieldId, value ) {
-				const operator = jQuery( '#field_rule_operator_' + ruleIndex ).val();
-				if ( operator !== 'does_not_contain' ) {
-					return str;
-				}
-				str = '<input type="text" placeholder="Enter a value" data-js-rule-input="value" class="gfield_rule_select gfield_rule_input active" id="field_rule_value_' + ruleIndex + '" name="field_rule_value_' + ruleIndex + '" value="' + value + '">';
-				return str;
-			} );
+
+			// Override the default GF function to add our custom operator.
+			function ruleNeedsTextValue( rule ) {
+				return ['does_not_contain','contains', 'starts_with', 'ends_with', '<', '>' ].indexOf ( rule.operator ) !== -1;
+			}
 		</script>
 		<?php
 	}

--- a/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
+++ b/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
@@ -46,9 +46,11 @@ class GF_CLO_Does_Not_Contain {
 				return operators;
 			} );
 
+			let origRuleNeedsTextValue = window.ruleNeedsTextValue;
 			// Override the default GF function to add our custom operator.
 			function ruleNeedsTextValue( rule ) {
-				return ['does_not_contain','contains', 'starts_with', 'ends_with', '<', '>' ].indexOf ( rule.operator ) !== -1;
+				let needsTextValue = origRuleNeedsTextValue( rule );
+				return needsTextValue || rule.operator.indexOf( 'does_not_contain' ) !== -1;
 			}
 		</script>
 		<?php

--- a/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
+++ b/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Gravity Wiz // Gravity Forms // Conditional Logic Operator: "Does Not Contain"
- * 
+ *
  * Instruction Video: https://www.loom.com/share/8e1b27ec47b341dbb4f0da2bec6a960b
  *
  * Check if a source field value does NOT contain a specific substring using the "does not contain" conditional logic operator.
@@ -42,13 +42,18 @@ class GF_CLO_Does_Not_Contain {
 			}
 
 			gform.addFilter( 'gform_conditional_logic_operators', function( operators ) {
-				operators.does_not_contain = 'does not contain';
+				// Injects our "does_not_contain" operator directly below the "contains" operator for logical ordering.
+				operators = Object.fromEntries(
+					Object.entries(operators).flatMap(([k, v]) =>
+						k === "contains" ? [[k, v], ['does_not_contain', 'does not contain']] : [[k, v]]
+					)
+				);
 				return operators;
 			} );
 
 			let origRuleNeedsTextValue = window.ruleNeedsTextValue;
 			// Override the default GF function to add our custom operator.
-			function ruleNeedsTextValue( rule ) {
+			window.ruleNeedsTextValue = function( rule ) {
 				let needsTextValue = origRuleNeedsTextValue( rule );
 				return needsTextValue || rule.operator.indexOf( 'does_not_contain' ) !== -1;
 			}
@@ -89,18 +94,21 @@ class GF_CLO_Does_Not_Contain {
 							}
 
 							var fieldValue = '';
-							var $field = $( '#input_' + formId + '_' + rule.fieldId );
+							var $field     = $( '#input_' + formId + '_' + rule.fieldId );
+							var $inputs    = $field.find( 'input, select, textarea' );
 
-							// Handle different field types
-							if ( $field.is(':checkbox') || $field.is(':radio') ) {
-								fieldValue = $field.filter(':checked').map(function() { 
-									return this.value; 
+							// This is a quick-and-dirty way to get the value of the field. We may need to revisit for
+							// edge cases in the future.
+							if ( $inputs.is(':checkbox') || $inputs.is(':radio') ) {
+								fieldValue = $inputs.filter(':checked').map(function() {
+									return this.value;
 								}).get().join(',');
-							} else if ( $field.is('select[multiple]') ) {
-								fieldValue = $field.val() ? $field.val().join(',') : '';
+							} else if ( $inputs.is('select[multiple]') ) {
+								fieldValue = $inputs.val() ? $inputs.val().join(',') : '';
 							} else {
 								fieldValue = $field.val() || '';
 							}
+
 							isMatch = typeof fieldValue === 'string' && fieldValue.indexOf( rule.value ) === -1;
 
 							return isMatch;

--- a/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
+++ b/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
@@ -45,6 +45,14 @@ class GF_CLO_Does_Not_Contain {
 				operators.does_not_contain = 'does not contain';
 				return operators;
 			} );
+			gform.addFilter( 'gform_conditional_logic_values_input', function( str, objectType, ruleIndex, selectedFieldId, value ) {
+				const operator = jQuery( '#field_rule_operator_' + ruleIndex ).val();
+				if ( operator !== 'does_not_contain' ) {
+					return str;
+				}
+				str = '<input type="text" placeholder="Enter a value" data-js-rule-input="value" class="gfield_rule_select gfield_rule_input active" id="field_rule_value_' + ruleIndex + '" name="field_rule_value_' + ruleIndex + '" value="' + value + '">';
+				return str;
+			} );
 		</script>
 		<?php
 	}


### PR DESCRIPTION
## Context

💬 Slack: https://gravitywiz.slack.com/archives/C04RQJ232PQ/p1746134330652079

## Summary

The does not contain rule renders select of dropdown, instead of the text box.

David's loom explaining the issue:
https://www.loom.com/share/fc3e8050e0284dc480247ad2e35112ff


This PR adds the override for `does_not_contain` operator as well. Loom Demo: https://www.loom.com/share/5eeed1dd533449eab06cef3088922def

I had initially thought of the approach of using 

```js
			gform.addFilter( 'gform_conditional_logic_values_input', function( str, objectType, ruleIndex, selectedFieldId, value ) {
				const operator = jQuery( '#field_rule_operator_' + ruleIndex ).val();
				if ( operator !== 'does_not_contain' ) {
					return str;
				}
				str = '<input type="text" placeholder="' + gf_vars['enterValue'] + '" data-js-rule-input="value" class="gfield_rule_select gfield_rule_input active" id="field_rule_value_' + ruleIndex + '" name="field_rule_value_' + ruleIndex + '" value="' + value + '">';
				return str;
			} );
```

However, the issue with this approach was that on first render the `field_rule_value_` was not defined yet, and we couldn't get `does not contain` to render the string instead of the dropdown of the values (for this example). It did work fine on frontend and any refresh on the values by adding/removing more rules. However, this solution was clearly lacking the correct behaviour. The issue with this approach:

https://www.loom.com/share/877e59bf2b9147e2aed59527754ec31e

