### PR TITLE
`gspc-remove-price-from-addon-display.php`: Fixed a typo with the snippet.

### DIFF
--- a/gs-product-configurator/gspc-remove-price-from-addon-display.php
+++ b/gs-product-configurator/gspc-remove-price-from-addon-display.php
@@ -17,7 +17,7 @@
  * First Choice × 2
  */
 add_filter( 'gspc_show_addon_price', function( $show, $product_field ) {
-	if ( strpos( $field->cssClass, 'gspc-remove-price' ) !== false ) {
+	if ( strpos( $product_field->cssClass, 'gspc-remove-price' ) !== false ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Context

💬 Slack: https://gravitywiz.slack.com/archives/D042URGA4QM/p1746440777693109
(Reported by Samuel)

## Summary

Typo with the snippet

`$field->cssClass`

Is supposed to be

`$product_field ->cssClass`
