### PR TITLE
`gpalf-count-only-non-blank-rows.js`: Added support to recalculate non-blank rows when a list field value changes.

### DIFF
--- a/gp-auto-list-field/gpalf-count-only-non-blank-rows.js
+++ b/gp-auto-list-field/gpalf-count-only-non-blank-rows.js
@@ -46,3 +46,20 @@ gform.addFilter('gform_merge_tag_value_pre_calculation', function (value, match,
 
 	return nonBlankCount;
 });
+
+$(document).ready(function () {
+	// Recalculate when a list field is changed.
+	$(document).on('change', '.gfield_list_group_item input', function () {
+		var $group = $(this).parents('.gfield_list_group');
+		var $container = $group.parents('.gfield_list_container');
+		var formId = $container.closest('.gform_wrapper').attr('id').replace('gform_wrapper_', '');
+
+		if ( !formId || typeof window.gf_global.gfcalc[formId] === 'undefined') {
+			return;
+		}
+
+		var calcObject = window.gf_global.gfcalc[formId];
+
+		calcObject.runCalcs(formId, calcObject.formulaFields);
+	});
+});


### PR DESCRIPTION
## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2921955434/82734

## Summary

Previously, non-blank rows were recalculated only when a user added or removed a row.

This PR enhances that behaviour by also triggering recalculations when a list field value changes.

Here’s the recorded Loom

https://www.loom.com/share/c901a19a3bc1478f828dedc7a3f464f9?sid=3332c522-f652-4356-8701-37d65f32a57c