### PR TITLE
`gpld-populate-new-minimum-date-into-linked-date-field.js`: Fixed an issue with default value of field notgetting used to apply minimum date.

### DIFF
--- a/gp-limit-dates/gpld-populate-new-minimum-date-into-linked-date-field.js
+++ b/gp-limit-dates/gpld-populate-new-minimum-date-into-linked-date-field.js
@@ -10,6 +10,17 @@
  * 1. Install this snippet with our free Custom JavaScript plugin.
  *    https://gravitywiz.com/gravity-forms-code-chest/
  */
- gform.addAction( 'gpld_after_set_min_date', function( $input, date ) {
- 	$input.datepicker( 'setDate', date );
+const sourceFieldId = 25; // Replace with the ID of the source field (Field A)
+document.addEventListener( 'gform/post_render', ( event ) => {
+	const $field = jQuery( `#input_GFFORMID_${sourceFieldId}` );
+	const value  = $field.val();
+	if ( value ) {
+		requestAnimationFrame( function(){
+			$field.trigger( 'input' ).trigger( 'change' );
+		});
+	}
+});
+
+gform.addAction( 'gpld_after_set_min_date', function( $input, date ) {
+	$input.datepicker( 'setDate', date );
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2929104779/83029

## Summary

The snippet above doesn't work on initial load if the Date field A has a default date value.

Loom of the issue and update:

https://www.loom.com/share/763dfa9262a44ead841b3fdb2818fac4
