### PR TITLE
`gw-disable-submission-on-enter.js`: Fixed an issue with disable enter snippet not working with Conversational Forms.

### DIFF
--- a/gravity-forms/gw-disable-submission-on-enter.js
+++ b/gravity-forms/gw-disable-submission-on-enter.js
@@ -10,7 +10,21 @@
 document.addEventListener( 'keydown', function(e) {
 	var isGravityForm = e.target.closest( '.gform_wrapper' ) !== null;
 	var code = e.keyCode || e.which;
-	if ( code == 13 && ! jQuery( e.target ).is( 'textarea,input[type="submit"],input[type="button"]' )  && isGravityForm ) {
+	if ( code == 13 && isGravityForm ) {
+		var isTextarea = e.target.tagName.toLowerCase() === 'textarea';
+		var isSubmitOrButton = jQuery(e.target).is('input[type="submit"], input[type="button"]');
+
+		// Allow default for submit/buttons.
+		if (isSubmitOrButton) {
+			return;
+		}
+
+		// Allow Shift+Enter in textarea for line breaks.
+		if (isTextarea && e.shiftKey) {
+			return;
+		}
+
+		// Block everything else.
 		e.stopImmediatePropagation();
 		e.preventDefault();
 	}

--- a/gravity-forms/gw-disable-submission-on-enter.js
+++ b/gravity-forms/gw-disable-submission-on-enter.js
@@ -7,10 +7,11 @@
  * Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
  * 2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
  */
-jQuery(document).on( 'keypress', '.gform_wrapper', function (e) {
-    var code = e.keyCode || e.which;
-    if ( code == 13 && ! jQuery( e.target ).is( 'textarea,input[type="submit"],input[type="button"]' ) ) {
-        e.preventDefault();
-        return false;
-    }
-} );
+document.addEventListener( 'keydown', function(e) {
+	var isGravityForm = e.target.closest( '.gform_wrapper' ) !== null;
+	var code = e.keyCode || e.which;
+	if ( code == 13 && ! jQuery( e.target ).is( 'textarea,input[type="submit"],input[type="button"]' )  && isGravityForm ) {
+		e.stopImmediatePropagation();
+		e.preventDefault();
+	}
+}, true );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2931919718/83124

## Summary

[Disable Submission on Enter](https://gravitywiz.com/snippet-library/gw-disable-submission-on-enter/) snippet and Gravity Forms Conversational Forms Add-on incompatibility. The snippet works as expected when Conversational forms is not active on the form, but once it is active on the form, the snippet doesn't work.

We have updated to
1. Use `addEventListener` with `keydown` to catch `Enter` across all input elements.
2. Check for `.gform_wrapper` as a parent to confirm the event is inside a Gravity Form field.
3. Add `stopImmediatePropagation()` to prevent interference from other listeners.

This works reliably with GF Conversational Forms Add-on, and continues to work with normal form preview/form front end pages.

**BEFORE** (Credits: Roxy):
https://www.loom.com/share/9c577fd7af1d47f090458e99e9118444

**AFTER**:
https://www.loom.com/share/050bd75bd63b475c9827a516083b4f84