### PR TITLE
`gpnf-hide-quantity-in-summary-field-values.php`: Added snippet to hide quantity from GPNF summary field values.

### DIFF
--- a/gp-nested-forms/gpnf-hide-quantity-in-summary-field-values.php
+++ b/gp-nested-forms/gpnf-hide-quantity-in-summary-field-values.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Gravity Perks // Nested Forms // Hide Quantity in Summary Field Values
+ * https://gravitywiz.com/documentation/gravity-forms-nested-forms/
+ *
+ * Product field display values are formatted as "Label, Quantity, Price". This snippet removes the quantity from the display value.
+ */
+add_filter( 'gpnf_display_value', function( $display_value, $field, $form, $entry ) {
+
+	if ( $field->type != 'product' ) {
+		return $display_value;
+	}
+
+	$display_value['label'] = preg_replace( '/,\s*[^,]+,\s*/', ', ', $display_value['label']);
+
+	return $display_value;
+}, 10, 4 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2929910662/83058

## Summary

To remove the quantity from the product data which is display on the Nested Forms Summary table.

The snippet is language independent!

**_Deutsch:_**
<img width="885" alt="Screenshot 2025-05-10 at 12 00 08 AM" src="https://github.com/user-attachments/assets/ba205980-4807-4891-9ede-c9ba5b3e4f46" />

**_English:_**
<img width="892" alt="Screenshot 2025-05-10 at 12 00 23 AM" src="https://github.com/user-attachments/assets/bbab52f1-4f47-425c-a224-40a5da2f56bd" />
