### PR TITLE
`gw-coupons-exclude-products.php`: Fixed an issue with discount not applied correctly in some scenarios.

### DIFF
--- a/gravity-forms/gw-coupons-exclude-products.php
+++ b/gravity-forms/gw-coupons-exclude-products.php
@@ -193,7 +193,7 @@ class GW_Coupons_Exclude_Products {
 		if ( $this->_args['exclude_options_from_fields'] ) {
 			if ( $coupon['type'] == 'percentage' && ! ( $amount == 100 && $this->_args['skip_for_100_percent'] ) ) {
 				$discount = $discount - ( $price * ( $amount / 100 ) );
-			} else {
+			} elseif ( $this->excluded_total < $discount) {
 				$discount = $this->excluded_total;
 			}
 		} elseif ( $coupon['type'] == 'percentage' && ! ( $amount == 100 && $this->_args['skip_for_100_percent'] ) ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2922744588/82764

## Summary

The snippet above is affecting the product total during submission if the coupon type is flat rate.

Fixed the edge case conditional.
