### PR TITLE
`gpnf-child-products-in-parent-order-summary.php`: Fixed an issue with snippet not working in some scenarios.

### DIFF
--- a/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
+++ b/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php
@@ -23,7 +23,7 @@ add_filter( 'gform_product_info', function( $product_info, $form, $entry ) use (
 
 		$child_products = array();
 
-		preg_match_all( '/{[^{]*?:([0-9]+):(sum|total|count)=?([0-9]*)}/', $field->calculationFormula, $matches, PREG_SET_ORDER );
+		preg_match_all( '/{[^{]*?:([0-9]+):(sum|total)=?([0-9]*)}/', $field->calculationFormula, $matches, PREG_SET_ORDER );
 		foreach ( $matches as $match ) {
 
 			list( ,$nested_form_field_id,, ) = $match;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2944761378/83684

## Summary

When using the GPNF [Include Child Products Directly in Parent Form Order Summary](https://github.com/gravitywiz/snippet-library/blob/master/gp-nested-forms/gpnf-child-products-in-parent-order-summary.php) snippet, along with a product field that references the nested form field in its calculation, the form throws a mismatch error.

Before (Matt A):
https://www.loom.com/share/23724cb319f241f6bb98cf9a7c7bb0b2

After:

<img width="1073" alt="Screenshot 2025-05-22 at 6 30 08 PM" src="https://github.com/user-attachments/assets/9e5bfce7-daa6-4300-97bd-1fade3c400a0" />
