### PR TITLE
`gw-capitilize-submitted-data.php`: Fixed an issue with processing hidden list field.

### DIFF
--- a/gravity-forms/gw-capitilize-submitted-data.php
+++ b/gravity-forms/gw-capitilize-submitted-data.php
@@ -28,6 +28,11 @@ function gw_capitalize_submitted_data( $form ) {
 			}
 		} else {
 			$input_key = sprintf( 'input_%s', $field['id'] );
+			// Value hidden or empty, skip it.
+			if ( empty( $_POST[ $input_key ] ) ) {
+				continue;
+			}
+
 			if ( $field->type == 'list' ) {
 				$_POST[ $input_key ] = array_map( function( $value ) {
 					return ucwords( strtolower( $value ) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2943198385/83618

## Summary

https://gravitywiz.com/snippet-library/gw-capitilize-submitted-data/

The snippet above is causing a fatal error if the form is submitted with a conditionally hidden List field.

```
PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given in ...
```

Loom (Samuel):
https://www.loom.com/share/f13287a7c9b84a8d9950bc2878fbf567
