### PR TITLE
`gw-conditional-logic-operator-does-not-contain.php`: Fixed an issue with the snippet.

### DIFF
--- a/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
+++ b/gravity-forms/gw-conditional-logic-operator-does-not-contain.php
@@ -32,7 +32,7 @@ class GF_CLO_Does_Not_Contain {
 	}
 
 	public function output_admin_inline_script() {
-		if ( ! GFForms::get_page() && ! is_admin() && ! in_array( rgget( 'page' ), array( 'gp-email-users' ) ) ) {
+		if ( ! GFForms::get_page() && is_admin() && ! in_array( rgget( 'page' ), array( 'gp-email-users' ) ) ) {
 			return;
 		}
 		?>

--- a/gravity-forms/gw-conditional-logic-operator-is-in.php
+++ b/gravity-forms/gw-conditional-logic-operator-is-in.php
@@ -34,7 +34,7 @@ class GF_CLO_Is_In {
 	}
 
 	public function output_admin_inline_script() {
-		if ( ! GFForms::get_page() && ! is_admin() && ! in_array( rgget( 'page' ), array( 'gp-email-users' ) ) ) {
+		if ( ! GFForms::get_page() && is_admin() && ! in_array( rgget( 'page' ), array( 'gp-email-users' ) ) ) {
 			return;
 		}
 		?>


### PR DESCRIPTION
## Context

⛑️ Ticket(s): with the snippet.

## Summary

The “Does Not Contain” and "Is In" Conditional Logic Operator snippets throws a JavaScript error on non-Gravity Forms pages due to an undefined gform.addFilter function. This occurs because the snippets attempt to call gform.addFilter when the Gravity Forms context is not available.

Loom (Glenn):
https://www.loom.com/share/e6b41c2a8ea84a30b9530965ca0e873c
