### PR TITLE
`gpnf-sortable-entries.php`: Fixed an issue with Sortable Entries snippet not working with Gravity Flow.

### DIFF
--- a/gp-nested-forms/gpnf-sortable-entries.php
+++ b/gp-nested-forms/gpnf-sortable-entries.php
@@ -185,6 +185,7 @@ class GPNF_Sortable_Entries {
 		if ( $this->is_applicable_form( $form ) && ! has_action( 'wp_footer', array( $this, 'output_script' ) ) ) {
 			add_action( 'wp_footer', array( $this, 'output_script' ) );
 			add_action( 'gform_preview_footer', array( $this, 'output_script' ) );
+			add_action( 'admin_footer', array( $this, 'output_script' ) );
 		}
 
 		return $form;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2918586555/82589

## Summary

Sortable Entries snippet not working in context of Gravity Flow. The scripts were not fired on the admin side, we add that with `admin_footer`. Also, since the code logic already have conditional guards checking for `is_applicable_form` etc, I can confirm that the script does not get run on other admin pages (or cause any conflicts or console errors etc).

**BEFORE**:
_Nested entries do not show up, and console errors._
<img width="1780" alt="Screenshot 2025-05-29 at 12 37 58 PM" src="https://github.com/user-attachments/assets/baf16413-8846-4a9c-b134-78cac0941ded" />

**AFTER:**
https://www.loom.com/share/2f3639e609c0449c8e89285613fd55db
