### PR TITLE
`gppa-preserve-selections.php`: Fixed an issue with preserve selections not working correctly for checkbox field.

### DIFF
--- a/gp-populate-anything/gppa-preserve-selections.php
+++ b/gp-populate-anything/gppa-preserve-selections.php
@@ -5,11 +5,26 @@
  */
 // Update "123" to your form ID and "4" to your field ID.
 add_filter( 'gppa_input_choices_123_4', function( $choices, $field, $objects ) {
-	$selected_values = (array) rgar( gp_populate_anything()->get_field_values_from_request(), $field->id );
+	$field_values    = gp_populate_anything()->get_field_values_from_request();
+	$selected_values = (array) rgar( $field_values, $field->id );
+	if ( $field->type == 'checkbox' && ! empty( $selected_values ) ) {
+		// look in field_values for values of index like 5.1, 5.2 etc. where 5 is the field id
+		$selected_values = array();
+		foreach ( $field_values as $key => $value ) {
+			if ( strpos( (string) $key, $field->id . '.' ) === 0 ) {
+				$selected_values[ $key ] = $value;
+			}
+		}
+	}
+
 	foreach ( $choices as &$choice ) {
 		if ( in_array( $choice['value'], $selected_values, true ) ) {
 			$choice['isSelected'] = true;
 		}
 	}
+
 	return $choices;
 }, 10, 3 );
+
+// Update "123" to your form ID and "4" to your field ID.
+add_filter( 'gppa_field_choices_posted_value_123_4', '__return_false' );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2954151326/84317

## Summary

The snippet to preserve the selected choice on repopulation, doesn't work on Checkbox fields.

This update needs GPPA PR: https://github.com/gravitywiz/gp-populate-anything/pull/625

https://www.loom.com/share/4128bac6460b4892b0a0b710ded0069c
