### PR TITLE
`gpfup-count-files-groups.js`: Added snippet to count files in groups.

### DIFF
--- a/gp-file-upload-pro/gpfup-count-files-groups.js
+++ b/gp-file-upload-pro/gpfup-count-files-groups.js
@@ -30,8 +30,9 @@ Object.entries(countMapping).forEach(([countFieldID, uploadFieldIDs]) => {
 });
 
 // Function to update all relevant count fields
-function updateAllCountFields() {
-	Object.entries(countMapping).forEach(([countFieldID, uploadFieldIDs]) => {
+function updateCountFields(countFieldIDs = Object.keys(countMapping)) {
+	countFieldIDs.forEach((countFieldID) => {
+		const uploadFieldIDs = countMapping[countFieldID];
 		const total = uploadFieldIDs.reduce((sum, uploadFieldID) => {
 			const key = 'GPFUP_' + formId + '_' + uploadFieldID;
 			const store = window[key]?.$store;
@@ -56,12 +57,12 @@ if (gpfupInstances.length) {
 		if (uploadToCountMap[fieldID]) {
 			store.subscribe((mutation, state) => {
 				if (mutation.type === 'SET_FILES') {
-					updateAllCountFields();
+					updateCountFields(uploadToCountMap[fieldID]);
 				}
 			});
 		}
 	});
 }
 
-// Initial count on load
-updateAllCountFields();
+// Initial count on load for all fields
+updateCountFields();

--- a/gp-file-upload-pro/gpfup-count-files-groups.js
+++ b/gp-file-upload-pro/gpfup-count-files-groups.js
@@ -1,0 +1,66 @@
+/**
+ * Gravity Perks // File Upload Pro // Count Files in Groups
+ * https://gravitywiz.com/documentation/gravity-forms-file-upload-pro/
+ *
+ * Instruction Video: https://www.loom.com/share/2328e327125844bebdcabf7c9baaabca
+ */
+var formId = GFFORMID;
+
+// Map count field IDs to arrays of file upload field IDs
+var countMapping = {
+	5: [1, 3, 4],    // Number Field ID 5 counts files from File Upload Field IDs 1, 3, 4
+	10: [7, 8, 9]    // Number Field ID 10 counts files from File Upload Field IDs 7, 8, 9
+	// Add more mappings if needed
+};
+
+// Find all GPFUP keys for the form
+var gpfupInstances = Object.keys(window).filter(function (key) {
+	return key.startsWith('GPFUP_' + formId + '_');
+});
+
+if (!gpfupInstances.length) {
+	return;
+}
+
+// Build reverse lookup: uploadFieldID => associated countFieldIDs
+var uploadToCountMap = {};
+Object.entries(countMapping).forEach(function ([countFieldID, uploadFieldIDs]) {
+	uploadFieldIDs.forEach(function (uploadFieldID) {
+		if (!uploadToCountMap[uploadFieldID]) {
+			uploadToCountMap[uploadFieldID] = [];
+		}
+		uploadToCountMap[uploadFieldID].push(parseInt(countFieldID));
+	});
+});
+
+// Function to update all relevant count fields
+function updateAllCountFields() {
+	Object.entries(countMapping).forEach(function ([countFieldID, uploadFieldIDs]) {
+		var total = uploadFieldIDs.reduce(function (sum, uploadFieldID) {
+			var key = 'GPFUP_' + formId + '_' + uploadFieldID;
+			var store = window[key] && window[key].$store;
+			return sum + (store ? (store.state.files.length || 0) : 0);
+		}, 0);
+
+		var selector = '#input_' + formId + '_' + countFieldID;
+		jQuery(selector).val(total).change();
+	});
+}
+
+// Subscribe to relevant GPFUP fields
+gpfupInstances.forEach(function (key) {
+	var parts = key.split('_');
+	var fieldID = parseInt(parts[2]); // GPFUP_formId_fieldId
+	var store = window[key].$store;
+
+	if (uploadToCountMap[fieldID]) {
+		store.subscribe(function (mutation, state) {
+			if (mutation.type === 'SET_FILES') {
+				updateAllCountFields();
+			}
+		});
+	}
+});
+
+// Initial count on load
+updateAllCountFields();


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2951970232/84219

## Summary

Add support for grouping file upload fields in the GPFUP Count Files snippet. Allow defining multiple groups and assigning each group’s count to a different number field.

https://www.loom.com/share/2328e327125844bebdcabf7c9baaabca