### PR TITLE
`gw-shortcode-attr-field-props.php`: Fixed potential PHP warnings.

### DIFF
--- a/gravity-forms/gw-shortcode-attr-field-props.php
+++ b/gravity-forms/gw-shortcode-attr-field-props.php
@@ -30,7 +30,8 @@
  */
 class GW_Shortcode_Attr_Field_Props {
 
-	private $_field_props;
+	private $_args        = array();
+	private $_field_props = array();
 
 	public function __construct( $args = array() ) {
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2960746738/84687

## Summary

Assigning `$_args` to `array()`.

We did a lot of these [here](https://github.com/gravitywiz/snippet-library/pull/761). Somehow this one was left out. 😬 