### PR TITLE
`gcgs-process-feed-on-gravityflowformconnector-new-entry.php`: Added snippet to process GCGS Feeds post Gravity Flow Form Connector New Entry.

### DIFF
--- a/gc-google-sheets/gcgs-process-feed-on-gravityflowformconnector-new-entry.php
+++ b/gc-google-sheets/gcgs-process-feed-on-gravityflowformconnector-new-entry.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Gravity Connect // Google Sheets // Process Feed when a New Entry is Created via Gravity Flow Form Connector.
+ * 
+ * Instruction Video: https://www.loom.com/share/7c5b3b5e286648538bf4a2326333f4d7
+ *
+ * Process Google Sheet feeds when a new entry is created.
+ */
+add_action( 'gravityflowformconnector_post_new_entry', function ( $new_entry_id, $entry, $form, $step ) {
+	if ( function_exists( 'gc_google_sheets' ) && $step->get_type() == 'new_entry' ) {
+		$new_entry = GFAPI::get_entry( $new_entry_id );
+		$new_form  = GFAPI::get_form( $new_entry['form_id'] );
+		gc_google_sheets()->maybe_process_feed( $new_entry, $new_form );
+		gf_feed_processor()->save()->dispatch();
+	}
+}, 10, 4 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2960107602/84668

## Summary

Using Gravity Flow Form Connector to create entries on Form A when Form B is submitted.

Form A also has a GCGS feed, however, when entries are created using Gravity Flow, the GCGS feed is not running.

This snippet adds support for that.

Demo:
https://www.loom.com/share/7c5b3b5e286648538bf4a2326333f4d7
