### PR TITLE
`gw-populate-date.php`: Fixed a deprecated warning notice.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -249,7 +249,8 @@ class GW_Populate_Date {
 			// If saved in array format, it will not reload the value after conditional viewing/hiding.
 			$date = "{$hour}:{$minute} {$ampm}";
 		} elseif ( $this->_args['enable_i18n'] ) {
-			$date = strftime( $format, $timestamp );
+			$date = ( new DateTime() )->setTimestamp( $timestamp )->format( $format );
+
 		} else {
 			$date = date( $format, $timestamp );
 		}

--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -249,7 +249,7 @@ class GW_Populate_Date {
 			// If saved in array format, it will not reload the value after conditional viewing/hiding.
 			$date = "{$hour}:{$minute} {$ampm}";
 		} elseif ( $this->_args['enable_i18n'] ) {
-			$date = ( new DateTime() )->setTimestamp( $timestamp )->format( $format );
+			$date = wp_date( $format, $timestamp );
 
 		} else {
 			$date = date( $format, $timestamp );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2966564752/85024

## Summary

The  `strftime` function, which is used in the Populate Dates snippet, is deprecated as of PHP 8.1.0 (reference: https://www.php.net/manual/en/function.strftime.php)

Also, it will be removed from PHP 9.0 (reference: https://php.watch/versions/8.1/strftime-gmstrftime-deprecated).

Time to move on!
