### PR TITLE
`gpcc-copy-option-to-checkbox.js`: Added a snippet to copy Option field selected value to Checkbox field.

### DIFF
--- a/gp-copy-cat/gpcc-copy-option-to-checkbox.js
+++ b/gp-copy-cat/gpcc-copy-option-to-checkbox.js
@@ -4,7 +4,7 @@
  *
  * Use this snippet to copy option field value to a Checkbox field.
  *
- * Screenshot: https://gwiz.io/3wWlUts
+ * Instructions Video: https://www.loom.com/share/0897b49b88ca43be9590e2aef13de50a
  *
  * Instructions:
  * 

--- a/gp-copy-cat/gpcc-copy-option-to-checkbox.js
+++ b/gp-copy-cat/gpcc-copy-option-to-checkbox.js
@@ -1,0 +1,29 @@
+/**
+ * Gravity Perks // Copy Cat // Copy Option to Checkbox
+ * https://gravitywiz.com/documentation/gravity-forms-copy-cat/
+ *
+ * Use this snippet to copy option field value to a Checkbox field.
+ *
+ * Screenshot: https://gwiz.io/3wWlUts
+ *
+ * Instructions:
+ * 
+ * 1. Install this snippet with our free Code Chest plugin.
+ *    https://gravitywiz.com/gravity-forms-code-chest/
+ */
+gform.addFilter('gpcc_copied_value', function(value, $elem, data) {
+	if (!data || !data.sourceFormId || !data.source) {
+		return value;
+	}
+
+	const sourcefieldId = '#field_' + data.sourceFormId + '_' + data.source;
+	const $sourceField = $(sourcefieldId);
+
+	if ($sourceField.length && $sourceField.hasClass('gfield--type-option')) {
+		if (Array.isArray(value)) {
+			value = value.map(item => typeof item === 'string' ? item.split('|')[0] : item);
+		}
+	}
+
+	return value;
+});


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2973256443/85365

## Summary

Make the Option field compatible to be used with [GP Copy Cat](https://gravitywiz.com/documentation/gravity-forms-copy-cat/) and a receiving Checkbox field.

https://www.loom.com/share/0897b49b88ca43be9590e2aef13de50a
