### PR TITLE
`gw-gravity-forms-rounding.php`: Fixed an issue with rounding now updating form total.

### DIFF
--- a/gravity-forms/gw-gravity-forms-rounding.php
+++ b/gravity-forms/gw-gravity-forms-rounding.php
@@ -189,6 +189,9 @@ class GW_Rounding {
 						var value = self.getRoundedValue( $input );
 						if( $input.val() != value ) {
 							$input.val( value ).change();
+							const input = $input[0];
+							// Ensure Gravity Forms detects the programmatic value change by dispatching a native input event
+							input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 						}
 					};
 
@@ -216,7 +219,7 @@ class GW_Rounding {
 
 						}
 
-						if( value != '' ) {
+						if( value !== '' ) {
 							for( var i = 0; i < actions.length; i++ ) {
 								value = GWRounding.round( value, actions[i].actionValue, actions[i].action );
 							}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2981539269/85760

## Summary

The GF Rounding snippet isn't working as expected.

**ISSUE 1**
_**The minimum rounding doesn't work when the value is entered. It works only when you're using the number field controls to increase or decrease the value.**_
We had `if( value != '' )`, which we changed to `if( value !== '' )`
Switching from loose inequality (`!=`) to strict inequality (`!==`) to prevent unintended type coercion. This ensures that numeric 0 and empty string '' are treated as distinct values during comparison. With `!=`, javascript converts `0 != ''` as a numeric comparison with both values as `0`.

**ISSUE 2**
_**When the rounding is applied to a quantity value, it doesn't update the total.**_
Using `$input.val( value ).change();` alone wasn’t enough to trigger Gravity Forms' total recalculation in some cases. Gravity Forms listens for native input events on fields like quantity and product fields for live calculations. We add a native input event dispatch after setting the value, ensuring Gravity Forms detects the change and recalculates totals as if the user had typed the value manually.

**BEFORE** (Samuel's loom):
https://www.loom.com/share/c94f0966f80f495db537dc68e7d5da81

**AFTER**:
https://www.loom.com/share/b012dd305bdb4ed1b800c2ef3957bcf9
