### PR TITLE
`gppa-disable-gfml-pre-render-callback.php`: Fixed an issue with snippet not working for newer versions of GPML.

### DIFF
--- a/gp-populate-anything/gppa-disable-gfml-pre-render-callback.php
+++ b/gp-populate-anything/gppa-disable-gfml-pre-render-callback.php
@@ -36,5 +36,6 @@ add_action( 'init', function () {
 	}
 
 	remove_filter( 'gform_pre_render', array( $GLOBALS['wpml_gfml_tm_api'], 'gform_pre_render' ) );
+	remove_filter( 'gform_merge_tag_filter', array( $GLOBALS['wpml_gfml_tm_api'], 'gform_merge_tag_filter' ) );
 
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2975924505/85517

## Summary

The value modifier of a merge tag doesn't work when WPML String translations is activated, even when using this [snippet](https://gravitywiz.com/snippet-library/gppa-disable-gfml-pre-render-callback/).

It seems we need to also target `gform_merge_tag_filter` in the disable logic, probably applicable for the newer versions of GFML.

**BEFORE**:
<img width="200" alt="Screenshot 2025-06-30 at 3 34 05 PM" src="https://github.com/user-attachments/assets/d6908bb6-3608-40c3-8120-2abaa20e9a0e" />

**AFTER**:
<img width="200" alt="Screenshot 2025-06-30 at 3 33 46 PM" src="https://github.com/user-attachments/assets/fed9cc12-2a6d-4340-acbf-eb6c56ddb992" />
