### PR TITLE
`gpnf-sort-nested-form-entries.php`: Added support for sorting by Date fields.

### DIFF
--- a/gp-nested-forms/gpnf-sort-nested-form-entries.php
+++ b/gp-nested-forms/gpnf-sort-nested-form-entries.php
@@ -119,10 +119,13 @@ class GPNF_Sort_Nested_Entries {
 							const dateA = new Date(valA);
 							const dateB = new Date(valB);
 
+							const timeA = isNaN(dateA.getTime()) ? 0 : dateA.getTime();
+							const timeB = isNaN(dateB.getTime()) ? 0 : dateB.getTime();
+
 							if (sortOrder === 'desc') {
-								return dateB - dateA;
+								return timeB - timeA;
 							}
-							return dateA - dateB;
+							return timeA - timeB;
 						}
 
 						if (sortOrder === 'desc') {

--- a/gp-nested-forms/gpnf-sort-nested-form-entries.php
+++ b/gp-nested-forms/gpnf-sort-nested-form-entries.php
@@ -65,8 +65,11 @@ class GPNF_Sort_Nested_Entries {
 				}
 
 				if ( $this->_is_date_field ) {
-					$first  = strtotime( $first );
-					$second = strtotime( $second );
+					$first_time  = strtotime( $first );
+					$second_time = strtotime( $second );
+
+					$first  = ( $first_time  !== false ) ? $first_time  : 0;
+					$second = ( $second_time !== false ) ? $second_time : 0;
 				}
 
 				if ( $order === 'asc' ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2995555966/86254?viewId=3808239

## Summary

**Issue:** Date fields were being sorted alphabetically instead of chronologically, causing unexpected ordering (see [Matt's loom](https://www.loom.com/share/52ed275489a54b75be2f63727fdecdd2))

Snippet now automatically detects date fields and sorts them chronologically.