### PR TITLE
`gw-force-default-value.php`: Added compatibility for date and time fields with force default value snippet.

### DIFF
--- a/gravity-forms/gw-force-default-value.php
+++ b/gravity-forms/gw-force-default-value.php
@@ -80,10 +80,14 @@ class GW_Force_Default_Value {
 				continue;
 			}
 
-			$value = GFCommon::replace_variables( $value, $form, $entry );
+			$value = is_string( $value ) ? GFCommon::replace_variables( $value, $form, $entry ) : $value;
 
 			if ( $value != $entry_value ) {
 				$requires_update     = true;
+				// For array based values like Date Field and Time Field.
+				if ( is_array( $value ) ) {
+					$value = $field->get_value_save_entry( $value, $form, null, null, null );
+				}
 				$entry[ $field->id ] = $value;
 			}
 		}
@@ -109,7 +113,7 @@ class GW_Force_Default_Value {
 			return $text;
 		}
 		$chars = str_split( trim( $text ) );
-		if ( $chars[0] === '{' && $chars[ count( $chars ) - 1 ] === '}' ) {
+		if ( rgar( $chars, 0 ) === '{' && rgar( $chars, count( $chars ) - 1 ) === '}' ) {
 			$text = '';
 		}
 		return $text;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3005790586/86637

## Summary

✅ Fixed some potential warnings.
✅ Added compatibility for Date and Time (array based field data).

**BEFORE (none of the hidden field data was getting populated, and fatal error/warnings)**:
<img width="509" height="119" alt="Screenshot 2025-07-18 at 5 18 45 PM" src="https://github.com/user-attachments/assets/717e2ebf-5406-42be-a4e9-022282d7cba9" />

**AFTER (all data populates correctly)**:
<img width="516" height="111" alt="Screenshot 2025-07-18 at 5 18 56 PM" src="https://github.com/user-attachments/assets/8e8592a0-94d6-464b-a0c4-75aa26b454d1" />
