### PR TITLE
`gpnf-sort-nested-form-entries.php`: Fixed date field sorting for European formats

### DIFF
--- a/gp-nested-forms/gpnf-sort-nested-form-entries.php
+++ b/gp-nested-forms/gpnf-sort-nested-form-entries.php
@@ -115,8 +115,14 @@ class GPNF_Sort_Nested_Entries {
 					}
 
 					return entries.sort((a, b) => {
-						let valA = a[sortFieldId]?.label || '';
-						let valB = b[sortFieldId]?.label || '';
+						let valA, valB;
+						if (isDateField) {
+							valA = a[sortFieldId]?.value || '';
+							valB = b[sortFieldId]?.value || '';
+						} else {
+							valA = a[sortFieldId]?.label || '';
+							valB = b[sortFieldId]?.label || '';
+						}
 
 						if (isDateField) {
 							const dateA = new Date(valA);


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2995555966/86254?viewId=8172236

## Summary

**Issue:** Date field sorting failed when using European formats like `dd.mm.yyyy`

**Fix:** Use the standardized `value` property for date fields instead of the formatted `label` property.