### PR TITLE
`gw-cache-buster.php`: Fixed an issue where form validation would fail when Cache Buster was enabled globally.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -285,6 +285,10 @@ class GW_Cache_Buster {
 	}
 
 	public function is_cache_busting_applicable() {
+		if ( isset( $_POST['gform_submit'] ) ) {
+			return false;
+		}
+		
 		// POSTED and LOGGED-IN requests are not typically cached
 		return empty( $_POST ) || ! is_user_logged_in();
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2998377368/86389?viewId=8172236

## Summary

**Issue:** When Cache Buster is enabled via the `gfcb_enable_cache_buster` filter, Cache Buster is forced to run on every form render, including the one during the validation request, which causes the issue. Whereas when Cache Buster is enabled via the shortcode attribute, form validation worked correctly since during Gravity Forms' validation request, it re-renders the form without re-evaluating the original shortcode attributes and therefor Cache Buster does not run.

**Fix:** Add a new check for `$_POST['gform_submit']` inside the `is_cache_busting_applicable()` method. This will detect form submissions and disable Cache Buster to ensure Gravity Forms validation process can complete successfully.