### PR TITLE
`gw-cache-buster.php`: Fixed an issue with Cache Buster causing conflict with GP Entry Blocks on editing entries.

### DIFF
--- a/gravity-forms/gw-cache-buster.php
+++ b/gravity-forms/gw-cache-buster.php
@@ -9,7 +9,7 @@
  * Plugin URI:  https://gravitywiz.com/cache-busting-with-gravity-forms/
  * Description: Bypass your website cache when loading a Gravity Forms form.
  * Author:      Gravity Wiz
- * Version:     0.6.5
+ * Version:     0.6.6
  * Author URI:  https://gravitywiz.com
  */
 class GW_Cache_Buster {
@@ -104,8 +104,8 @@ class GW_Cache_Buster {
 	}
 
 	public function form_filter( $markup, $form ) {
-		// Prevent recursion.
-		if ( rgar( $GLOBALS, 'processing' ) ) {
+		// Prevent recursion, and ensure we're not editing an entry via GP Entry Blocks.
+		if ( rgar( $GLOBALS, 'processing' ) || rgget( 'edit_entry' ) ) {
 			return $markup;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3019129686/87078

## Summary

When Cache Buster active, clicking the edit button on Entry Blocks creates a new entry instead of updating the existing one.

**BEFORE**:
https://www.loom.com/share/19d881969a4640259a4838ce8deb9e65


**AFTER**:
https://www.loom.com/share/0bbe4985606f4aa5a8067e71fae6e2dc
