### PR TITLE
`gw-require-unique-values.php`: Added support for whole-field validation for multi-input fields.

### DIFF
--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -52,6 +52,10 @@ class GW_Require_Unique_Values {
 		add_filter( sprintf( 'gform_field_validation_%s', $this->_args['form_id'] ), array( $this, 'validate' ), 10, 4 );
 	}
 
+	private function get_all_field_ids() {
+		return array_merge( $this->_args['field_ids'], array( $this->_args['master_field_id'] ) );
+	}
+
 	public function validate( $result, $value, $form, $field ) {
 
 		if ( ! $this->is_applicable_field( $field ) ) {
@@ -84,7 +88,7 @@ class GW_Require_Unique_Values {
 			$values = $this->get_group_values( $form, $field->id );
 
 			// Check if this should be validated as whole field
-			$all_field_ids = array_merge( $this->_args['field_ids'], array( $this->_args['master_field_id'] ) );
+			$all_field_ids = $this->get_all_field_ids();
 			$validate_as_whole = in_array( $field->id, $all_field_ids );
 
 			// If the field has inputs, let's loop through them and check if they are unique.
@@ -200,7 +204,7 @@ class GW_Require_Unique_Values {
 
 		// When using a field ID (not input ID) for multi-input fields, combine all subfield values into one for validation.
 		if ( ! $input_id && is_array( $field->inputs ) && is_array( $value ) ) {
-			$all_field_ids = array_merge( $this->_args['field_ids'], array( $this->_args['master_field_id'] ) );
+			$all_field_ids = $this->get_all_field_ids();
 			if ( in_array( $field->id, $all_field_ids ) ) {
 				$combined_parts = array();
 				foreach ( $field->inputs as $input ) {

--- a/gravity-forms/gw-require-unique-values.php
+++ b/gravity-forms/gw-require-unique-values.php
@@ -11,7 +11,7 @@
  * Plugin URI:   https://gravitywiz.com/gravity-forms-require-unique-values-for-different-fields/
  * Description:  Require two or more fields on the same form to be different from each other.
  * Author:       Gravity Wiz
- * Version:      0.2
+ * Version:      0.3
  * Author URI:   https://gravitywiz.com/
  */
 class GW_Require_Unique_Values {
@@ -83,8 +83,12 @@ class GW_Require_Unique_Values {
 		} else {
 			$values = $this->get_group_values( $form, $field->id );
 
+			// Check if this should be validated as whole field
+			$all_field_ids = array_merge( $this->_args['field_ids'], array( $this->_args['master_field_id'] ) );
+			$validate_as_whole = in_array( $field->id, $all_field_ids );
+
 			// If the field has inputs, let's loop through them and check if they are unique.
-			if ( is_array( $field->inputs ) && ! empty( $field->inputs ) ) {
+			if ( is_array( $field->inputs ) && ! empty( $field->inputs ) && ! $validate_as_whole ) {
 				$is_unique = true;
 
 				foreach ( $field->inputs as $input ) {
@@ -192,6 +196,21 @@ class GW_Require_Unique_Values {
 
 		if ( $input_id && is_array( $value ) && isset( $value[ $input_id ] ) ) {
 			$value = $value[ $input_id ];
+		}
+
+		// When using a field ID (not input ID) for multi-input fields, combine all subfield values into one for validation.
+		if ( ! $input_id && is_array( $field->inputs ) && is_array( $value ) ) {
+			$all_field_ids = array_merge( $this->_args['field_ids'], array( $this->_args['master_field_id'] ) );
+			if ( in_array( $field->id, $all_field_ids ) ) {
+				$combined_parts = array();
+				foreach ( $field->inputs as $input ) {
+					$input_value = rgar( $value, $input['id'] );
+					if ( ! empty( $input_value ) ) {
+						$combined_parts[] = $input_value;
+					}
+				}
+				$value = array( implode( ' ', $combined_parts ) );
+			}
 		}
 
 		$value = ! is_array( $value ) ? array( $value ) : $value;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3019475786/87093?viewId=8172236

## Summary

**Original issue/feature request:** https://www.loom.com/share/7efd82e759514e21866854c87a802f2a (By Matt A.)

This adds support for allowing multi-input fields to be validated as a single, combined value.

**Quick loom showing new feature:** https://www.loom.com/share/22a0b59a9b6f46c69f708621f78d507b
