### PR TITLE
`gpppw-capture-count-as-field-value.js`: Fixed an issue with snippet not working with Conditional Logic in play.

### DIFF
--- a/gp-pay-per-word/gpppw-capture-count-as-field-value.js
+++ b/gp-pay-per-word/gpppw-capture-count-as-field-value.js
@@ -9,6 +9,13 @@
  * [1]: https://gravitywiz.com/gravity-forms-code-chest/
  */
 gform.addFilter( 'gpppw_word_count', function( wordCount ) {
-  // Update "4" to the ID of the field which should be populated with the word count.
-	$( '#input_GFFORMID_4' ).val( wordCount ).change();
+	// Update "2" to the ID of the field which should be populated with the word count.
+	var $field = $( '#input_GFFORMID_2' );
+
+	// Only update if value is actually different
+		if ( $field.val() != wordCount ) {
+		$field.val( wordCount).change();
+	}
+
+	return wordCount;
 }, 11 );

--- a/gp-pay-per-word/gpppw-capture-count-as-field-value.js
+++ b/gp-pay-per-word/gpppw-capture-count-as-field-value.js
@@ -13,8 +13,8 @@ gform.addFilter( 'gpppw_word_count', function( wordCount ) {
 	var $field = $( '#input_GFFORMID_2' );
 
 	// Only update if value is actually different
-		if ( $field.val() != wordCount ) {
-		$field.val( wordCount).change();
+	if ( $field.val() != wordCount ) {
+		$field.val( wordCount ).change();
 	}
 
 	return wordCount;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3028599571/87494

## Summary

When using the gpppw_word_count snippet to populate a text field with the word count from a paragraph field, we relied on triggering the `.change()` event to ensure that the value could be used in Gravity Forms conditional logic. However, this approach caused a JavaScript error — specifically `Uncaught RangeError: Maximum call stack size exceeded` — which ultimately prevented the form from loading in the browser.

The root cause was that `.change()` was being triggered even when the field value hadn’t changed. Since that field was used in conditional logic, Gravity Forms repeatedly re-evaluated conditions and retriggered the same logic, leading to an infinite loop.

This PR proposes to add a check to compare the existing value of the field `#input_GFFORMID_2` with the new `wordCount`. The `.change()` event is now only triggered when the new value differs from the current one, preventing unnecessary logic execution and recursive event loops.

By avoiding redundant `.change()` triggers, we prevent conditional logic from being re-applied unnecessarily. This breaks the recursive chain and ensures the form loads and functions correctly without JavaScript errors.

**BEFORE** (Samuel):
https://www.loom.com/share/5d47f02f47b24e39a619fe4e6959ffab

**AFTER**:
https://www.loom.com/share/ffee4fdb11694477a633fa424a0e1ec0


