### PR TITLE
Tooling: Fixed PHPCS check.

### DIFF
--- a/.github/workflows/php-lint-pr.yml
+++ b/.github/workflows/php-lint-pr.yml
@@ -12,9 +12,11 @@ jobs:
           fetch-depth: 0 # The blame will not work without this
 
       # PHP 8 will throw PHP Fatal error: Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given in ...
-      - uses: nanasess/setup-php@v4.1.0
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          tools: composer:v2
+          coverage: none
 
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
## Context

The PHPCS check was failing

## Summary

* Newer GH action runners don't have `apt-fast` installed (or aliased to `apt`). Updates `nanasess/setup-php` to version 4.1.0 which accounts for that change.
* Also updates `actions/checkout` to version 5. Unrelated to the above, but just for house keeping purposes.
