### PR TITLE
`gwpc-post-image-subfields.php`: Added snippet to enable word count for Post Image subfields.

### DIFF
--- a/gp-word-count/gwpc-post-image-subfields.php
+++ b/gp-word-count/gwpc-post-image-subfields.php
@@ -56,7 +56,7 @@ class GW_Post_Image_Word_Count {
 	public function get_subfields() {
 		return array(
 			'caption'     => array(
-				'suffix' => '4', 
+				'suffix' => '4',
 				'label'  => __( 'Caption', 'gravityforms' ),
 			),
 			'description' => array(
@@ -64,11 +64,11 @@ class GW_Post_Image_Word_Count {
 				'label'  => __( 'Description', 'gravityforms' ),
 			),
 			'alt'         => array(
-				'suffix' => '2', 
+				'suffix' => '2',
 				'label'  => __( 'Alt Text', 'gravityforms' ),
 			),
 			'title'       => array(
-				'suffix' => '1', 
+				'suffix' => '1',
 				'label'  => __( 'Title', 'gravityforms' ),
 			),
 		);


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3033697344/87708

## Summary

Use GP Word Count to count the words entered in the subfields (caption, description, alt text, title) of a Post Image field.

Loom:
https://www.loom.com/share/005eda834a6348f9a874a5e6cdd85461
