### PR TITLE
`gpecf-deduct-deposit.php`: Fixed an issue where disabled deposit field caused issues with calculations.

### DIFF
--- a/gp-ecommerce-fields/gpecf-deduct-deposit.php
+++ b/gp-ecommerce-fields/gpecf-deduct-deposit.php
@@ -72,6 +72,11 @@ class GW_Deduct_Deposit {
 					self.init = function() {
 						gform.addFilter( 'gform_product_total', function( total, formId ) {
 							if ( formId == self.formId ) {
+								// If deposit is disabled or hidden, return total as it is.
+								if ( $( 'input[name="input_' + self.depositFieldId + '.2"]' ).is( ':disabled' ) ) {
+									return total;
+								}
+								
 								var depositPrice    = $( 'input[name="input_' + self.depositFieldId + '.2"]' ).val();
 								var depositQuantity = $( 'input[name="input_' + self.depositFieldId + '.3"]' ).val();
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3042483189/88050

## Summary

The snippet to use a product field to deduct deposit is causing GF to display incorrect calculations on the frontend when the Deposit field is conditionally hidden.

**BEFORE** (Credits Samuel):
https://www.loom.com/share/ad6470f9886c4a0983e253b23b796cd0

**AFTER**:
https://www.loom.com/share/4448c9551ec246c4b8756e3a64e839c0
