### PR TITLE
`gw-update-posts.php`: Fixed an issue with snippet not working in some scenarios.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -358,7 +358,7 @@ class GW_Update_Posts {
 	 */
 	public function return_ids_instead_of_names( $value, $field, $template_name, $populate, $object, $object_type, $objects, $template ) {
 		// Check if this is for the specific form we want.
-		if ( $field->formId != $this->_args['form_id'] ) {
+		if ( rgar( $field, 'formId' ) != $this->_args['form_id'] ) {
 			return $value;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s):https://secure.helpscout.net/conversation/3048075959/88266

## Summary

The Update Posts (https://gravitywiz.com/snippet-library/gw-update-posts/) snippet is deactivating automatically due to an error on line 360-361 with WPCode snippets. Use `rgar` instead and it fixes the issue.
