### PR TITLE
`gpi-show-inventory-only-for-logged-in-users.php`: Added snippet to show available inventory message only for logged in user.

### DIFF
--- a/gp-inventory/gpi-show-inventory-only-for-logged-in-users.php
+++ b/gp-inventory/gpi-show-inventory-only-for-logged-in-users.php
@@ -2,7 +2,7 @@
 /**
  * Gravity Perks // Inventory // Show Inventory Only For Logged In users
  * https://gravitywiz.com/documentation/gravity-forms-inventory/
- * 
+ *
  * Instruction Video: https://www.loom.com/share/2d9843302a54456987ed2c66a83612ba
  *
  * By default the inventory available is shown for everyone, if enabled.

--- a/gp-inventory/gpi-show-inventory-only-for-logged-in-users.php
+++ b/gp-inventory/gpi-show-inventory-only-for-logged-in-users.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Gravity Perks // Inventory // Show Inventory Only For Logged In users
+ * https://gravitywiz.com/documentation/gravity-forms-inventory/
+ * 
+ * Instruction Video: https://www.loom.com/share/2d9843302a54456987ed2c66a83612ba
+ *
+ * By default the inventory available is shown for everyone, if enabled.
+ * Use this filter to show the inventory available only for logged in users.
+ */
+add_filter( 'gpi_inventory_available_message', function( $message ) {
+	if ( is_user_logged_in() ) {
+		return $message;
+	}
+	return '';
+} );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3048324137/88279/

## Summary

Show Inventory Only For Logged In users only.

https://www.loom.com/share/2d9843302a54456987ed2c66a83612ba