### PR TITLE
`gprf-clear-specific-field-values-on-reload.php`: Fixed an issue where checkbox and file upload field values were not cleared as expected when reloading the form.

### DIFF
--- a/gp-reload-form/gprf-clear-specific-field-values-on-reload.php
+++ b/gp-reload-form/gprf-clear-specific-field-values-on-reload.php
@@ -9,12 +9,41 @@
  */
 // Update "123" to your form ID.
 add_filter( 'gprf_disable_dynamic_reload_123', function( $return ) {
-	function gprf_clear_specific_field_values( $return ) {
-		// Update "3" to the ID of the field for whose value you would like to clear.
-		$_POST['input_3'] = '';
-		remove_filter( 'gform_pre_render', 'gprf_clear_specific_field_values' );
-		return $return;
-	}
-	add_filter( 'gform_pre_render', 'gprf_clear_specific_field_values' );
+
+	$form_id         = 123;
+	$fields_to_clear = array( 2, 3, 4 ); // array of field IDs to clear
+
+	add_filter( 'gform_pre_render_' . $form_id, function( $form ) use ( $fields_to_clear ) {
+
+		foreach ( $fields_to_clear as $field_id ) {
+			$field = GFAPI::get_field( $form, $field_id );
+
+			if ( ! $field ) {
+				continue; // skip if field not found
+			}
+
+			if ( $field->type === 'checkbox' ) {
+				foreach ( $_POST as $key => $value ) {
+					if ( strpos( $key, "input_{$field_id}" ) === 0 ) {
+						$_POST[ $key ] = '';
+					}
+				}
+			} elseif ( $field->type === 'fileupload' ) {
+				if ( isset( $_POST['gform_uploaded_files'] ) ) {
+					$uploaded_files = json_decode( stripslashes( $_POST['gform_uploaded_files'] ), true );
+					if ( isset( $uploaded_files[ "input_{$field_id}" ] ) ) {
+						unset( $uploaded_files[ "input_{$field_id}" ] );
+						$_POST['gform_uploaded_files'] = wp_json_encode( $uploaded_files );
+					}
+				}
+				GFFormsModel::$uploaded_files[ $form['id'] ][ "input_{$field_id}" ] = array();
+			} else {
+				$_POST[ "input_{$field_id}" ] = '';
+			}
+		}
+
+		return $form;
+	} );
+
 	return $return;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3053111690/88474

## Summary

Fixed an issue where checkbox and file upload field values were not cleared as expected when reloading the form.