### PR TITLE
`gpi-populate-days.php`: Added new snippet.

### DIFF
--- a/gp-inventory/gpi-populate-days.php
+++ b/gp-inventory/gpi-populate-days.php
@@ -61,19 +61,19 @@ function gw_populate_days_into_radio( $form ) {
 			$start_day = new DateTime( 'this ' . $day );
 
 			// If it's past the cutoff, also skip this week's day
-			if ( ( $today->format( 'N' ) == $cutoff_day && ( int )$today->format( 'H' ) >= $cutoff_time ) || $today->format( 'N' ) > $cutoff_day && $today->format( 'N' ) <= $start_day->format( 'N' ) ) {
+			if ( ( $today->format( 'N' ) == $cutoff_day && (int) $today->format( 'H' ) >= $cutoff_time ) || $today->format( 'N' ) > $cutoff_day && $today->format( 'N' ) <= $start_day->format( 'N' ) ) {
 				$start_day->modify( '+1 week' );
 			}
 
 			// Generate next n days
 			for ( $i = 0; $i < $number_of_days; $i++ ) {
 				$label     = $start_day->format( $format );
-				$choices[] = array( 
+				$choices[] = array(
 					'text'            => $label,
 					'value'           => $label,
 					'inventory_limit' => $inventory,
 				);
-				$start_day->modify('+1 week');
+				$start_day->modify( '+1 week' );
 			}
 
 			$field->choices = $choices;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3049406579/88333?viewId=7627047

## Summary

Added new snippet that will populate a Radio field with the next 10 Thursdays, and assign each choice an inventory of 25. It's customizable to use for other days, and includes the ability to set a cutoff day and time for populating the current week's day.
