### PR TITLE
`gpuid-dynamic-population.php`: Fixed an issue where dynamically populating Unique ID in Nested Forms caused memory exhaustion.

### DIFF
--- a/gp-unique-id/gpuid-dynamic-population.php
+++ b/gp-unique-id/gpuid-dynamic-population.php
@@ -11,6 +11,13 @@
  */
 add_filter( 'gform_field_value_uid', function( $value, $field ) {
 
+	static $processing = array();
+	$key = $field->formId . '_' . $field->id;
+	if ( isset( $processing[ $key ] ) ) {
+		return $value;
+	}
+	$processing[ $key ] = true;
+
 	// Update what type of unique ID you would like to generate. Accepts 'alphanumeric', 'numeric', or 'sequential'.
 	$type_of_id = 'alphanumeric';
 
@@ -28,5 +35,6 @@ add_filter( 'gform_field_value_uid', function( $value, $field ) {
 		$value = $gw_uid;
 	}
 
+	unset( $processing[ $key ] );
 	return $value;
 }, 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3056792565/88583?viewId=8172236

## Summary

The `gform_field_value_uid` filter was being called recursively when dynamically populating unique IDs in GP Nested Forms, resulting in memory exhaustion.

Here's Samuel's loom showing the issue: https://www.loom.com/share/123f6ad1e9ab4e3ab55ae7d1328cb835

**Fix:** Added recursion protection to prevent infinite filter calls