### PR TITLE
`gpps-live-refresh.php`: Fixed an issue with GPPS Live Refresh with Radio Button field.

### DIFF
--- a/gp-preview-submission/gpps-live-refresh.php
+++ b/gp-preview-submission/gpps-live-refresh.php
@@ -88,7 +88,16 @@ class GPPS_Live_Refresh {
 						};
 
 						self.$form.find( 'input, select, textarea' ).each( function() {
-							data[ $( this ).attr( 'name' ) ] = $( this ).val();
+							var $input = $( this ),
+								name   = $input.attr( 'name' );
+
+							if ( $input.is(':radio') ) {
+								if ( $input.is(':checked') ) {
+									data[name] = $input.val();
+								}
+							} else {
+								data[name] = $input.val();
+							}
 						} );
 
 						$.post( self.ajaxUrl, data, function( response ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3059656764/88676

## Summary

The Live Update snippet for GPPS is not working with Radio fields, added a case for that.
