### PR TITLE
`gw-gravity-forms-rename-uploaded-files.php`: Fixed an issue where renamed multi-file uploads in Nested Forms became malformed after editing the child entry.

### DIFF
--- a/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
+++ b/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
@@ -98,6 +98,11 @@ class GW_Rename_Uploaded_Files {
 
 				$result = rename( $file, $renamed_file );
 
+				if ( ! $result ) {
+					$renamed_files[] = $_file;
+					continue;
+				}
+
 				$renamed_url = $this->get_url_by_path( $renamed_file, $form['id'] );
 				$renamed_files[] = $renamed_url;
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3049464511/88344?viewId=8172236

## Summary

**Issue:** When users used the Rename Uploaded Files snippet on a multi-file upload field inside a Nested Form, filenames were correctly renamed when adding the child entry, but if the user then edited the child entry and saved, the filename became malformed.

This happened because GF's stored path metadata referenced the original URL instead of the URL of our renamed file. On edit, GF couldn't find the path info for the renamed URL and fell back to deriving a filename from the full URL, which after sanitization produced the long incorrect basename.

**Fix:** Immediately after each file is renamed, we now also write GF's file path meta for the new URL.

Quick before and after: https://www.loom.com/share/297e7afb604c4e9788ca24eb451b8fcf