### PR TITLE
`gw-conditional-logic-operator-is-in.php`: Added GPCP CSV Import support for `is_in` operator.

### DIFF
--- a/gravity-forms/gw-conditional-logic-operator-is-in.php
+++ b/gravity-forms/gw-conditional-logic-operator-is-in.php
@@ -31,7 +31,7 @@ class GF_CLO_Is_In {
 		add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ), 10, 2 );
 		add_filter( 'gform_is_value_match', array( $this, 'evaluate_operator' ), 10, 6 );
 
-		// Add support for Conditional Pricing import operators
+		// Add support for GP Conditional Pricing import operators
 		if ( class_exists( 'GP_Conditional_Pricing' ) ) {
 			add_filter( 'gpcp_supported_import_operators', array( $this, 'add_import_operator' ) );
 		}
@@ -205,7 +205,16 @@ class GF_CLO_Is_In {
 		return GFFormDisplay::has_conditional_logic( $form );
 	}
 
-	// Register 'is_in' operator for GP Conditional Pricing CSV imports.
+	/**
+	 * Register CSV import operator(s) for GP Conditional Pricing.
+	 *
+	 * Maps the "~" token to the internal 'is_in' operator.
+	 *
+	 * @param array $operators Operator map of CSV token => internal operator.
+	 * @return array
+	 * 
+	 *  @since 1.2
+	 */
 	public function add_import_operator( $operators ) {
 		$operators['~'] = 'is_in';
 		return $operators;

--- a/gravity-forms/gw-conditional-logic-operator-is-in.php
+++ b/gravity-forms/gw-conditional-logic-operator-is-in.php
@@ -10,7 +10,7 @@
  * Plugin URI:   https://gravitywiz.com/
  * Description:  Check if a source value is in a comma-delimited list of values.
  * Author:       Gravity Wiz
- * Version:      1.1
+ * Version:      1.2
  * Author URI:   https://gravitywiz.com
  */
 class GF_CLO_Is_In {
@@ -30,6 +30,11 @@ class GF_CLO_Is_In {
 		add_filter( 'gform_pre_render', array( $this, 'load_form_script' ), 10, 2 );
 		add_filter( 'gform_register_init_scripts', array( $this, 'add_init_script' ), 10, 2 );
 		add_filter( 'gform_is_value_match', array( $this, 'evaluate_operator' ), 10, 6 );
+
+		// Add support for Conditional Pricing import operators
+		if ( class_exists( 'GP_Conditional_Pricing' ) ) {
+			add_filter( 'gpcp_supported_import_operators', array( $this, 'add_import_operator' ) );
+		}
 
 	}
 
@@ -198,6 +203,12 @@ class GF_CLO_Is_In {
 	public function is_applicable_form( $form ) {
 		// @todo we will need to recursively search conditional logic for "is in" operator (see GPCLD).
 		return GFFormDisplay::has_conditional_logic( $form );
+	}
+
+	// Register 'is_in' operator for GP Conditional Pricing CSV imports.
+	public function add_import_operator( $operators ) {
+		$operators['~'] = 'is_in';
+		return $operators;
 	}
 
 }


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3056241699/88571?viewId=8172236

## Summary

This PR adds `is_in` as a custom import operator to GP Conditional Pricing. This goes hand-in-hand with another new [PR for GPCP](https://github.com/gravitywiz/gwconditionalpricing/pull/76), which adds the `gpcp_supported_import_operators` filter.