### PR TITLE
`gw-draft-resume-change-notice.php`: Added new snippet that displays a notice when a user resumes draft from a new IP/UA.

### DIFF
--- a/gravity-forms/gw-draft-resume-change-notice.php
+++ b/gravity-forms/gw-draft-resume-change-notice.php
@@ -15,8 +15,8 @@ add_filter( 'gform_get_form_filter', function( $form_markup, $form ) {
 	global $wpdb;
 	$table = GFFormsModel::get_draft_submissions_table_name();
 
-    // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	$draft = $wpdb->get_row(
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$wpdb->prepare(
 			sprintf(
 				'SELECT form_id, ip, submission FROM `%s` WHERE uuid = %%s',


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3062075880/88769?viewId=3808239

## Summary

A new snippet to display a notice on top of the form when a saved draft is resumed from a different IP address and/or User-Agent than the one that created or last edited it.

<img width="710" height="427" alt="image" src="https://github.com/user-attachments/assets/ec1c15f2-cc64-4d36-9b2a-301cb25e42ce" />