### PR TITLE
`gpnf-sortable-entries.php`: Fixed an issue where duplicated entries appeared in sortable child entries.

### DIFF
--- a/gp-nested-forms/gpnf-sortable-entries.php
+++ b/gp-nested-forms/gpnf-sortable-entries.php
@@ -112,11 +112,16 @@ class GPNF_Sortable_Entries {
 		// Sort $args['entries'] which contains Gravity Forms entries arrays. They contain an 'id' key.
 		// $cookie_entries contains the entry IDs in the order they should be displayed.
 		$sorted_entries = array();
+		$valid_entry_ids = array();
 
 		foreach ( $cookie_entries as $entry_id ) {
+			$entry_id_str = (string) $entry_id;
+
 			foreach ( $args['entries'] as $entry ) {
-				if ( $entry['id'] == $entry_id ) {
+				// Use strict comparison and prevent duplicates
+				if ( (string) $entry['id'] === $entry_id_str && ! in_array( $entry_id_str, $valid_entry_ids, true ) ) {
 					$sorted_entries[] = $entry;
+					$valid_entry_ids[] = $entry_id_str;
 					break;
 				}
 			}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3069089927/89053?viewId=3808239

## Summary

When using GP Nested Forms with both sortable entries and duplication features enabled, extra child entries would appear after duplicating an entry, editing it, and navigating between form pages.

Quick loom showing issue: https://www.loom.com/share/246831998d5344c6bfdc937cca04b470

The issue was that entry IDs were stored in different formats (strings and numbers) but compared using loose matching (`==`). This made the system think identical entries were different, causing duplicate entries to be added when users navigated between pages.

**Solution:** Fixed the issue by making sure all entry IDs are compared consistently. We now convert all entry IDs to strings and use strict matching (`===`) for comparison. We also track which entries have already been processed to make sure each entry is only added once

Quick after loom: https://www.loom.com/share/4f2af783bfc64c2782a8fd46b9ee1126
