### PR TITLE
`gpnf-hide-empty-columns.php`: Fixed an issue withsnippet not working for fields having data stored on sub field IDs like Name, Address, etc.

### DIFF
--- a/gp-nested-forms/gpnf-hide-empty-columns.php
+++ b/gp-nested-forms/gpnf-hide-empty-columns.php
@@ -163,8 +163,13 @@ function gpnf_hec_output_script() {
 
 function gpnf_hec_column_has_value( $field_id, $entries ) {
 	foreach ( $entries as $entry ) {
-		if ( rgar( $entry, $field_id ) ) {
-			return true;
+		foreach ( $entry as $key => $value ) {
+			// Match $field_id or subfield IDs (For fields like Name, Address, etc).)
+			if ( preg_match( '/^' . preg_quote( $field_id, '/' ) . '(\.\d+)?$/', $key ) ) {
+				if ( ! rgblank( $value ) ) {
+					return true;
+				}
+			}
 		}
 	}
 	return false;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3069272683/89066

## Summary

Updated `gpnf_hec_column_has_value()` to correctly detect values stored on sub-inputs (e.g. `8.3`, `8.6`) in addition to the actual field ID (e.g. `8`).

Fields like Name or Address, which store values across multiple sub-input IDs, were not being detected.