### PR TITLE
`gpapf-show-all-countries.php`: Added new snippet.

### DIFF
--- a/gp-advanced-phone-field/gpapf-show-all-countries.php
+++ b/gp-advanced-phone-field/gpapf-show-all-countries.php
@@ -8,6 +8,6 @@
  */
 // Update "123" to your form ID and "4" to your Phone field ID.
 add_filter( 'gpapf_init_args_123_4', function( $args ) {
-  $args['countriesAction'] = 'all';
-  return $args;
+	$args['countriesAction'] = 'all';
+	return $args;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3078299767/89409?viewId=7627047

## Summary

This snippet will set the allowed countries in GPAPF to `All` for a specific form/field. Useful for if a user has locked down the countries in the plugin settings, but wants to allow all countries for a specific form.
