### PR TITLE
`gppt-disable-auto-height.php`: Fixed an issue where the styles weren't output in all contexts.

### DIFF
--- a/gp-page-transitions/gppt-disable-auto-height.php
+++ b/gp-page-transitions/gppt-disable-auto-height.php
@@ -14,7 +14,7 @@ add_filter( "gppt_script_args_{$target_form_id}", function( $args, $form ) {
 }, 10, 2 );
 
 add_filter( "gform_pre_render_{$target_form_id}", function( $form ) {
-	add_action( 'wp_head', 'disable_auto_height_styles' );
+	disable_auto_height_styles();
 	return $form;
 });
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3081415206/89552

## Summary

This PR fixes an issue where the CSS for the snippet wasn't being output when forms were loaded in popups or other contexts where `wp_head` had already fired.

**Fix:** The styles are now output inline with the form to ensure they apply in all scenarios.