### PR TITLE
`gpld-exclude-blocked-dates-from-modifiers.php`: Fixed an issue where the minimum date overshot by one day when the reference date fell on a blocked day.

### DIFF
--- a/gp-limit-dates/gpld-exclude-blocked-dates-from-modifiers.php
+++ b/gp-limit-dates/gpld-exclude-blocked-dates-from-modifiers.php
@@ -59,6 +59,11 @@ function gpld_extend_modifiers_by_blocked_dates( $end_date, $field, $key, $optio
 		}
 	}
 
+	// The base date isn't part of the modifier range, so don't count it as a blocked day.
+	if ( ! gpld_is_valid_date( $date, $field ) ) {
+		$blocked_count--;
+	}
+
 	if ( ! $blocked_count ) {
 		return $end_date;
 	}
@@ -121,6 +126,11 @@ function gpld_exclude_blocked_dates_js() {
 					if( ! GPLimitDates.isDateShown( date, data, fieldId )[0] ) {
 						blockedCount++;
 					}
+				}
+
+				// The base date isn't part of the modifier range, so don't count it as a blocked day.
+				if( ! GPLimitDates.isDateShown( new Date( startDate ), data, fieldId )[0] ) {
+					blockedCount--;
 				}
 
 				if( ! blockedCount ) {


### PR DESCRIPTION
## Context


⛑️ Ticket(s): https://secure.helpscout.net/conversation/3285849749/100533?viewId=3808239

## Summary

**Issue**: When the reference date fell on a blocked day, the minimum date would overshoot by one working day. This happened because the blocked-date counting loop includes the base date, but in this case the base isn't part of the modifier range, so a blocked base gets counted when it shouldn't be.

**Fix**: Subtract the extra count when the base date is blocked. Applied to both PHP and JS.