### PR TITLE
`gpld-us-federal-holidays.php`: Added new snippet for adding US federal holidays as exceptions.

### DIFF
--- a/gp-limit-dates/gpld-us-federal-holidays.php
+++ b/gp-limit-dates/gpld-us-federal-holidays.php
@@ -6,20 +6,20 @@
  * Add US federal holidays as exceptions to your GP Limit Dates fields. Supports fixed-date holidays (e.g.
  * Independence Day) and floating holidays (e.g. Thanksgiving, Memorial Day). Fixed holidays that fall on a
  * Saturday or Sunday are automatically shifted to the observed weekday (Saturday to Friday, Sunday to Monday).
- * 
+ *
  * Credit: Clifford (https://github.com/cliffordp)
  *
  * Instructions:
- * 
+ *
  * 1. Install this snippet by following the steps here:
  *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
- * 
+ *
  * 2. Update the "targets" configuration at the bottom of this file
  *    with your own form and field IDs in "formId_fieldId" format.
  */
 class GPLD_US_Federal_Holidays {
 
-	private $_args = array();
+	private $_args     = array();
 	private $_holidays = null;
 
 	public function __construct( $args = array() ) {

--- a/gp-limit-dates/gpld-us-federal-holidays.php
+++ b/gp-limit-dates/gpld-us-federal-holidays.php
@@ -35,12 +35,23 @@ class GPLD_US_Federal_Holidays {
 
 	public function init() {
 
-		if ( ! $this->_args['form_id'] ) {
+		$form_id   = $this->_args['form_id'];
+		$field_ids = (array) $this->_args['field_ids'];
+
+		if ( ! $form_id ) {
+			// Sitewide: apply to all GPLD-enabled Date fields on all forms.
+			add_filter( 'gpld_limit_dates_options', array( $this, 'add_holiday_exceptions' ), 10, 3 );
 			return;
 		}
 
-		foreach ( (array) $this->_args['field_ids'] as $field_id ) {
-			add_filter( "gpld_limit_dates_options_{$this->_args['form_id']}_{$field_id}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
+		if ( empty( $field_ids ) ) {
+			// Form-wide: apply to all GPLD-enabled Date fields on the specified form.
+			add_filter( "gpld_limit_dates_options_{$form_id}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
+			return;
+		}
+
+		foreach ( $field_ids as $field_id ) {
+			add_filter( "gpld_limit_dates_options_{$form_id}_{$field_id}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
 		}
 
 	}
@@ -111,8 +122,20 @@ class GPLD_US_Federal_Holidays {
 
 # Configuration
 
+# Apply to all GPLD-enabled Date fields on all forms.
 new GPLD_US_Federal_Holidays( array(
-	'form_id'           => 123,
-	'field_ids'         => array( 4, 5 ),
 	'years_to_generate' => 20, // Matches the datepicker's default 20-year forward range.
 ) );
+
+# Apply to all GPLD-enabled Date fields on a specific form.
+//new GPLD_US_Federal_Holidays( array(
+//	'form_id'           => 123,
+//	'years_to_generate' => 20,
+// ) );
+
+# Apply to specific GPLD-enabled Date fields on a specific form.
+//new GPLD_US_Federal_Holidays( array(
+//	'form_id'           => 123,
+//	'field_ids'         => array( 4, 5 ),
+//	'years_to_generate' => 20,
+//) );

--- a/gp-limit-dates/gpld-us-federal-holidays.php
+++ b/gp-limit-dates/gpld-us-federal-holidays.php
@@ -14,8 +14,7 @@
  * 1. Install this snippet by following the steps here:
  *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
  *
- * 2. Update the "targets" configuration at the bottom of this file
- *    with your own form and field IDs in "formId_fieldId" format.
+ * 2. Update the configuration at the bottom of this file with your form and field IDs.
  */
 class GPLD_US_Federal_Holidays {
 
@@ -25,7 +24,8 @@ class GPLD_US_Federal_Holidays {
 	public function __construct( $args = array() ) {
 
 		$this->_args = wp_parse_args( $args, array(
-			'targets'           => array(),
+			'form_id'           => false,
+			'field_ids'         => array(),
 			'years_to_generate' => 20,
 		) );
 
@@ -35,8 +35,12 @@ class GPLD_US_Federal_Holidays {
 
 	public function init() {
 
-		foreach ( $this->_args['targets'] as $target ) {
-			add_filter( "gpld_limit_dates_options_{$target}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
+		if ( ! $this->_args['form_id'] ) {
+			return;
+		}
+
+		foreach ( (array) $this->_args['field_ids'] as $field_id ) {
+			add_filter( "gpld_limit_dates_options_{$this->_args['form_id']}_{$field_id}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
 		}
 
 	}
@@ -108,9 +112,7 @@ class GPLD_US_Federal_Holidays {
 # Configuration
 
 new GPLD_US_Federal_Holidays( array(
-	'targets'           => array(
-		'123_4', // Form ID 123, Field ID 4
-		// Add more targets as needed
-	),
+	'form_id'           => 123,
+	'field_ids'         => array( 4, 5 ),
 	'years_to_generate' => 20, // Matches the datepicker's default 20-year forward range.
 ) );

--- a/gp-limit-dates/gpld-us-federal-holidays.php
+++ b/gp-limit-dates/gpld-us-federal-holidays.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Gravity Perks // Limit Dates // US Federal Holidays
+ * https://gravitywiz.com/documentation/gravity-forms-limit-dates/
+ *
+ * Add US federal holidays as exceptions to your GP Limit Dates fields. Supports fixed-date holidays (e.g.
+ * Independence Day) and floating holidays (e.g. Thanksgiving, Memorial Day). Fixed holidays that fall on a
+ * Saturday or Sunday are automatically shifted to the observed weekday (Saturday to Friday, Sunday to Monday).
+ * 
+ * Credit: Clifford (https://github.com/cliffordp)
+ *
+ * Instructions:
+ * 
+ * 1. Install this snippet by following the steps here:
+ *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ * 
+ * 2. Update the "targets" configuration at the bottom of this file
+ *    with your own form and field IDs in "formId_fieldId" format.
+ */
+class GPLD_US_Federal_Holidays {
+
+	private $_args = array();
+	private $_holidays = null;
+
+	public function __construct( $args = array() ) {
+
+		$this->_args = wp_parse_args( $args, array(
+			'targets'           => array(),
+			'years_to_generate' => 20,
+		) );
+
+		add_action( 'init', array( $this, 'init' ) );
+
+	}
+
+	public function init() {
+
+		foreach ( $this->_args['targets'] as $target ) {
+			add_filter( "gpld_limit_dates_options_{$target}", array( $this, 'add_holiday_exceptions' ), 10, 3 );
+		}
+
+	}
+
+	public function add_holiday_exceptions( $field_options, $form, $field ) {
+
+		if ( $this->_holidays === null ) {
+			$this->_holidays = $this->generate_holidays();
+		}
+
+		$exceptions                  = isset( $field_options['exceptions'] ) ? $field_options['exceptions'] : array();
+		$field_options['exceptions'] = array_values( array_unique( array_merge( $exceptions, $this->_holidays ) ) );
+
+		return $field_options;
+	}
+
+	public function generate_holidays() {
+
+		$holidays     = array();
+		$current_year = (int) wp_date( 'Y' );
+
+		for ( $i = 0; $i <= $this->_args['years_to_generate']; $i++ ) {
+			$year = $current_year + $i;
+
+			// Fixed-date holidays (may fall on a weekend).
+			$fixed_dates = array(
+				"{$year}-01-01", // New Year's Day
+				"{$year}-06-19", // Juneteenth
+				"{$year}-07-04", // Independence Day
+				"{$year}-11-11", // Veterans Day
+				"{$year}-12-25", // Christmas Day
+			);
+
+			foreach ( $fixed_dates as $date_string ) {
+				$timestamp = strtotime( $date_string );
+
+				$day_of_week = (int) gmdate( 'w', $timestamp );
+				if ( $day_of_week === 0 ) {
+					// Sunday -> Observe on Monday
+					$timestamp = strtotime( '+1 day', $timestamp );
+				} elseif ( $day_of_week === 6 ) {
+					// Saturday -> Observe on Friday
+					$timestamp = strtotime( '-1 day', $timestamp );
+				}
+
+				$holidays[] = gmdate( 'm/d/Y', $timestamp );
+			}
+
+			// Floating-date holidays (always fall on a weekday).
+			$floating_dates = array(
+				"third monday of january {$year}",     // Martin Luther King Jr. Day
+				"third monday of february {$year}",    // Washington's Birthday / Presidents' Day
+				"last monday of may {$year}",          // Memorial Day
+				"first monday of september {$year}",   // Labor Day
+				"second monday of october {$year}",    // Columbus Day / Indigenous Peoples' Day
+				"fourth thursday of november {$year}", // Thanksgiving Day
+			);
+
+			foreach ( $floating_dates as $date_string ) {
+				$holidays[] = gmdate( 'm/d/Y', strtotime( $date_string ) );
+			}
+		}
+
+		return $holidays;
+	}
+
+}
+
+# Configuration
+
+new GPLD_US_Federal_Holidays( array(
+	'targets'           => array(
+		'123_4', // Form ID 123, Field ID 4
+		// Add more targets as needed
+	),
+	'years_to_generate' => 20, // Matches the datepicker's default 20-year forward range.
+) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3289096722/100633?viewId=3808239

## Summary

This PR standardizes Clifford's US Federal Holidays [snippet](https://gist.github.com/cliffordp/38892bbfe30702d4623c9c13e17a1b09) for the snippet library. Adds a credit link in the header, aligns class/method naming and formatting with our conventions, and restructures the constructor to use `wp_parse_args` with an `init` hook for filter registration.
