### PR TITLE
`gpadvs-auto-select-on-match.js`: Fixed issue where auto select did not trigger when choices loaded after the user finished typing.

### DIFF
--- a/gp-advanced-select/gpadvs-auto-select-on-match.js
+++ b/gp-advanced-select/gpadvs-auto-select-on-match.js
@@ -10,22 +10,30 @@
  *    https://gravitywiz.com/gravity-forms-code-chest/
  */
 gform.addFilter( 'gpadvs_settings', function( settings, gpadvs, selectNamespace ) {
-  if ( gpadvs.formId == GFFORMID ) {
-    settings.onType = function( str ) {
-      const tomSelect = window[ selectNamespace ];
-      const matchedKey = Object.keys( tomSelect.options ).filter( function( key ) {
-        return -1 !== tomSelect.options[ key ].text.toLowerCase().indexOf( str.toLowerCase() );
-      } );
+	if ( gpadvs.formId == GFFORMID ) {
+		let lastQuery = '';
+		settings.onType = function( str ) {
+			lastQuery = str;
+			const tomSelect = window[ selectNamespace ];
+			const matchedKey = Object.keys( tomSelect.options ).filter( function( key ) {
+				return -1 !== tomSelect.options[ key ].text.toLowerCase().indexOf( str.toLowerCase() );
+			} );
 
-      if ( 1 === matchedKey.length ) {
-        tomSelect.setValue( tomSelect.options[ matchedKey[0] ].id, false );
-        // Especially after an option was previously selected, if the first
-        // character typed next to resume search matches just one option,
-        // the dropdown would remain open; blur closes it immediately.
-        tomSelect.blur();
-      }
-    };
-  }
+			if ( 1 === matchedKey.length ) {
+				tomSelect.setValue( tomSelect.options[ matchedKey[0] ].id, false );
+				// Especially after an option was previously selected, if the first
+				// character typed next to resume search matches just one option,
+				// the dropdown would remain open; blur closes it immediately.
+				tomSelect.blur();
+			}
+		};
+
+		const originalOnLoad = settings.onLoad;
+		settings.onLoad = function() {
+			if ( originalOnLoad ) originalOnLoad.call( this );
+			settings.onType( lastQuery );
+		};
+	}
 
 	return settings;
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3294610193/100872?viewId=3808239

## Summary

Issue: The Auto Select on Match snippet only checked for a single match in `onType`, which fires before GPPA's AJAX request completes. If the user typed faster than choices could populate, the check ran against an empty or stale option set and never auto-selected.

Fix: wrap `onLoad` (which fires after Tom Select's lazy-load AJAX callback completes) to re-run the same match check against the now-populated options, using the user's last typed query.

Also fixed snippet's inconsistent formatting.
