### PR TITLE
`gpb-weighted-resource-capacity-by-service.php`: Added new snippet for weighted resource capacity by service.

### DIFF
--- a/gp-bookings/gpb-weighted-resource-capacity-by-service.php
+++ b/gp-bookings/gpb-weighted-resource-capacity-by-service.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Gravity Perks // Bookings // Weighted Resource Capacity by Service
+ * https://gravitywiz.com/documentation/gravity-forms-bookings/
+ *
+ * Let different services take up different amounts of the same resource.
+ *
+ * For example: a tennis court fits one Tennis match or two Pickleball matches at once.
+ * Give the court a capacity of `2`, then set Tennis to use 2 units and Pickleball to use 1.
+ * Booking Tennis fills the court on its own; up to two Pickleball bookings can share it.
+ *
+ * Instructions
+ *
+ * 1. Install: https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *
+ * 2. Set the shared Resource's capacity to the total units available (e.g. `2` for two halves).
+ *
+ * 3. Map each Service ID to the units it consumes in `service_units`. A service's units
+ *    must not exceed the resource's capacity, or it will be unbookable on that resource.
+ *
+ * 4. (Optional) `resource_ids` to scope to specific resources; `default_units` for unlisted services.
+ */
+class GPB_Weighted_Resource_Capacity_By_Service {
+
+	private $service_units;
+	private $resource_ids;
+	private $default_units;
+
+	public function __construct( array $args ) {
+		$this->service_units = array_map( 'intval', (array) ( $args['service_units'] ?? array() ) );
+		$this->resource_ids  = array_map( 'intval', (array) ( $args['resource_ids'] ?? array() ) );
+		$this->default_units = max( 1, (int) ( $args['default_units'] ?? 1 ) );
+
+		add_filter( 'gpb_capacity_limit', array( $this, 'filter_capacity' ), 10, 4 );
+	}
+
+	public function filter_capacity( $capacity, $start_datetime, $end_datetime, $bookable ) {
+		if ( ! $bookable instanceof \GP_Bookings\Resource || $capacity->is_unlimited() ) {
+			return $capacity;
+		}
+
+		if ( ! empty( $this->resource_ids ) && ! in_array( (int) $bookable->get_id(), $this->resource_ids, true ) ) {
+			return $capacity;
+		}
+
+		$service = $bookable->get_service();
+		if ( ! $service ) {
+			return $capacity;
+		}
+
+		$service_units          = $this->units_for( $service->get_id() );
+		list( $raw, $weighted ) = $this->usage_for( $bookable, $start_datetime, $end_datetime );
+
+		$bookings_that_fit = (int) floor( max( 0, $capacity->to_int() - $weighted ) / $service_units );
+		$adjusted          = $raw + $bookings_that_fit;
+
+		if ( $adjusted < 1 ) {
+			return $capacity;
+		}
+
+		return \GP_Bookings\Capacity\Capacity_Limit::limited( $adjusted );
+	}
+
+	private function usage_for( $resource, $start_datetime, $end_datetime ) {
+		global $wpdb;
+
+		$table   = \GP_Bookings\Database::table_bookings();
+		$exclude = $this->excluded_booking_id();
+
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT b.booking_id, b.parent_booking_id, b.quantity, p.object_id AS service_id
+				FROM %i AS b
+				LEFT JOIN %i AS p ON b.parent_booking_id = p.booking_id AND p.object_type = 'service'
+				WHERE b.object_id = %d
+				AND b.object_type = 'resource'
+				AND b.start_datetime < %s
+				AND b.end_datetime > %s
+				AND b.status IN ('pending', 'confirmed')",
+				$table,
+				$table,
+				$resource->get_id(),
+				$end_datetime,
+				$start_datetime
+			)
+		);
+
+		$raw = $weighted = 0;
+
+		foreach ( $rows as $row ) {
+			if ( $exclude && ( (int) $row->booking_id === $exclude || (int) $row->parent_booking_id === $exclude ) ) {
+				continue;
+			}
+
+			$quantity  = max( 1, (int) $row->quantity );
+			$raw      += $quantity;
+			$weighted += $this->units_for( (int) $row->service_id ) * $quantity;
+		}
+
+		return array( $raw, $weighted );
+	}
+
+	private function units_for( $service_id ) {
+		return $this->service_units[ (int) $service_id ] ?? $this->default_units;
+	}
+
+	private function excluded_booking_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$id = $_REQUEST['excludeBookingId'] ?? $_REQUEST['exclude_booking_id'] ?? null;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return $id ? absint( wp_unslash( $id ) ) : 0;
+	}
+}
+
+# Configuration
+
+new GPB_Weighted_Resource_Capacity_By_Service( array(
+	// Service ID => resource capacity units consumed by one booking quantity.
+	'service_units' => array(
+		14 => 2, // e.g. Tennis - consumes the full court.
+		15 => 1, // e.g. Pickleball - consumes half the court.
+	),
+	// 'resource_ids'  => array( 5, 7 ), // Optional: limit to specific Resource IDs.
+	// 'default_units' => 1,             // Optional: units consumed by services not listed above.
+) );

--- a/gp-bookings/gpb-weighted-resource-capacity-by-service.php
+++ b/gp-bookings/gpb-weighted-resource-capacity-by-service.php
@@ -67,25 +67,26 @@ class GPB_Weighted_Resource_Capacity_By_Service {
 		$table   = \GP_Bookings\Database::table_bookings();
 		$exclude = $this->excluded_booking_id();
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is provided by GP Bookings.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT b.booking_id, b.parent_booking_id, b.quantity, p.object_id AS service_id
-				FROM %i AS b
-				LEFT JOIN %i AS p ON b.parent_booking_id = p.booking_id AND p.object_type = 'service'
+				FROM `{$table}` AS b
+				LEFT JOIN `{$table}` AS p ON b.parent_booking_id = p.booking_id AND p.object_type = 'service'
 				WHERE b.object_id = %d
 				AND b.object_type = 'resource'
 				AND b.start_datetime < %s
 				AND b.end_datetime > %s
 				AND b.status IN ('pending', 'confirmed')",
-				$table,
-				$table,
 				$resource->get_id(),
 				$end_datetime,
 				$start_datetime
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		$raw = $weighted = 0;
+		$raw      = 0;
+		$weighted = 0;
 
 		foreach ( $rows as $row ) {
 			if ( $exclude && ( (int) $row->booking_id === $exclude || (int) $row->parent_booking_id === $exclude ) ) {
@@ -101,7 +102,8 @@ class GPB_Weighted_Resource_Capacity_By_Service {
 	}
 
 	private function units_for( $service_id ) {
-		return $this->service_units[ (int) $service_id ] ?? $this->default_units;
+		$units = $this->service_units[ (int) $service_id ] ?? $this->default_units;
+		return max( 1, (int) $units );
 	}
 
 	private function excluded_booking_id() {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3299467246/101054?viewId=3808239

## Summary

This PR adds a new GPB snippet "Weighted Resource Capacity by Service" that lets different services consume different amounts of the same resource's capacity.

**The customer use case**: the customer runs a tennis facility. Courts are set up as Resources, and activities like Tennis and Pickleball are Services. A Tennis match takes up a whole court, but two Pickleball matches can share one. Just setting the Court's capacity to 2 doesn't fix this, it would let someone book Tennis and Pickleball on the same court at the same time.

The snippet allows the admin to set how many units of a Resource each Service uses per booking, and only allows new bookings when enough units remain to cover the Service being booked.

**Quick walkthrough: https://www.loom.com/share/02aa8ff59a1746d7afeb887279d74532**