### PR TITLE
`gw-gravity-forms-rename-uploaded-files.php`: Fixed entry display for fields with storageType as 'json' for Gravity Forms 2.10 compatibility.

### DIFF
--- a/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
+++ b/gravity-forms/gw-gravity-forms-rename-uploaded-files.php
@@ -126,7 +126,7 @@ class GW_Rename_Uploaded_Files {
 
 			if ( $field->get_input_type() == 'post_image' ) {
 				$value = str_replace( $uploaded_files[0], $renamed_files[0], rgar( $entry, $field->id ) );
-			} elseif ( $field->multipleFiles ) {
+			} elseif ( $field->multipleFiles || rgar( $field, 'storageType' ) === 'json' ) {
 				$value = json_encode( $renamed_files );
 			} else {
 				$value = $renamed_files[0];


### PR DESCRIPTION
Fixes compatibility with Gravity Forms 2.10.
GF 2.10 introduced a `storageType` property on file upload fields. New fields default to `storageType = 'json'`, so even single-file values must be persisted as a JSON-encoded array.

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

<!-- Briefly explain what's new in this pull request. -->
