### PR TITLE
`gw-zip-files.php`: Updated snippet to ensure Gravity Forms 2.10 compatibility.

### DIFF
--- a/gravity-forms/gw-zip-files.php
+++ b/gravity-forms/gw-zip-files.php
@@ -146,7 +146,9 @@ class GW_Zip_Files {
 			}
 
 			$files = GFFormsModel::get_lead_field_value( $entry, $field );
-			if ( $this->is_multi_file( $field ) ) {
+			if ( is_callable( array( $field, 'to_array' ) ) ) {
+				$files = $field->to_array( $files );
+			} elseif ( $this->is_multi_file( $field ) ) {
 				$files = json_decode( $files );
 			}
 


### PR DESCRIPTION
## Context

💬 Slack: https://gravitywiz.slack.com/archives/C064V6CCF7H/p1777645060980859

## Summary

Updating `get_entry_files()` to use `$field->to_array( $files )` , if callable, that way it handles new single file upload fields created since the  Gravity Forms 2.10 release that also use JSON
