### PR TITLE
`gw-populate-date.php`: Fixed Populate Date Snippet logic affecting datepicker icon with Gravity Forms 2.5 Theme.

### DIFF
--- a/gravity-forms/gw-populate-date.php
+++ b/gravity-forms/gw-populate-date.php
@@ -1752,7 +1752,7 @@ class GW_Populate_Date {
 											.replace( 'm', GWDates.padDateOrMonth( dateParts.month ) )
 											.replace( 'd', GWDates.padDateOrMonth( dateParts.day ) )
 											.replace( 'y', dateParts.year );
-										$inputs.val( dateStr );
+										$inputs.eq(0).val(dateStr);
 										break;
 									default:
 										break;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3317892728/101966?viewId=3808239

## Summary

Fixed the input element to set the date value, ensuring the datepicker icon remains functional.

**BEFORE**:
<img width="264" height="97" alt="Screenshot 2026-05-13 at 16 28 33" src="https://github.com/user-attachments/assets/7ce57c78-543f-42dc-8417-46eadddb9837" />

**AFTER**:
<img width="289" height="102" alt="Screenshot 2026-05-13 at 16 27 56" src="https://github.com/user-attachments/assets/8ea16263-127c-4b5d-bae9-ce858fbdc7a2" />
