### PR TITLE
`gpaa-use-short-name-for-province.js`: Updated snippets to clarify which one is global and which one is per form based.

### DIFF
--- a/gp-address-autocomplete/gpaa-use-short-name-for-province.js
+++ b/gp-address-autocomplete/gpaa-use-short-name-for-province.js
@@ -4,10 +4,13 @@
  *
  * Instruction Video: https://www.loom.com/share/f39708854d504d32902b5fca29e73213
  *
- * This was develope for a customer using Address Autocomplete in Italy. The province was retuned as
+ * This was developed for a customer using Address Autocomplete in Italy. The province was retuned as
  * "Città Metropolitana di Torino" where they wanted to use the province code instead (e.g. "TO").
  *
  * Note: This snippet is only intended for use with Gravity Forms’ default International Address field type.
+ *
+ * This JavaScript snippet applies the short name rule PER FORM. Add it only to forms where you want this behavior.
+ * For a global PHP version, see: https://gravitywiz.com/snippet-library/gpaa-use-short-name-for-province-2/
  */
 gform.addFilter("gpaa_values", function (values, place) {
   for (var i = 0; i < place.address_components.length; i++) {

--- a/gp-address-autocomplete/gpaa-use-short-name-for-province.js
+++ b/gp-address-autocomplete/gpaa-use-short-name-for-province.js
@@ -4,7 +4,7 @@
  *
  * Instruction Video: https://www.loom.com/share/f39708854d504d32902b5fca29e73213
  *
- * This was developed for a customer using Address Autocomplete in Italy. The province was retuned as
+ * This was developed for a customer using Address Autocomplete in Italy. The province was returned as
  * "Città Metropolitana di Torino" where they wanted to use the province code instead (e.g. "TO").
  *
  * Note: This snippet is only intended for use with Gravity Forms’ default International Address field type.

--- a/gp-address-autocomplete/gpaa-use-short-name-for-province.php
+++ b/gp-address-autocomplete/gpaa-use-short-name-for-province.php
@@ -3,6 +3,9 @@
  * Gravity Perks // GP Address Autocomplete // Always Use Short Name for State/Province/Region
  * https://gravitywiz.com/documentation/gravity-forms-address-autocomplete/
  *
+ * This PHP snippet applies the short name rule GLOBALLY to all forms and all address fields using GP Address Autocomplete.
+ * For a per-form JavaScript version, see: https://gravitywiz.com/snippet-library/gpaa-use-short-name-for-province/
+ *
  * Forces GP Address Autocomplete to use the short name (e.g. "TO" instead of "Città Metropolitana di Torino")
  * for state, province, or region components on ALL forms and ALL address fields.
  *


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3321540607/102188?viewId=3808239

## Summary

1. Disambiguate both of these snippets, making it clear that one applies the rule globally and the other is per form.
2. Link them to each other 🔄

JS: https://gravitywiz.com/snippet-library/gpaa-use-short-name-for-province/
PHP: https://gravitywiz.com/snippet-library/gpaa-use-short-name-for-province-2/
