### PR TITLE
`gpaa-show-place-name.js`: Fixed an issue with snippet duplicating place name in nested forms context.

### DIFF
--- a/gp-address-autocomplete/gpaa-show-place-name.js
+++ b/gp-address-autocomplete/gpaa-show-place-name.js
@@ -24,5 +24,12 @@ gform.addFilter( 'gpaa_autocomplete_options', function( options ) {
 // Display Place Name
 gform.addAction( 'gpaa_fields_filled', function ( place, instance, formId, fieldId ) {
 	let $addressLine1 = jQuery( '#input_{0}_{1}_1'.gformFormat( formId, fieldId ) );
+
+	// Nested Forms scenario where the value may duplicate.
+	if ( $addressLine1.val().includes( place.name ) ) {
+		$addressLine1.val( place.name ).trigger('change');
+		return;
+	}
+
 	$addressLine1.val( place.name + ', ' + $addressLine1.val() ).trigger('change');
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3329747912/102682?viewId=3808239

## Summary

The street address seems to duplicate when the Nested Form is loaded more than once.

https://www.loom.com/share/54076ff243974175af1402e5f30b2287
