### PR TITLE
`gpb-no-lead-time-restriction-admins.php`: Added snippet for no lead time restriction for Admins.

### DIFF
--- a/gp-bookings/gpb-no-lead-time-restriction-admins.php
+++ b/gp-bookings/gpb-no-lead-time-restriction-admins.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Gravity Perks // GP Bookings // No Lead Time Restriction for Admins
+ * https://gravitywiz.com/documentation/gp-bookings/
+ *
+ * Removes lead time restriction for users with 'manage_options' capability (typically admins) by setting the availability start to now.
+ */
+add_filter( 'gpb_availability_start', function( $start, $service, $resource_ids ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return $start;
+	}
+
+	// Admins: no lead time restriction.
+	return \Carbon\CarbonImmutable::now();
+}, 20, 3 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3334899783/102922?viewId=3808239

## Summary

Admins to be able to make bookings that override the lead time. For example, an admin could create a booking that is only in a couple of days.