### PR TITLE
`gpcp-show-original-price.js`: Fixed display issues and added support for GPPA dynamic pricing.

### DIFF
--- a/gp-conditional-pricing/gpcp-show-original-price.js
+++ b/gp-conditional-pricing/gpcp-show-original-price.js
@@ -1,34 +1,77 @@
 /**
  * Gravity Perks // GP Conditional Pricing // Show the original price crossed out next to the adjusted price
- * http://gravitywiz.com/documentation/gravity-forms-conditional-pricing/
+ * https://gravitywiz.com/documentation/gravity-forms-conditional-pricing/
  *
  * Instructions:
  *     1. Install our free Custom Javascript for Gravity Forms plugin.
  *        Download the plugin here: https://gravitywiz.com/gravity-forms-code-chest/
  *     2. Copy and paste the snippet into the editor of the Custom Javascript for Gravity Forms plugin.
  */
+var gwcpBasePrices = {};
+
+$( document ).off( 'gppa_updated_batch_fields.gwcp' ).on( 'gppa_updated_batch_fields.gwcp', function( event, formId, updatedFieldIds ) {
+
+	var gwcp = GWConditionalPricing.getFormElement( formId ).data( 'gwcp' );
+	if ( ! gwcp || ! gwcp._pricingLogic || ! updatedFieldIds || ! updatedFieldIds.length ) {
+		return;
+	}
+
+	var currency = typeof gform !== 'undefined' && typeof gform.Currency === 'function'
+		? new gform.Currency( gf_global['gf_currency_config'] )
+		: new Currency( gf_global['gf_currency_config'] );
+
+	for ( var productId in gwcp._pricingLogic ) {
+		if ( ! gwcp._pricingLogic.hasOwnProperty( productId ) || updatedFieldIds.indexOf( parseInt( productId, 10 ) ) === -1 && updatedFieldIds.indexOf( productId.toString() ) === -1 ) {
+			continue;
+		}
+
+		var key   = formId + '_' + productId;
+		var $base = $( '#ginput_base_price_{0}_{1}'.gformFormat( formId, productId ) );
+
+		if ( $base.length && $base.val() !== '' ) {
+			gwcpBasePrices[ key ] = currency.toMoney( currency.toNumber( $base.val() ), true );
+		} else {
+			delete gwcpBasePrices[ key ];
+		}
+	}
+
+} );
+
 gform.addAction( 'gpcp_after_update_pricing', function( triggerFieldId, GWConditionalPricing, productId ) {
 
-	var basePrice = GWConditionalPricing.getBasePrice( productId );
+	var basePrice = gwcpBasePrices[ GWConditionalPricing._formId + '_' + productId ] || GWConditionalPricing.getBasePrice( productId );
 	if ( ! basePrice ) {
 		return;
 	}
 
-	var $input = $( '#field_{0}_{1}'.gformFormat( GWConditionalPricing._formId, productId ) );
+	// Quantity enabled: price is text in span#input_*. Quantity disabled: price is the value of
+	// the readonly input#ginput_base_price_*.
+	var $input  = $( 'span#input_{0}_{1}'.gformFormat( GWConditionalPricing._formId, productId ) );
+	var isInput = false;
+	if ( ! $input.length ) {
+		$input  = $( 'input#ginput_base_price_{0}_{1}'.gformFormat( GWConditionalPricing._formId, productId ) );
+		isInput = true;
+	}
 	if ( ! $input.length ) {
 		return;
 	}
 
+	var displayedPrice = isInput ? $input.val() : $input.text();
+
 	var $basePrice = $( '#base_price_{0}_{1}'.gformFormat( GWConditionalPricing._formId, productId ) );
 
 	// Remove base price if there is no discounted price.
-	if ( $input.text() === basePrice ) {
+	if ( displayedPrice === basePrice ) {
 		$basePrice.remove();
 	}
 	// Otherwise, add base price if it has not been added.
-	else if ( ! $basePrice.length ) {
-		$basePrice = '<span id="base_price_{0}_{1}" style="text-decoration:line-through;margin-right:0.3rem">{2}</span>'.gformFormat( GWConditionalPricing._formId, productId, basePrice );
-		$input.before( $basePrice );
+	else {
+		if ( ! $basePrice.length ) {
+			$basePrice = '<span id="base_price_{0}_{1}" style="text-decoration:line-through;margin-right:0.3rem"></span>'.gformFormat( GWConditionalPricing._formId, productId );
+			$input.before( $basePrice );
+		}
+
+		$basePrice.text( basePrice );
 	}
 
 } );

--- a/gp-conditional-pricing/gpcp-show-original-price.js
+++ b/gp-conditional-pricing/gpcp-show-original-price.js
@@ -71,7 +71,9 @@ gform.addAction( 'gpcp_after_update_pricing', function( triggerFieldId, GWCondit
 			$input.before( $basePrice );
 		}
 
-		$basePrice.text( basePrice );
+		if ( $basePrice && typeof $basePrice.text === 'function' ) {
+			$basePrice.text( basePrice );
+		}
 	}
 
 } );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3338825288/103089?viewId=3808239

## Summary

Issue: the crossed-out price rendered  above the field instead of inline, and it showed even when no discount applied (the wrapper's text includes the label/quantity, so the comparison never matched). It also only ever added the crossed-out element, so it didn't stay in sync as prices changed. Separately, it read the original  price from `getBasePrice()`, which only holds the static prices captured at page render, so when GP Populate Anything set the price live, the crossed-out value was stale.

Fix: now targets the price element directly (`span#input_*`, or the readonly `input#ginput_base_price_*` when Quantity is disabled), fixing the positioning and comparison, and refreshes the crossed-out text on every update. For live pricing, it captures each product's base price from GPPA's `gppa_updated_batch_fields` event and falls back to the static price otherwise.
