### PR TITLE
`gw-update-posts.php`: Fixed issue where file upload URLs were saved with surrounding brackets and quotes on Gravity Forms 2.10.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -186,7 +186,7 @@ class GW_Update_Posts {
 					}
 
 					// If the taxonomy is not hierarchical, we need to get the term names from the term ids.
-					if( ! $this->gw_is_taxonomy_hierarchical( $taxonomy ) ) {
+					if ( ! $this->gw_is_taxonomy_hierarchical( $taxonomy ) ) {
 						$terms = $this->get_term_names_by_ids( $terms, $taxonomy );
 					}
 

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -5,10 +5,10 @@
  *
  * Update existing post title, content, author and custom fields with values from Gravity Forms.
  *
- * @version 0.7
+ * @version 0.8
  * @author  Scott Ryer <scott@gravitywiz.com>
  * @license GPL-2.0+
- * @link    http://gravitywiz.com
+ * @link    https://gravitywiz.com
  */
 class GW_Update_Posts {
 
@@ -279,6 +279,13 @@ class GW_Update_Posts {
 			$meta_value = rgar( $entry, $value );
 			// Address input
 			if ( $field_type == 'address' ) {
+				$meta_value = $field->get_value_export( $entry, $value );
+			}
+
+			// File Upload input. As of Gravity Forms 2.10, file upload fields store their value as a
+			// JSON-encoded array (e.g. ["https://.../file.jpg"]), even for single file uploads. Use
+			// get_value_export() to resolve the plain URL(s) rather than storing the raw JSON value.
+			if ( $field_type === 'fileupload' ) {
 				$meta_value = $field->get_value_export( $entry, $value );
 			}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3345214180/103343?viewId=3808239

## Summary

Issue: Mapping a file upload field to a post custom field stored a JSON-encoded array (e.g. `["https://example.com/file.jpg"]`) instead of the plain URL. As of Gravity Forms 2.10, file upload fields store their value as JSON even for single uploads, and the snippet was copying that raw entry value straight into the custom field.

Fix: The snippet now resolves file upload values through the field's `get_value_export()` method, returning the plain URL (or a delimited list for multi-file uploads). This works across Gravity Forms versions, handling both legacy plain-URL and 2.10 JSON storage.