### PR TITLE
`gpld-limit-max-date-to-current-year.php`: Added new snippet.

### DIFF
--- a/gp-limit-dates/gpld-limit-max-date-to-current-year.php
+++ b/gp-limit-dates/gpld-limit-max-date-to-current-year.php
@@ -6,7 +6,7 @@
 // Update "123" to your form ID and "4" to your Date field ID.
 add_filter( 'gpld_limit_dates_options_123_4', function( $field_options ) {
 
-	$field_options['maxDate'] = date( '12/31/Y' );
+	$field_options['maxDate'] = gmdate( '12/31/Y' );
 
 	return $field_options;
 } );

--- a/gp-limit-dates/gpld-limit-max-date-to-current-year.php
+++ b/gp-limit-dates/gpld-limit-max-date-to-current-year.php
@@ -6,7 +6,7 @@
 // Update "123" to your form ID and "4" to your Date field ID.
 add_filter( 'gpld_limit_dates_options_123_4', function( $field_options ) {
 
-  $field_options['maxDate'] = date( '12/31/Y' );
+	$field_options['maxDate'] = date( '12/31/Y' );
 
-  return $field_options;
+	return $field_options;
 } );

--- a/gp-limit-dates/gpld-limit-max-date-to-current-year.php
+++ b/gp-limit-dates/gpld-limit-max-date-to-current-year.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Gravity Perks // Limit Dates // Limit Max Date to Current Year
+ * https://gravitywiz.com/documentation/gravity-forms-limit-dates/
+ */
+// Update "123" to your form ID and "4" to your Date field ID.
+add_filter( 'gpld_limit_dates_options_123_4', function( $field_options ) {
+
+  $field_options['maxDate'] = date( '12/31/Y' );
+
+  return $field_options;
+} );


### PR DESCRIPTION
## Context

📓 Notion: https://app.notion.com/p/gravitywiz/GPLD-Leave-request-forms-limited-to-the-current-year-2f100ab68edf806eaba3e23a26e9c1ca

## Summary

Added a new snippet for GPLD that limits the maximum date to the current year.