### PR TITLE
`gw-update-posts.php`: Added support for per-meta `delete_if_empty` overrides.

### DIFF
--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -268,7 +268,7 @@ class GW_Update_Posts {
 					continue;
 				} else {
 					$append          = rgar( $value, 'append', false );
-					$delete_if_empty = rgar( $value, 'delete_if_empty', $delete_if_empty );
+					$delete_if_empty = array_key_exists( 'delete_if_empty', $value ) ? (bool) $value['delete_if_empty'] : $delete_if_empty;
 					$value           = $value['field_id'];
 				}
 			}

--- a/gravity-forms/gw-update-posts.php
+++ b/gravity-forms/gw-update-posts.php
@@ -259,14 +259,17 @@ class GW_Update_Posts {
 		foreach ( $meta as $key => $value ) {
 
 			$append = false;
+			// Default to the global 'delete_if_empty' setting; may be overridden per-field below.
+			$delete_if_empty = $this->_args['delete_if_empty'];
 
 			if ( is_array( $value ) ) {
 				if ( ! isset( $value['field_id'] ) ) {
 					$meta_input = $this->prepare_meta_input( $value, $post_id, $entry, $form, $meta_input, $key );
 					continue;
 				} else {
-					$append = rgar( $value, 'append', false );
-					$value  = $value['field_id'];
+					$append          = rgar( $value, 'append', false );
+					$delete_if_empty = rgar( $value, 'delete_if_empty', $delete_if_empty );
+					$value           = $value['field_id'];
 				}
 			}
 
@@ -329,7 +332,7 @@ class GW_Update_Posts {
 				} else {
 					$meta_input[ $key ] = $meta_value;
 				}
-			} elseif ( $this->_args['delete_if_empty'] ) {
+			} elseif ( $delete_if_empty ) {
 				delete_post_meta( $post_id, $key );
 			}
 		}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3349393593/103509?viewId=8614371

## Summary

_Submitting this PR which @saifsultanc started because he's out on vacation._

This PR adds the ability to override the global `delete_if_empty` setting on a per-meta-field basis.

Previously, `delete_if_empty` was an all or nothing global flag. When enabled, every mapped meta field with an empty submitted value was deleted from the post. This update adds a `delete_if_empty` key that can be set inside an individual meta field's config array, to override the global setting.

**Usage**:
```
new GW_Update_Posts( array(
	'form_id' => 123,
	'post_id' => 1,
	'meta'    => array(
		// Preserve existing value if this field is submitted empty.
		'gallery' => array(
			'field_id'        => 5,
			'append'          => true,
			'delete_if_empty' => false,
		),
		// Inherits the global setting below (deleted when empty).
		'text' => 7,
	),
	'delete_if_empty' => true, // global default
) );
```