### PR TITLE
`gpb-conditional-conferencing-by-field-value.php`: Added new snippet for conditional conferencing by field value.

### DIFF
--- a/gp-bookings/gpb-conditional-conferencing-by-field-value.php
+++ b/gp-bookings/gpb-conditional-conferencing-by-field-value.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Gravity Perks // Bookings // Conditional Conferencing by Field Value
+ * https://gravitywiz.com/documentation/gravity-forms-bookings/
+ *
+ * Only add conferencing (e.g. the Google Meet link) to a booking's Google Calendar event when a
+ * chosen field matches an allowed value.
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet by following the steps here:
+ *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *
+ * 2. Update the three settings below to match your form.
+ */
+add_filter( 'gpb_google_calendar_event_data', function( $event_data, $booking ) {
+
+	// Configuration
+	$form_id      = 123;            // Update '123' to your Form ID
+	$field_id     = '4';            // Field ID that controls conferencing. Use a sub-field ID (e.g. '4.1') for multi-input fields.
+	$field_values = array( 'Yes' ); // Update to the field value(s) that should add conferencing.
+
+	if ( empty( $event_data['conferenceData'] ) ) {
+		return $event_data;
+	}
+
+	$entry = $booking->get_entry();
+	if ( ! $entry ) {
+		return $event_data;
+	}
+
+	if ( (int) rgar( $entry, 'form_id' ) !== $form_id ) {
+		return $event_data;
+	}
+
+	if ( ! in_array( (string) rgar( $entry, $field_id ), $field_values, true ) ) {
+		unset( $event_data['conferenceData'] );
+	}
+
+	return $event_data;
+}, 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3349810804/103527?viewId=8172236

## Summary

This PR adds a new GP Bookings snippet that makes Google Calendar conferencing conditional on an entry field value, instead of  attaching it to every booking.

When the GC Google Calendar integration has Conferencing set to Google Meet, a link is added to every pushed event. This snippet hooks the `gpb_google_calendar_event_data` filter and removes the conferencing data unless a configured field matches an allowed value, scoped to a specific form.
