### PR TITLE
`gpb-form-specific-event-title-description.php`: Added new snippet for form-specific Event Title & Description.

### DIFF
--- a/gp-bookings/gpb-form-specific-event-title-description.php
+++ b/gp-bookings/gpb-form-specific-event-title-description.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Gravity Perks // Bookings // Form-Specific Event Title & Description
+ * https://gravitywiz.com/documentation/gravity-forms-bookings/
+ *
+ * Use different Google Calendar event titles and/or descriptions depending on which form
+ * created the booking. This is useful when the same service is shared across several booking
+ * forms and each form needs its own merge tags (which vary by field ID from form to form).
+ *
+ * Event settings are configured on the service, so the same template applies to every form
+ * that books that service. Each rule below targets a specific service + form pair and overrides
+ * the template for that combination. Templates are processed with the booking's own form and
+ * entry, so form-specific merge tags (e.g. {:3}) resolve correctly.
+ *
+ * Instructions:
+ *
+ * 1. Install this snippet by following the steps here:
+ *    https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
+ *
+ * 2. Update the $rules below with a row per service + form. Omit 'title' or 'description' to
+ *    leave that value as configured in the service's event settings.
+ */
+add_filter( 'gpb_google_calendar_event_data', function( $event_data, $booking ) {
+
+	// Each rule targets a service_id + form_id. Values support GPB and Gravity Forms merge tags.
+	$rules = array(
+		array(
+			'service_id'  => 42, // The GPB service this booking is for.
+			'form_id'     => 1,
+			'title'       => '{:3} - {:5}',
+			'description' => 'Booking for {:3} - {gpb_datetime}',
+		),
+		array(
+			'service_id'  => 42,
+			'form_id'     => 2,
+			'title'       => '{:7} with {gpb_service}',
+			'description' => 'Location: {:9}',
+		),
+	);
+
+	$entry = $booking->get_entry();
+	if ( ! $entry ) {
+		return $event_data;
+	}
+
+	$form_id    = (int) rgar( $entry, 'form_id' );
+	$service_id = (int) $booking->get_service_id();
+
+	foreach ( $rules as $rule ) {
+		if ( (int) $rule['form_id'] !== $form_id || (int) $rule['service_id'] !== $service_id ) {
+			continue;
+		}
+
+		if ( ! empty( $rule['title'] ) ) {
+			$event_data['summary'] = \GP_Bookings\Merge_Tags::apply_template( $booking, $rule['title'] );
+		}
+
+		if ( ! empty( $rule['description'] ) ) {
+			$event_data['description'] = \GP_Bookings\Merge_Tags::apply_template( $booking, $rule['description'] );
+		}
+
+		break;
+	}
+
+	return $event_data;
+}, 10, 2 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3378281127/104640?viewId=3808239

## Summary

Event settings (event title/description with merge tag support) are configured on the service, so every booking form that books that service gets the same template. When one service is shared across multiple forms whose fields differ, a single template can't work, the same field ID (`{:3}`) means different things on each form.

This PR adds a new snippet that overrides the Google Calendar event title and/or description on a per service + form basis, using the existing `gpb_google_calendar_event_data` filter.