### PR TITLE
`gpro-enable-when-dynamically-populated.php`: Added support for multi-page forms.

### DIFF
--- a/gp-read-only/gpro-enable-when-dynamically-populated.php
+++ b/gp-read-only/gpro-enable-when-dynamically-populated.php
@@ -10,6 +10,16 @@
  */
 add_filter( 'gform_pre_render', function ( $form, $ajax, $field_values ) {
 
+	if ( ! session_id() ) {
+		session_start();
+	}
+
+	if ( ! isset( $_SESSION['gwreadonly_disabled_fields'] ) ) {
+		$_SESSION['gwreadonly_disabled_fields'] = array();
+	}
+
+	$gwreadonly_disabled_fields = $_SESSION['gwreadonly_disabled_fields'];
+
 	foreach ( $form['fields'] as &$field ) {
 
 		if ( ! $field->gwreadonly_enable ) {
@@ -39,10 +49,19 @@ add_filter( 'gform_pre_render', function ( $form, $ajax, $field_values ) {
 			}
 		}
 
+		// Multi page form support.
+		if ( isset( $gwreadonly_disabled_fields[ $field->id ] ) && $gwreadonly_disabled_fields[ $field->id ] ) {
+			$field->gwreadonly_enable = false;
+			continue;
+		}
+
 		if ( ! $value || ( isset( $has_matching_choice ) && ! $has_matching_choice ) ) {
 			$field->gwreadonly_enable = false;
+			$gwreadonly_disabled_fields[ $field->id ] = true;
 		}
 	}
+
+	$_SESSION['gwreadonly_disabled_fields'] = $gwreadonly_disabled_fields;
 
 	return $form;
 }, 10, 3 );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3131650087/92324?viewId=7098280

## Summary

On multi-page forms, the snippet above incorrectly makes a field read-only when the user manually enters a value, navigates away from the page, and then returns, even though the field wasn’t dynamically populated. This PR fixes the issue.