### PR TITLE
`gw-display-navigation-buttons-inline.css`: Added new snippet for displaying page navigation buttons inline.

### DIFF
--- a/gravity-forms/gw-display-navigation-buttons-inline.css
+++ b/gravity-forms/gw-display-navigation-buttons-inline.css
@@ -1,0 +1,30 @@
+/**
+ * Gravity Wiz // Gravity Forms // Display Page Navigation Buttons Inline With Fields
+ * https://gravitywiz.com/
+ *
+ * Displays a form page's Previous/Next navigation buttons inline with the
+ * last row of fields, rather than stacked below them.
+ *
+ * Instructions:
+ *
+ * 1. Install Code Chest: https://gravitywiz.com/gravity-forms-code-chest/
+ *
+ * 2. Add this CSS to the form via Code Chest.
+ *
+ * 3. Add the `button-inline` class to the Next button.
+ */
+.gform_page.button-inline {
+	display: flex;
+	align-items: flex-end;
+	gap: 20px;
+}
+
+.gform_page.button-inline .gform_page_fields {
+	flex: 1;
+}
+
+.gform_page.button-inline .gform_page_footer {
+	flex-shrink: 0;
+	margin-top: 0 !important;
+	padding-bottom: 0;
+}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3209016871/96688?viewId=8172236

## Summary

Thiis PR adds a CSS snippet that lets users display a form page's Previous/Next navigation inline with the last row of fields (instead of stacked below).

<img width="848" height="253" alt="image" src="https://github.com/user-attachments/assets/ec766da2-a91b-4f33-9355-1e446042cf29" />
