### PR TITLE
`gw-quantity-as-decimal.php`: Fixed a compatibility issue with Gravity Forms 3.

### DIFF
--- a/gravity-forms/gw-quantity-as-decimal.php
+++ b/gravity-forms/gw-quantity-as-decimal.php
@@ -46,7 +46,14 @@ class GW_Quantity_Decimal {
 			add_filter( 'gform_field_validation_' . $this->form_id, array( $this, 'allow_quantity_float' ), 10, 4 );
 		}
 
-		if ( GFFormsModel::is_html5_enabled() ) {
+		// The HTML5 output setting was deprecated in GF 2.8 (always enabled) and the method was removed in GF 3.0,
+		// so only check it on older versions where the setting could actually be disabled.
+		$is_html5_enabled = true;
+		if ( version_compare( GFCommon::$version, '2.8', '<' ) && method_exists( 'GFFormsModel', 'is_html5_enabled' ) ) {
+			$is_html5_enabled = GFFormsModel::is_html5_enabled();
+		}
+
+		if ( $is_html5_enabled ) {
 			add_filter( 'gform_pre_render', array( $this, 'stash_current_form' ) );
 			add_filter( 'gform_field_input', array( $this, 'modify_quantity_input_tag' ), 10, 5 );
 		}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3411481240/106006?viewId=3808239

## Summary

The snippet above is incompatible with GF 3.0. It causes the error below:
```
Uncaught Error: Call to undefined method GFFormsModel::is_html5_enabled()
```

Last signature of this plugin
```
	/**
	 * @deprecated 2.8 HTML5 setting was removed, and HTML5 is now always enabled.
	 * @remove-in 3.0
	 *
	 * @return true
	 */
	public static function is_html5_enabled() {
		_deprecated_function( __METHOD__ , '2.8' );
		return true;
	}
```

Following this, we update the snippet to ensure:

- **GF < 2.8**: original behavior preserved. The real setting is still honored.
- **GF 2.8 - 2.9**: runs unconditionally and no longer triggers the `_deprecated_function` notice under debug.
- **GF 3.0+**: runs unconditionally, no fatal.
