### PR TITLE
`gca-create-relation.php`: Added new matching options for linking existing Airtable records.

### DIFF
--- a/gc-airtable/gca-create-relation.php
+++ b/gc-airtable/gca-create-relation.php
@@ -8,6 +8,10 @@
  *   1. There is an Airtable Base with at least two tables.
  *   2. There is a Gravity Forms feed that is connected to one of the tables in the Airtable Base.
  *
+ * Optionally, the snippet can search the linked table for an existing record and
+ * link it instead of creating a duplicate. If no matching record is found, a new
+ * linked record is created as usual.
+ *
  * TIP: you can easily find the following by creating a new GC Airtable feed, connecting
  * it to the Table which you want to create the relation in and then saving.
  * If you open the developer console in your browser and refresh the page, a table of all
@@ -16,6 +20,9 @@
  *     - $args['linked_table_id']
  *     - $args['link_field_id']
  *     - $args['value_mappings'] (the Airtable field IDs which you want to optionally add data to in the new linked record)
+ *     - $args['match_field_id'] (the Airtable field ID to populate when a new linked record is created)
+ *     - $args['match_field_name'] (the name of the same Airtable field, used to find an existing linked record)
+ *     - $args['match_value_field_id'] (the Gravity Forms field ID containing the value to match)
  *
  * Installation:
  *   1. Install per https://gravitywiz.com/documentation/how-do-i-install-a-snippet/
@@ -32,6 +39,9 @@
  * @param string $args['linked_table_id']       The ID of the linked table in Airtable.
  * @param string $args['link_field_id']         The ID of the field in the linked table that links to table connected to the feed.
  * @param? array $args['value_mappings']        An associative array mapping Airtable field IDs to Gravity Forms field IDs.
+ * @param? string $args['match_field_id']       The ID of the Airtable field populated when a new linked record is created.
+ * @param? string $args['match_field_name']     The name of the Airtable field used to match an existing linked record.
+ * @param? string $args['match_value_field_id'] The ID of the Gravity Forms field containing the value to match.
  *
  * @return void
  */
@@ -39,16 +49,27 @@ function gca_create_relation( $args = array() ) {
 	$args = wp_parse_args(
 		$args,
 		array(
-			'form_id'         => null, // include form ID
-			'feed_id'         => null,
-			'linked_table_id' => null, // The ID of the Phone Numbers table.
-			'link_field_id'   => null, // The ID of the field in the Phone Numbers table that links to the People table.
+			'form_id'              => null, // include form ID
+			'feed_id'              => null,
+			'linked_table_id'      => null, // The ID of the Phone Numbers table.
+			'link_field_id'        => null, // The ID of the field in the Phone Numbers table that links to the People table.
 
-			'value_mappings'  => array(), // The value mappings of Airtable field ids to Graivty Forms field ids.
+			'value_mappings'       => array(), // The value mappings of Airtable field ids to Gravity Forms field ids.
+			'match_field_id'       => null,
+			'match_field_name'     => null,
+			'match_value_field_id' => null,
 		)
 	);
 
 	if ( ! $args['linked_table_id'] || ! $args['link_field_id'] ) {
+		return;
+	}
+
+	$has_match_config = $args['match_field_id'] || $args['match_field_name'] || $args['match_value_field_id'];
+	$can_match        = $args['match_field_id'] && $args['match_field_name'] && $args['match_value_field_id'];
+
+	if ( $has_match_config && ! $can_match ) {
+		gc_airtable()->log_error( 'gca_create_relation(): All three matching settings are required.' );
 		return;
 	}
 
@@ -66,8 +87,14 @@ function gca_create_relation( $args = array() ) {
 
 	add_action(
 		$filter_name,
-		function( $entry, $create_record_resp, $gca_connection_instance ) use ( $args ) {
+		function( $entry, $create_record_resp, $gca_connection_instance ) use ( $args, $can_match ) {
 			if ( empty( $args['linked_table_id'] ) ) {
+				return;
+			}
+
+			$main_record_id = rgar( $create_record_resp, 'id' );
+
+			if ( empty( $main_record_id ) ) {
 				return;
 			}
 
@@ -87,19 +114,90 @@ function gca_create_relation( $args = array() ) {
 				$mappings[ $airtable_field_id ] = $value;
 			}
 
-			$records = array(
-				array(
-					'fields' => array_merge(
-						array(
-							$args['link_field_id'] => array( $create_record_resp['id'] ),
-						),
-						$mappings
-					),
-				),
-			);
-
 			try {
-				$airtable_api       = $gca_connection_instance->get_airtable_api();
+				$airtable_api = $gca_connection_instance->get_airtable_api();
+
+				if ( $can_match ) {
+					$match_value = rgar( $entry, $args['match_value_field_id'] );
+
+					if ( $match_value === '' || $match_value === null ) {
+						gc_airtable()->log_error( 'gca_create_relation(): The configured match field has no value.' );
+						return;
+					}
+
+					$field_name = str_replace(
+						array( '\\', '}' ),
+						array( '\\\\', '\\}' ),
+						$args['match_field_name']
+					);
+					$formula_value = str_replace(
+						array( '\\', '"' ),
+						array( '\\\\', '\\"' ),
+						(string) $match_value
+					);
+
+					$response = $airtable_api->list_records(
+						$base_id,
+						$args['linked_table_id'],
+						array(
+							'filterByFormula'       => sprintf( '{%s} = "%s"', $field_name, $formula_value ),
+							'returnFieldsByFieldId' => true,
+							'maxRecords'            => 2,
+							'pageSize'              => 2,
+						)
+					);
+					$matches = (array) rgar( $response, 'records', array() );
+
+					if ( count( $matches ) > 1 ) {
+						gc_airtable()->log_error( 'gca_create_relation(): More than one linked record matched; no relation was created.' );
+						return;
+					}
+
+					if ( count( $matches ) === 1 ) {
+						$matched_record_id = rgar( $matches[0], 'id' );
+						$linked_record_ids = rgars(
+							$matches[0],
+							'fields/' . $args['link_field_id'],
+							array()
+						);
+
+						if ( empty( $matched_record_id ) ) {
+							gc_airtable()->log_error( 'gca_create_relation(): Airtable did not return the matched record ID.' );
+							return;
+						}
+
+						if ( ! is_array( $linked_record_ids ) ) {
+							$linked_record_ids = array();
+						}
+
+						$linked_record_ids[] = $main_record_id;
+
+						$airtable_api->patch_record(
+							$base_id,
+							$args['linked_table_id'],
+							$matched_record_id,
+							array(
+								$args['link_field_id'] => array_values( array_unique( $linked_record_ids ) ),
+							)
+						);
+
+						return;
+					}
+
+					$mappings[ $args['match_field_id'] ] = $match_value;
+				}
+
+				$records = array(
+					array(
+						'fields' => array_merge(
+							array(
+								$args['link_field_id'] => array( $main_record_id ),
+							),
+							$mappings
+						),
+					),
+				);
+
 				$create_record_resp = $airtable_api->create_records(
 					$base_id,
 					$args['linked_table_id'],
@@ -137,10 +235,23 @@ gca_create_relation(
 		 */
 		'link_field_id'   => 'fldXXXXXXXXXXXXXX',
 		/**
+		 * Optional. To link an existing record when one matches, provide all three settings:
+		 *
+		 * - The ID of the Airtable field to populate when a new linked record is created.
+		 * - The name of that same Airtable field, used by Airtable's matching formula.
+		 * - The ID of the Gravity Forms field containing the value to match.
+		 *
+		 * Omit all three settings to retain the original always-create behavior.
+		 */
+		'match_field_id'       => 'fldXXXXXXXXXXXXXX',
+		'match_field_name'     => 'Name',
+		'match_value_field_id' => '3.3',
+		/**
 		 * Change this to an array of value mappings.
 		 * The keys are Airtable field IDs and the values are Gravity Forms field IDs.
+		 * These values are only written when a new linked record is created.
 		 */
-		'value_mappings'  => array(
+		'value_mappings'       => array(
 			'fldXXXXXXXXXXXXXX' => 3, // map Airtable field "fldXXXXXXXXXXXXXX" to Gravity Forms field with ID 3
 			// Add more mappings as needed
 		),


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3430465035/107098?viewId=3808239

## Summary

Extended the Create Relation snippet with optional matching support.

  When all three matching settings are configured, the snippet now:

  - Searches the linked table for a record matching the configured Gravity Forms field value.
  - Links the feed-created record to the existing record when exactly one match is found.
  - Preserves any relationships already stored on the matched record.
  - Creates a new linked record when no match is found.
  - Stops and logs an error when multiple records match, avoiding an ambiguous relationship.